### PR TITLE
chore: include poetry.lock in criteria

### DIFF
--- a/.github/workflows/reusable_dependabot_reviewer.yml
+++ b/.github/workflows/reusable_dependabot_reviewer.yml
@@ -116,7 +116,7 @@ jobs:
             eco="github_actions"
           elif grep -q "go.mod" "$ALL_CHANGED_FILES"; then
             eco="go"
-          elif grep -q -E "requirements\.txt|pyproject\.toml|setup\.cfg" "$ALL_CHANGED_FILES"; then
+          elif grep -q -E "requirements\.txt|pyproject\.toml|setup\.cfg|poetry\.lock" "$ALL_CHANGED_FILES"; then
             eco="python"
           # Fallback for other GitHub Actions changes
           # (e.g., action updates that don't follow the owner/repo format, or if dependency name check failed)


### PR DESCRIPTION
## Summary

Noticed when reviewing https://github.com/complytime/complyscribe/pull/725 

## Related Issues

- This should allow the process to detect the dependency adoption and therefore give more information for reviewers.

## Review Hints

- Once merged we can check dependabot PRs for Python dependencies.
- For the PR review, basically checking if the syntax is correct.
