### PR TITLE
chore: Add GITHUB_TOKEN secrets parameter to reusable SonarCloud workflow

### DIFF
--- a/.github/workflows/reusable_sonarqube.yml
+++ b/.github/workflows/reusable_sonarqube.yml
@@ -31,6 +31,9 @@ on:
       SONAR_TOKEN:
         required: true
         description: 'The SonarCloud analysis token.'
+      GITHUB_TOKEN:
+        required: true
+        description: 'Github token'
 
 permissions:
   contents: none


### PR DESCRIPTION
## Summary

Add GITHUB_TOKEN secrets parameter to reusable SonarCloud workflow

## Related Issues

N/A

## Review Hints

- Add GITHUB_TOKEN secrets parameter to reusable SonarCloud workflow
- Failure example https://github.com/complytime/complyctl/actions/runs/20915450270 
