### PR TITLE
chore: update AMPEL policy and schedule compliance checks

### DIFF
--- a/.github/workflows/ci_scheduled.yml
+++ b/.github/workflows/ci_scheduled.yml
@@ -7,6 +7,7 @@ on:
 permissions:
   contents: read
   actions: none
+  attestations: none
   id-token: none
   security-events: none
 
@@ -19,3 +20,17 @@ jobs:
       security-events: write  # Require writing security events to upload SARIF file to security tab
       id-token: write         # Needed to access GitHub's OIDC token which verifies the authenticity of the result when publishing it.
     uses: complytime/org-infra/.github/workflows/reusable_scheduled.yml@main
+
+  call_reusable_compliance:
+    name: Compliance Evaluation
+    permissions:
+      contents: read
+      actions: read
+      id-token: write
+      attestations: write
+    uses: complytime/org-infra/.github/workflows/reusable_compliance.yml@main
+    with:
+      policy_url: https://github.com/complytime/org-infra#compliance/ampel/branch-protection-rules.json
+      push_attestation: true
+    secrets:
+      source_token: ${{ secrets.GITHUB_TOKEN }}

--- a/compliance/ampel/branch-protection-rules.json
+++ b/compliance/ampel/branch-protection-rules.json
@@ -1,16 +1,19 @@
 {
-    "id": "ComplyTime Policy for Branch Protection Rules",
+    "id": "AMPEL Policy for Branch Protection",
     "meta": {
         "frameworks": [
-            { "id": "MyOrg-Branch-Protection-Rules", "name": "MyOrg Branch Protection Rules" }
-        ],
+            { "id": "ComplyTime-Branch-Protection-Rules", "name": "ComplyTime Branch Protection Rules" }
+        ]
     },
     "policies": [
         {
-            "id": "OSPS-QA-07.01",
+            "id": "SC-CODE-01.01",
             "meta": {
-                "description": "VCS MUST require at least one non-author approval of changes to the primary branch",
-                "controls": [ { "framework": "OSPS", "class": "QA", "id": "07" } ]
+                "description": "Validate branch protection settings require pull requests via GitHub API or GitLab API",
+                "controls": [
+                    { "framework": "SC", "class": "SC-CODE", "id": "01" },
+                    { "framework": "OSPS", "class": "OSPS-QA", "id": "07" }
+                ]
             },
             "tenets": [
                 {
@@ -26,23 +29,21 @@
                         "message": "Direct pushes are enabled so PRs are not required.",
                         "guidance": "Create a branch ruleset protecting your default branch and enable \"Restrict updates\""
                     }
-                },
+                }
+            ]
+        },
+        {
+            "id": "SC-CODE-02.01",
+            "meta": {
+                "description": "Validate minimum approval count (≥1) and prevent self-approval via GitHub API or GitLab API",
+                "controls": [
+                    { "framework": "SC", "class": "SC-CODE", "id": "02" },
+                    { "framework": "OSPS", "class": "OSPS-QA", "id": "07" }
+                ]
+            },
+            "tenets": [
                 {
-                    "id": "02",
-                    "code": "has(predicates[0].data.values) ? predicates[0].data.values.exists(rule, rule.type == \"non_fast_forward\") : false",
-                    "predicates": {
-                        "types": ["http://github.com/carabiner-dev/snappy/specs/branch-rules.yaml"]
-                    },
-                    "assessment": {
-                        "message": "Force pushing is disabled in default branch."
-                    },
-                    "error": {
-                        "message": "Force pushes can be sent to main branch",
-                        "guidance": "Create a branch ruleset protecting your default branch and enable \"Block force pushes\""
-                    }
-                },
-                {
-                    "id": "03",
+                    "id": "01",
                     "code": "has(predicates[0].data.values) ? predicates[0].data.values.exists(rule, rule.type == \"pull_request\" && rule.parameters.required_approving_review_count >= 1) : false",
                     "predicates": {
                         "types": ["http://github.com/carabiner-dev/snappy/specs/branch-rules.yaml"]
@@ -54,37 +55,96 @@
                         "message": "PRs can be merged without peer review.",
                         "guidance": "Ensure the pull request rule requires at least one approving review."
                     }
-                }
-            ]
-        },
-        {
-            "id": "OSPS-AC-03.02",
-            "meta": {
-                "description": "VCS MUST treat main branch deletion as a sensitive activity and require explicit confirmation of intent",
-                "controls": [ { "framework": "OSPS", "class": "AC", "id": "03" } ]
-            },
-            "tenets": [
+                },
                 {
                     "id": "02",
-                    "code": "has(predicates[0].data.values) ? predicates[0].data.values.exists(rule, rule.type == \"deletion\") : false",
+                    "code": "has(predicates[0].data.values) ? predicates[0].data.values.exists(rule, rule.type == \"pull_request\" && rule.parameters.dismiss_stale_reviews_on_push == true) : false",
+
                     "predicates": {
                         "types": ["http://github.com/carabiner-dev/snappy/specs/branch-rules.yaml"]
                     },
                     "assessment": {
-                        "message": "Branch deletion is disabled on default branch"
+                        "message": "New, reviewable commits pushed will dismiss previous PR review approvals."
                     },
                     "error": {
-                        "message": "Branch delete protection is not enabled",
-                        "guidance": "Create a branch ruleset protecting your default branch and enable \"Restrict deletions\""
+                        "message": "Approvals are not dismissed when new commits are pushed.",
+                        "guidance": "Create a branch ruleset protecting your default branch and enable \"Dismiss stale pull request approvals when new commits are pushed\""
+                    }
+                },
+                {
+                    "id": "03",
+                    "code": "has(predicates[0].data.values) ? predicates[0].data.values.exists(rule, rule.type == \"pull_request\" && rule.parameters.require_last_push_approval == true) : false",
+
+                    "predicates": {
+                        "types": ["http://github.com/carabiner-dev/snappy/specs/branch-rules.yaml"]
+                    },
+                    "assessment": {
+                        "message": "The most recent push must be approved by someone other than the person who pushed it."
+                    },
+                    "error": {
+                        "message": "The most recent reviewable push is not approved by someone other than the person who pushed it.",
+                        "guidance": "Create a branch ruleset protecting your default branch and enable \"Require approval of the most recent reviewable push\""
                     }
                 }
             ]
         },
         {
-            "id": "MYORG-01",
+            "id": "SC-CODE-03.01",
             "meta": {
-                "description": "Require CODEOWNER approval before merging",
-                "controls": [ { "framework": "MYORG", "class": "ORG", "id": "01" } ]
+                "description": "Validate force push blocking is enabled on protected branches via GitHub API or GitLab API",
+                "controls": [
+                    { "framework": "SC", "class": "SC-CODE", "id": "03" },
+                    { "framework": "OSPS", "class": "OSPS-QA", "id": "07" }
+                ]
+            },
+            "tenets": [
+                {
+                    "id": "01",
+                    "code": "has(predicates[0].data.values) ? predicates[0].data.values.exists(rule, rule.type == \"non_fast_forward\") : false",
+                    "predicates": {
+                        "types": ["http://github.com/carabiner-dev/snappy/specs/branch-rules.yaml"]
+                    },
+                    "assessment": {
+                        "message": "Force pushing is disabled in default branch."
+                    },
+                    "error": {
+                        "message": "Force pushes can be sent to main branch",
+                        "guidance": "Create a branch ruleset protecting your default branch and enable \"Block force pushes\""
+                    }
+                }
+            ]
+        },
+        {
+            "id": "SC-CODE-04.01",
+            "meta": {
+                "description": "Validate admin bypass prevention is enabled via GitHub API or GitLab API",
+                "controls": [
+                    { "framework": "SC", "class": "SC-CODE", "id": "03" },
+                    { "framework": "OSPS", "class": "OSPS-QA", "id": "07" }
+                ]
+            },
+            "tenets": [
+                {
+                    "id": "01",
+                    "code": "has(predicates[0].data.values) ? predicates[0].data.values.exists(rule, rule.type == \"non_fast_forward\") : false",
+                    "predicates": {
+                        "types": ["http://github.com/carabiner-dev/snappy/specs/branch-rules.yaml"]
+                    },
+                    "assessment": {
+                        "message": "Force pushing is disabled in default branch."
+                    },
+                    "error": {
+                        "message": "Force pushes can be sent to main branch",
+                        "guidance": "Create a branch ruleset protecting your default branch and enable \"Block force pushes\""
+                    }
+                }
+            ]
+        },
+        {
+            "id": "SC-CODE-05.01",
+            "meta": {
+                "description": "Validate code owner review requirements are enabled when CODEOWNERS file exists via GitHub API or GitLab API",
+                "controls": [ { "framework": "SC", "class": "SC-CODE", "id": "05" } ]
             },
             "tenets": [
                 {
@@ -100,69 +160,6 @@
                     "error": {
                         "message": "CODEOWNER approval is not required before merging",
                         "guidance": "Create a branch ruleset protecting your default branch and enable \"Require review from Code Owners\""
-                    }
-                }
-            ]
-        },
-        {
-            "id": "MYORG-02",
-            "meta": {
-                "description": "Require signed commits before merging",
-                "controls": [ { "framework": "MYORG", "class": "ORG", "id": "02" } ]
-            },
-            "tenets": [
-                {
-                    "id": "01",
-                    "code": "has(predicates[0].data.values) ? predicates[0].data.values.exists(rule, rule.type == \"required_signatures\") : false",
-
-                    "predicates": {
-                        "types": ["http://github.com/carabiner-dev/snappy/specs/branch-rules.yaml"]
-                    },
-                    "assessment": {
-                        "message": "Signed commits are required before merging"
-                    },
-                    "error": {
-                        "message": "Signed commits are not required before merging",
-                        "guidance": "Create a branch ruleset protecting your default branch and enable \"Require signed commits\""
-                    }
-                }
-            ]
-        },
-        {
-            "id": "MYORG-03",
-            "meta": {
-                "description": "Ensure approvals are updated and compliant when changes are made",
-                "controls": [ { "framework": "MYORG", "class": "ORG", "id": "03" } ]
-            },
-            "tenets": [
-                {
-                    "id": "01",
-                    "code": "has(predicates[0].data.values) ? predicates[0].data.values.exists(rule, rule.type == \"pull_request\" && rule.parameters.dismiss_stale_reviews_on_push == true) : false",
-
-                    "predicates": {
-                        "types": ["http://github.com/carabiner-dev/snappy/specs/branch-rules.yaml"]
-                    },
-                    "assessment": {
-                        "message": "New, reviewable commits pushed will dismiss previous PR review approvals."
-                    },
-                    "error": {
-                        "message": "Approvals are not dismissed when new commits are pushed.",
-                        "guidance": "Create a branch ruleset protecting your default branch and enable \"Dismiss stale pull request approvals when new commits are pushed\""
-                    }
-                },
-                {
-                    "id": "02",
-                    "code": "has(predicates[0].data.values) ? predicates[0].data.values.exists(rule, rule.type == \"pull_request\" && rule.parameters.require_last_push_approval == true) : false",
-
-                    "predicates": {
-                        "types": ["http://github.com/carabiner-dev/snappy/specs/branch-rules.yaml"]
-                    },
-                    "assessment": {
-                        "message": "The most recent push must be approved by someone other than the person who pushed it."
-                    },
-                    "error": {
-                        "message": "The most recent reviewable push is not approved by someone other than the person who pushed it.",
-                        "guidance": "Create a branch ruleset protecting your default branch and enable \"Require approval of the most recent reviewable push\""
                     }
                 }
             ]


### PR DESCRIPTION
## Summary

Reviewed and updated Ampel policy for branch protection rules.
This PR also enables a scheduled job to check the branch protection rules and save the results as attestation artifact.

## Related Issues

- Brings visibility and traceability for branch protection rules.

## Review Hints

- https://github.com/complytime/org-infra/actions/workflows/ci_compliance.yml