### PR TITLE
chore: more flexible way to get query info

### DIFF
--- a/.github/workflows/reusable_dependabot_reviewer.yml
+++ b/.github/workflows/reusable_dependabot_reviewer.yml
@@ -65,7 +65,7 @@ jobs:
 
           # Extract dependency name and version together in case of GitHub Actions
           # The title is not always standardized, so we need to extract the name and version from the file changes.
-          dep_name_and_version="$(grep -RhoE "uses:[[:space:]']*$dep_name@[^\s#]+" .github/workflows/ | sed 's/uses:[[:space:]]*//' | tail -n1 || echo '')"
+          dep_name_and_version="$(grep -rhoE "uses:[[:space:]']*$dep_name.*@[^\s#]+" .github/workflows/ | sed 's/uses:[[:space:]]*//' | tail -n1 || echo '')"
           echo "Dependency Name and Version: $dep_name_and_version"
           echo "DEP_NAME_AND_VERSION=$dep_name_and_version" >> "$GITHUB_ENV"
 


### PR DESCRIPTION
## Summary
There are cases where the dependabot PRs are not matching the most common pattern. This commit fixes the observed cases we have.

## Related Issues

Here are some examples that should be fixed by this PR:
- https://github.com/complytime/complytime-collector-components/actions/runs/20945830833/job/60188567254?pr=94
- https://github.com/complytime/org-infra/actions/runs/20930754177/job/60140751343?pr=61

## Review Hints

You could checkout the PR https://github.com/complytime/complytime-collector-components/pull/94 and try this commands:
Before the commit:
```bash
dep_name="github/codeql-action"
# As it was originally:
grep -RhoE "uses:[[:space:]']*$dep_name@[^\s#]+" .github/workflows/ | sed 's/uses:[[:space:]]*//' | tail -n1

# After this commit:
grep -rhoE "uses:[[:space:]']*$dep_name.*@[^\s#]+" .github/workflows/ | sed 's/uses:[[:space:]]*//' | tail -n1
```