### PR TITLE
chore: reduce output for accurate match

### DIFF
--- a/.github/workflows/reusable_dependabot_reviewer.yml
+++ b/.github/workflows/reusable_dependabot_reviewer.yml
@@ -63,7 +63,11 @@ jobs:
           fi
 
           # Extract dependency pinned version in case of GitHub Actions
-          pinned_version="$(git show "$DEPENDABOT_SHA" | grep -oE '[0-9a-fA-F]{40}' | tail -n1 || echo '')"
+          pinned_version="$(
+            git show "$DEPENDABOT_SHA" --unified=0 --no-prefix -- .github/workflows/ \
+              | grep -oE '[0-9a-fA-F]{40}' \
+              | tail -n1 || echo ''
+          )"
           if [[ -n "$pinned_version" ]]; then
             echo "Dependency Commit Hash: $pinned_version"
             echo "PINNED_VERSION=$pinned_version" >> "$GITHUB_ENV"


### PR DESCRIPTION
## Summary

Reduce output for accurate match since the grep could match multiple hashes.

## Related Issues

Improvements after checking test CI jobs

## Review Hints

CI Jobs check.