### PR TITLE
feat: reusable workflow for sonarqube

### DIFF
--- a/.github/workflows/reusable_sonarqube.yml
+++ b/.github/workflows/reusable_sonarqube.yml
@@ -1,0 +1,83 @@
+name: Reusable SonarCloud Analysis
+
+# --------------------------------------------------------------------------
+# This workflow only runs when explicitly called by another workflow.
+# --------------------------------------------------------------------------
+on:
+  workflow_call:
+    inputs:
+      sonar_organization:
+        required: true
+        type: string
+        description: 'The SonarCloud organization key (e.g., rh-psce).'
+      sonar_project_key:
+        required: true    # Make this mandatory for clarity
+        type: string
+        description: 'The SonarCloud project key (e.g., rh-psce_complyctl).'
+      coverage_artifact_name:
+        required: false   # Optional, as some repos might not have coverage
+        type: string
+        default: coverage
+        description: 'The name of the coverage artifact that was uploaded by the caller (e.g., coverage).'
+      coverage_file_path:
+        required: false   # Optional, as some repos might not have coverage
+        type: string
+        description: 'The path to the generated coverage file (e.g., coverage.out).'
+      language_scanner_property:
+        required: false
+        type: string
+        description: 'The Sonar Scanner property for coverage, e.g., sonar.typescript.lcov.reportPaths.'
+    secrets:
+      SONAR_TOKEN:
+        required: true
+        description: 'The SonarCloud analysis token.'
+
+permissions:
+  contents: none
+  issues: none
+  pull-requests: none
+
+jobs:
+  sonar_analysis:
+    name: Analyze with SonarCloud
+    runs-on: ubuntu-latest
+    permissions:
+      contents: read
+      pull-requests: read
+
+    steps:
+      - name: Checkout Repository
+        uses: actions/checkout@08c6903cd8c0fde910a37f88322edcfb5dd907a8 # v5.0.0
+        with:
+          repository: "${{ github.event.repository.full_name }}"
+          fetch-depth: 0 # This may also capture vulnerabilities unrelated to the PR.
+
+      - name: Download coverage file
+        uses: actions/download-artifact@018cc2cf5baa6db3ef3c5f8a56943fffe632ef53 # v6.0.0
+        if: ${{ inputs.coverage_file_path != '' }}
+        env:
+          COVERAGE_ARTIFACT_NAME: "${{ inputs.coverage_artifact_name }}"
+          COVERAGE_FILE_PATH: "${{ inputs.coverage_file_path }}"
+        with:
+          name: ${{ env.COVERAGE_ARTIFACT_NAME }}
+          path: ${{ env.COVERAGE_FILE_PATH }}
+
+      # The calling workflow MUST ensure the coverage file exists before calling this.
+      # This step just runs the SonarCloud analysis with the provided inputs.
+      - name: SonarCloud Scan
+        uses: SonarSource/sonarqube-scan-action@fd88b7d7ccbaefd23d8f36f73b59db7a3d246602 # v6.0.0
+        env:
+          GITHUB_TOKEN: ${{ secrets.GITHUB_TOKEN }}
+          SONAR_TOKEN: ${{ secrets.SONAR_TOKEN }}
+          SONAR_ORGANIZATION: ${{ inputs.sonar_organization }}
+          SONAR_PROJECT_KEY: ${{ inputs.sonar_project_key }}
+          COVERAGE_FILE_PATH: ${{ inputs.coverage_file_path }}
+          LANGUAGE_SCANNER_PROPERTY: ${{ inputs.language_scanner_property }}
+        with:
+          projectBaseDir: ${{ github.workspace }} # Ensure scan starts at the repo root
+          args: >
+            "-Dsonar.organization=${{ env.SONAR_ORGANIZATION }}"
+            "-Dsonar.projectKey=${{ env.SONAR_PROJECT_KEY }}"
+            "-Dsonar.qualitygate.wait=true"
+            # Inject dynamic coverage properties only if path is provided
+            "${{ env.COVERAGE_FILE_PATH && format('-D{0}={1}', env.LANGUAGE_SCANNER_PROPERTY, env.COVERAGE_FILE_PATH) || '' }}"


### PR DESCRIPTION
## Summary

Repositories still generate coverage files on their sides, but the SonarQube scan part can be standardized.
This workflow was created aligned with the official documentation but also using existing workflows as reference, such as:
- https://github.com/complytime/complyscribe/blob/main/.github/workflows/codecov.yml
- https://github.com/complytime/complyctl/blob/main/.github/workflows/sonarcloud.yml
- https://github.com/complytime/complybeacon/blob/main/.github/workflows/test-coverage.yml

The logic is that the caller repositories generate their coverage files and call a standardized reusable workflow informing the name of the generated file and some project information to be analysed by SonarQube.

`sonarsource/sonarqube-quality-gate-action` is no longer necessary since `SonarSource/sonarqube-scan-action` with `"-Dsonar.qualitygate.wait=true"` argument has the same effect.

Informing `language_scanner_property` should also help with more refined scans adapted for the project language.

## Related Issues

- We have three slightly different approaches of using SonarQube. Keeping the logic centralized ensures standards and also helps to keep settings updated.

## Review Hints

- https://github.com/SonarSource/sonarqube-scan-action/
- https://github.com/SonarSource/sonarqube-scan-action/?tab=readme-ov-file#configuration
- https://github.com/complytime/complyscribe/pull/679

While this PR is introducing the reusable workflow, it is not consuming it yet. Once available as reusable workflow we can gradually update the existing repositories where SonarQube is used and adopt in other repositories when necessary.