### PR TITLE
chore: remove not necessary permission

### DIFF
--- a/.github/workflows/ci_compliance.yml
+++ b/.github/workflows/ci_compliance.yml
@@ -26,7 +26,6 @@ jobs:
     permissions:
       contents: read
       actions: read
-      security-events: write
       id-token: write
       attestations: write
     uses: complytime/org-infra/.github/workflows/reusable_compliance.yml@main


### PR DESCRIPTION
## Summary

Minor fix noticed during review of https://github.com/complytime/complytime-demos/pull/30

## Related Issues

- https://github.com/complytime/complytime-demos/pull/30#discussion_r2688817696

## Review Hints

- Should not have any impact in the workflow since the permission was not used.
