### PR TITLE
chore: simplify permissions

### DIFF
--- a/.github/workflows/ci_scheduled.yml
+++ b/.github/workflows/ci_scheduled.yml
@@ -7,17 +7,11 @@ on:
   schedule:
     - cron: '0 0 * * *'
 
-permissions:
-  contents: read
-  issues: none
-  pull-requests: none
-  actions: none
-  security-events: none
-
 jobs:
   security_audit:
     name: Vulnerabilities Scan
     permissions:
+      contents: read
       actions: read           # Required to upload SARIF file to CodeQL. See: https://github.com/github/codeql-action/issues/2117
       security-events: write  # Require writing security events to upload SARIF file to security tab
     uses: complytime/org-infra/.github/workflows/reusable_scheduled.yml@main

--- a/.github/workflows/ci_vulns.yml
+++ b/.github/workflows/ci_vulns.yml
@@ -5,17 +5,11 @@ on:
     branches:
       - main
 
-permissions:
-  contents: read
-  issues: none
-  pull-requests: none
-  actions: none
-  security-events: none
-
 jobs:
   security_audit:
     name: OSV-Scanner
     permissions:
+      contents: read
       actions: read           # Required to upload SARIF file to CodeQL. See: https://github.com/github/codeql-action/issues/2117
       security-events: write  # Require writing security events to upload SARIF file to security tab
     uses: complytime/org-infra/.github/workflows/reusable_vuln_scan.yml@main

--- a/.github/workflows/reusable_ci.yml
+++ b/.github/workflows/reusable_ci.yml
@@ -18,8 +18,7 @@ jobs:
   megalinter:
     name: Run linters
     runs-on: ubuntu-latest
-    permissions:
-      issues: write
+
     steps:
       - name: Checkout Code
         uses: actions/checkout@08c6903cd8c0fde910a37f88322edcfb5dd907a8 # v5.0.0

--- a/.github/workflows/reusable_scheduled.yml
+++ b/.github/workflows/reusable_scheduled.yml
@@ -26,6 +26,7 @@ jobs:
     # https://google.github.io/osv-scanner/github-action/
     uses: google/osv-scanner-action/.github/workflows/osv-scanner-reusable.yml@9bb69575e74019c2ad085a1860787043adf47ccb # v2.2.4
     permissions:
+      contents: read
       actions: read           # Required to upload SARIF file to CodeQL. See: https://github.com/github/codeql-action/issues/2117
       security-events: write  # Require writing security events to upload SARIF file to security tab
     with:

--- a/.github/workflows/reusable_vuln_scan.yml
+++ b/.github/workflows/reusable_vuln_scan.yml
@@ -26,6 +26,7 @@ jobs:
     # https://google.github.io/osv-scanner/github-action/
     uses: google/osv-scanner-action/.github/workflows/osv-scanner-reusable-pr.yml@9bb69575e74019c2ad085a1860787043adf47ccb # v2.2.4
     permissions:
+      contents: read
       actions: read           # Required to upload SARIF file to CodeQL. See: https://github.com/github/codeql-action/issues/2117
       security-events: write  # Require writing security events to upload SARIF file to security tab
     with:


### PR DESCRIPTION
## Summary
Once a permission is explicit in a job level, all other implicit permissions are set to none

## Related Issues

- Scheduled Jobs failed.

## Review Hints

- Noticed when checking this Job: https://github.com/complytime/org-infra/actions/runs/19216700300