### PR TITLE
fix(ci): CPLYTM-1255 simplify reusable push to GHCR

### DIFF
--- a/.github/workflows/reusable_publish_ghcr.yml
+++ b/.github/workflows/reusable_publish_ghcr.yml
@@ -40,21 +40,8 @@ on:
       platforms:
         description: 'Comma-separated target platforms'
         required: false
-        default: 'linux/amd64,linux/arm64'
+        default: 'linux/amd64'
         type: string
-      registry_username:
-        description: 'Username for GHCR login (defaults to github.actor)'
-        required: false
-        type: string
-      require_protected_ref:
-        description: 'Require the ref to be protected '
-        required: false
-        default: true
-        type: boolean
-    secrets:
-      registry_token:
-        description: 'Optional GHCR token. If not provided, falls back to GITHUB_TOKEN.'
-        required: false
     outputs:
       digest:
         description: 'Pushed image digest'
@@ -73,8 +60,9 @@ concurrency:
 
 jobs:
   push:
+    if: ${{ github.ref_protected }}
     runs-on: ubuntu-latest
-    timeout-minutes: 60
+    timeout-minutes: 20
     permissions:
       contents: read    # Checkout source code
       packages: write   # Push to GHCR (and write cache)
@@ -87,20 +75,12 @@ jobs:
         with:
           persist-credentials: false
 
-      - name: Verify protected ref
-        if: ${{ inputs.require_protected_ref }}
-        run: |
-          if [[ "${{ github.ref_protected }}" != "true" ]]; then
-            echo "::error::Pushing images from unprotected refs is not allowed. Set require_protected_ref: false to override."
-            exit 1
-          fi
-
       - name: Log in to GHCR
         uses: docker/login-action@5e57cd118135c172c3672efd75eb46360885c0ef # v3.6.0
         with:
           registry: ghcr.io
-          username: ${{ inputs.registry_username || github.actor }}
-          password: ${{ secrets.registry_token || github.token }}
+          username: ${{ github.repository_owner }}
+          password: ${{ secrets.GITHUB_TOKEN }}
 
       - name: Set up QEMU
         uses: docker/setup-qemu-action@c7c53464625b32c7a7e944ae62b3e17d2b600130 # v3.7.0
@@ -110,7 +90,9 @@ jobs:
 
       - name: Set image reference
         id: images
-        run: echo "image=ghcr.io/${{ inputs.image_name }}" >> "$GITHUB_OUTPUT"
+        env:
+          IMAGE_NAME: ${{ inputs.image_name }}
+        run: echo "image=ghcr.io/${IMAGE_NAME}" >> "$GITHUB_OUTPUT"
 
       - name: Container metadata
         id: meta
@@ -136,12 +118,16 @@ jobs:
           platforms: ${{ inputs.platforms }}
           tags: ${{ steps.meta.outputs.tags }}
           labels: ${{ steps.meta.outputs.labels }}
-          cache-from: type=gha,scope=${{ inputs.component_name }}
-          cache-to: type=gha,mode=max,scope=${{ inputs.component_name }}
+          cache-from: |
+            type=gha,scope=${{ inputs.component_name }}-${{ github.ref_name }}
+            type=gha,scope=${{ inputs.component_name }}-main
+          cache-to: type=gha,mode=max,scope=${{ inputs.component_name }}-${{ github.ref_name }}
           sbom: true
           provenance: mode=max
           no-cache: ${{ inputs.force_rebuild }}
 
       - name: Export digest
         id: digest
-        run: echo "digest=${{ steps.build.outputs.digest }}" >> "$GITHUB_OUTPUT"
+        env:
+          BUILD_DIGEST: ${{ steps.build.outputs.digest }}
+        run: echo "digest=${BUILD_DIGEST}" >> "$GITHUB_OUTPUT"


### PR DESCRIPTION
## Summary

Simplifies `reusable_publish_ghcr.yml` to focus on GHCR image publishing, fixing bugs and removing multi-registry complexity.

### Updates
- Workflow now clearly focuses on GHCR
- Security review of the workflow

## Review Hints
- This is a focused cleanup of the push workflow
- Also refer: https://github.com/complytime/complytime-collector-components/pull/110
- Test run: https://github.com/sonupreetam/image-publish-test/actions/runs/21246605392