### PR TITLE
fix: only test pr title if available

### DIFF
--- a/.github/workflows/reusable_ci.yml
+++ b/.github/workflows/reusable_ci.yml
@@ -26,14 +26,16 @@ jobs:
         uses: actions/checkout@de0fac2e4500dabe0009e67214ff5f5447ce83dd # v6.0.2
 
       - name: Install Dependencies
-        if: github.event.pull_request.user.login != 'dependabot[bot]'
+        if: ${{ github.event.pull_request.title != '' && github.event.pull_request.user.login != 'dependabot[bot]' }}
         run: npm install @commitlint/cli @commitlint/config-conventional
 
       - name: Validate PR Title
-        if: github.event.pull_request.user.login != 'dependabot[bot]'
+        if: ${{ github.event.pull_request.title != '' && github.event.pull_request.user.login != 'dependabot[bot]' }}
         env:
           PR_TITLE: "${{ github.event.pull_request.title }}"
-        run: echo "$PR_TITLE" | npx commitlint --config commitlint.config.js
+        run: |
+            echo "PR title provided: $PR_TITLE"
+            echo "$PR_TITLE" | npx commitlint --config commitlint.config.js
 
       - name: Run MegaLinter
         id: megalinter


### PR DESCRIPTION
## Summary

This test was removed in https://github.com/complytime/org-infra/pull/107 but needs to be reintroduced to avoid avoidable CI failures.

## Related Issues

- https://github.com/complytime/complytime-demos/actions/runs/22313548420/job/64841110519?pr=34

## Review Hints

- It reintroduces a PR title validation before checking its syntax.