### PR TITLE
fix: Rename secret name for reusable_sonarqube

### DIFF
--- a/.github/workflows/reusable_sonarqube.yml
+++ b/.github/workflows/reusable_sonarqube.yml
@@ -31,9 +31,9 @@ on:
       SONAR_TOKEN:
         required: true
         description: 'The SonarCloud analysis token.'
-      GITHUB_TOKEN:
+      source_token:
         required: true
-        description: 'Github token'
+        description: 'GitHub Token'
 
 permissions:
   contents: none
@@ -70,7 +70,7 @@ jobs:
       - name: SonarCloud Scan
         uses: SonarSource/sonarqube-scan-action@a31c9398be7ace6bbfaf30c0bd5d415f843d45e9 # v7.0.0
         env:
-          GITHUB_TOKEN: ${{ secrets.GITHUB_TOKEN }}
+          GITHUB_TOKEN: ${{ secrets.source_token }}
           SONAR_TOKEN: ${{ secrets.SONAR_TOKEN }}
           SONAR_ORGANIZATION: ${{ inputs.sonar_organization }}
           SONAR_PROJECT_KEY: ${{ inputs.sonar_project_key }}


### PR DESCRIPTION

## Summary

Rename secret name for reusable_sonarqube.yml due to collide with system reserved name


## Related Issues

- N/A

## Review Hints

- rationale:  https://github.com/complytime/complyctl/actions/runs/20986718398 

