### PR TITLE
chore: simplify query for actions dependencies

### DIFF
--- a/.github/workflows/reusable_dependabot_reviewer.yml
+++ b/.github/workflows/reusable_dependabot_reviewer.yml
@@ -65,11 +65,9 @@ jobs:
 
           # Extract dependency name and version together in case of GitHub Actions
           # The title is not always standardized, so we need to extract the name and version from the file changes.
-          if grep -rq "$dep_name" .github/workflows/; then
-            dep_name_and_version="$(git show HEAD~1 -U0 --no-prefix | sed -n 's/^+ //p' | awk '{ print $2 }' | tail -n1 || echo '')"
-            echo "Dependency Name and Version: $dep_name_and_version"
-            echo "DEP_NAME_AND_VERSION=$dep_name_and_version" >> "$GITHUB_ENV"
-          fi
+          dep_name_and_version="$(grep -r "$dep_name" .github/workflows/ | awk '{ print $3 }' | tail -n1 || echo '')"
+          echo "Dependency Name and Version: $dep_name_and_version"
+          echo "DEP_NAME_AND_VERSION=$dep_name_and_version" >> "$GITHUB_ENV"
 
       - name: Classify Risk Based on Semantic Version
         id: classify_risk


### PR DESCRIPTION
## Summary

The PR is already checked-out at this point so using grep is enough to see the proposed change.
It is not necessary to use the git history.

## Related Issues

The previous logic was causing inconsistencies that ultimately impacted the auto-approval process.
e.g.:
- https://github.com/complytime/complyscribe/actions/runs/20057331925/job/57525535550?pr=752

## Review Hints

- Checkout the PR https://github.com/complytime/complyscribe/pull/752 in [complyscribe](https://github.com/complytime/complyscribe) repository.
- Then try:
```bash
grep -r "github/codeql-action" .github/workflows/ | awk '{ print $3 }' | tail -n1
github/codeql-action/upload-sarif@cf1bb45a277cb3c205638b2cd5c984db1c46a412
```