### PR TITLE
chore: ensure different names for result files

### DIFF
--- a/.github/workflows/reusable_scheduled.yml
+++ b/.github/workflows/reusable_scheduled.yml
@@ -33,6 +33,7 @@ jobs:
       scan-args: "${{ inputs.scan-args }}"
       fail-on-vuln: true
       upload-sarif: true
+      results-file-name: osv-scanner-scheduled-results.sarif
 
   call_reusable_security:
     name: OpenSSF Scorecards

--- a/.github/workflows/reusable_security.yml
+++ b/.github/workflows/reusable_security.yml
@@ -33,7 +33,7 @@ jobs:
       - name: "Run analysis"
         uses: ossf/scorecard-action@4eaacf0543bb3f2c246792bd56e8cdeffafb205a # v2.4.3
         with:
-          results_file: results.sarif
+          results_file: scorecard-results.sarif
           results_format: sarif
           publish_results: true
 
@@ -41,10 +41,10 @@ jobs:
         uses: actions/upload-artifact@330a01c490aca151604b8cf639adc76d48f6c5d4 # v5.0.0
         with:
           name: SARIF file
-          path: results.sarif
+          path: scorecard-results.sarif
           retention-days: 5
 
       - name: "Upload to code-scanning"
         uses: github/codeql-action/upload-sarif@0499de31b99561a6d14a36a5f662c2a54f91beee # v4.31.2
         with:
-          sarif_file: results.sarif
+          sarif_file: scorecard-results.sarif

--- a/.github/workflows/reusable_vuln_scan.yml
+++ b/.github/workflows/reusable_vuln_scan.yml
@@ -33,3 +33,4 @@ jobs:
       scan-args: "${{ inputs.scan-args }}"
       fail-on-vuln: true
       upload-sarif: true
+      results-file-name: osv-scanner-pr-results.sarif


### PR DESCRIPTION
## Summary

In case multiple reusable workflows generating results are combined, this should avoid names conflicts.

## Related Issues

- https://github.com/complytime/complyctl/actions/runs/19458690221/job/55677662278?pr=335

## Review Hints

- The idea is that each reusable workflow has a results file linked to its source.
- https://google.github.io/osv-scanner/github-action/#customization