### PR TITLE
fix: duplicated names when uploading artifacts

### DIFF
--- a/.github/workflows/reusable_scheduled.yml
+++ b/.github/workflows/reusable_scheduled.yml
@@ -33,7 +33,7 @@ jobs:
       scan-args: "${{ inputs.scan-args }}"
       fail-on-vuln: true
       upload-sarif: true
-      results-file-name: osv-scanner-scheduled-results-${{ github.workflow }}-${{ github.job }}.sarif
+      results-file-name: osv-scanner-scheduled-results-${{ github.workflow_sha }}-${{ github.run_number }}.sarif
 
   call_reusable_security:
     name: OpenSSF Scorecards

--- a/.github/workflows/reusable_security.yml
+++ b/.github/workflows/reusable_security.yml
@@ -33,7 +33,7 @@ jobs:
       - name: "Run analysis"
         uses: ossf/scorecard-action@4eaacf0543bb3f2c246792bd56e8cdeffafb205a # v2.4.3
         with:
-          results_file: scorecard-results-${{ github.workflow }}-${{ github.job }}.sarif
+          results_file: scorecard-results-${{ github.workflow_sha }}-${{ github.run_number }}.sarif
           results_format: sarif
           publish_results: true
 
@@ -41,10 +41,10 @@ jobs:
         uses: actions/upload-artifact@330a01c490aca151604b8cf639adc76d48f6c5d4 # v5.0.0
         with:
           name: Scorecard SARIF file
-          path: scorecard-results-${{ github.workflow }}-${{ github.job }}.sarif
+          path: scorecard-results-${{ github.workflow_sha }}-${{ github.run_number }}.sarif
           retention-days: 5
 
       - name: "Upload to code-scanning"
         uses: github/codeql-action/upload-sarif@fe4161a26a8629af62121b670040955b330f9af2 # v4.31.6
         with:
-          sarif_file: scorecard-results-${{ github.workflow }}-${{ github.job }}.sarif
+          sarif_file: scorecard-results-${{ github.workflow_sha }}-${{ github.run_number }}.sarif

--- a/.github/workflows/reusable_vuln_scan.yml
+++ b/.github/workflows/reusable_vuln_scan.yml
@@ -33,4 +33,4 @@ jobs:
       scan-args: "${{ inputs.scan-args }}"
       fail-on-vuln: true
       upload-sarif: true
-      results-file-name: osv-scanner-pr-results-${{ github.workflow }}-${{ github.job }}.sarif
+      results-file-name: osv-scanner-pr-results-${{ github.workflow_sha }}-${{ github.run_number }}.sarif


### PR DESCRIPTION
## Summary

Many executions are failing when trying to upload the artifacts:
- https://github.com/complytime/org-infra/actions

It is caused because the same name is used in two reusable workflows called by the same runner.

## Related Issues

- Example: https://github.com/complytime/org-infra/actions/runs/20047320862/job/57495623540

## Review Hints

- https://github.com/actions/upload-artifact
- https://docs.github.com/en/actions/reference/workflows-and-actions/contexts#github-context