### PR TITLE
chore: extract versions from commit descriptions

### DIFF
--- a/.github/workflows/reusable_dependabot_reviewer.yml
+++ b/.github/workflows/reusable_dependabot_reviewer.yml
@@ -54,8 +54,15 @@ jobs:
             echo "DEP_NAME=$dep_name" >> "$GITHUB_ENV"
           fi
 
-          # Extract two semantic version numbers (e.g., 1.2.3)
-          mapfile -t versions < <(grep -Eo '[0-9]+\.[0-9]+\.[0-9]+' <<< "$COMMIT_SUBJECT")
+          if grep -Eo '[0-9]+\.[0-9]+\.[0-9]+' <<< "$COMMIT_SUBJECT"; then
+            # Extract two semantic version numbers (e.g., 1.2.3)
+            mapfile -t versions < <(grep -Eo '[0-9]+\.[0-9]+\.[0-9]+' <<< "$COMMIT_SUBJECT")
+          else
+            # In some cases, the dependency name and version are not in the commit title.
+            # So, we need to extract the versions from the commit description.
+            COMMIT_DESCRIPTION="$(git log -1 --format=%B "$DEPENDABOT_SHA" | grep -i Bumps)"
+            mapfile -t versions < <(grep -Eo '[0-9]+\.[0-9]+\.[0-9]+' <<< "$COMMIT_DESCRIPTION")
+          fi
 
           if [[ "${#versions[@]}" -eq 2 ]]; then
             echo "Versions: ${versions[0]} -> ${versions[1]}"


### PR DESCRIPTION
## Summary
If the versions are not found in dependabot PR titles, try to find versions from commit messages.

## Related Issues

- https://github.com/complytime/complyctl/actions/runs/20945031675/job/60186284105

## Review Hints

Try to checkout https://github.com/complytime/complyctl/pull/369 and execute the following commands

```bash
DEPENDABOT_SHA="beed550294611cbb1a5877dcba185a70a5a9324e"

COMMIT_SUBJECT="$(git log -1 --format=%s "$DEPENDABOT_SHA")"
mapfile -t versions < <(grep -Eo '[0-9]+\.[0-9]+\.[0-9]+' <<< "$COMMIT_SUBJECT"); echo "Versions: ${versions[@]}"

COMMIT_DESCRIPTION="$(git log -1 --format=%B "$DEPENDABOT_SHA" | grep -i Bumps)"
mapfile -t versions < <(grep -Eo '[0-9]+\.[0-9]+\.[0-9]+' <<< "$COMMIT_DESCRIPTION"); echo "Versions: ${versions[@]}"
```