### PR TITLE
chore: skip pr title test for dependabot prs

### DIFF
--- a/.github/workflows/reusable_ci.yml
+++ b/.github/workflows/reusable_ci.yml
@@ -26,10 +26,11 @@ jobs:
         uses: actions/checkout@de0fac2e4500dabe0009e67214ff5f5447ce83dd # v6.0.2
 
       - name: Install Dependencies
+        if: github.actor != 'dependabot[bot]'
         run: npm install @commitlint/cli @commitlint/config-conventional
 
       - name: Validate PR Title
-        if: ${{ github.event.pull_request.title != '' }}
+        if: ${{ github.event.pull_request.title != '' && github.actor != 'dependabot[bot]' }}
         env:
           PR_TITLE: "${{ github.event.pull_request.title }}"
         run: echo "$PR_TITLE" | npx commitlint --config commitlint.config.js


### PR DESCRIPTION
## Summary

Dependabot PRs eventually create long titles depending on the dependency name.
This is not critical and could be safely waived.

## Related Issues

- https://github.com/complytime/complytime-collector-components/actions/runs/21836443154/job/63008725122?pr=139

## Review Hints

Here is an example PR: https://github.com/complytime/complytime-collector-components/pull/139