### PR TITLE
chore: show query info for easier review

### DIFF
--- a/.github/workflows/reusable_dependabot_reviewer.yml
+++ b/.github/workflows/reusable_dependabot_reviewer.yml
@@ -182,6 +182,9 @@ jobs:
           repo_list="$(jq -r '.[].repository.nameWithOwner' <<<"$result" | sort -u)"
           count=$(wc -w <<<"$repo_list")
 
+          echo "Repository Count: $count"
+          echo "Repository List: $repo_list"
+
           {
             echo "updates_count=$count"
             echo "repo_list<<EOF"


### PR DESCRIPTION
## Summary

It should not impact the behavior but makes it easier to review executed jobs in CI.

## Related Issues

- https://github.com/complytime/complyctl/actions/runs/20092281912/job/57642253536?pr=354

## Review Hints

Taking a look in a executed job should be enough.
