### PR TITLE
chore: more specific filter in grep

### DIFF
--- a/.github/workflows/reusable_dependabot_reviewer.yml
+++ b/.github/workflows/reusable_dependabot_reviewer.yml
@@ -65,7 +65,7 @@ jobs:
 
           # Extract dependency name and version together in case of GitHub Actions
           # The title is not always standardized, so we need to extract the name and version from the file changes.
-          dep_name_and_version="$(grep -r "$dep_name" .github/workflows/ | awk '{ print $3 }' | tail -n1 || echo '')"
+          dep_name_and_version="$(grep -RhoE "uses:[[:space:]']*$dep_name@[^\s#]+" .github/workflows/ | sed 's/uses:[[:space:]]*//' | tail -n1 || echo '')"
           echo "Dependency Name and Version: $dep_name_and_version"
           echo "DEP_NAME_AND_VERSION=$dep_name_and_version" >> "$GITHUB_ENV"
 


### PR DESCRIPTION
## Summary
To avoid matching other lines, such as comments.

## Related Issues

- https://github.com/complytime/org-infra/actions/runs/20306257981/job/58324387635?pr=51

## Review Hints

The above mentioned run can show the issue where the dependency name+version was incorrect:
```
Run # Use 'git log' specifically on the Dependabot commit SHA to get its subject.
Dependabot Commit Subject: ci(deps): Bump github/codeql-action from 4.31.8 to 4.31.9
Dependency Name: github/codeql-action
Versions: 4.31.8 -> 4.31.9
Dependency Name and Version: read
``` 
It was matching a comment line:
```
.github/workflows/reusable_scheduled.yml:      actions: read           # Needed to upload SARIF file to CodeQL. See: https://github.com/github/codeql-action/issues/2117
```

A good test could be done in complyscribe repository:
```
dep_name="actions/setup-node"
grep -RhoE "uses:[[:space:]']*$dep_name@[^\s#]+" .github/workflows/ | sed 's/uses:[[:space:]]*//'

dep_name="google-github-actions/auth"
grep -RhoE "uses:[[:space:]']*$dep_name@[^\s#]+" .github/workflows/ | sed 's/uses:[[:space:]]*//'

dep_name="actions/create-github-app-token"
grep -RhoE "uses:[[:space:]']*$dep_name@[^\s#]+" .github/workflows/ | sed 's/uses:[[:space:]]*//'
```