### PR TITLE
ci: broken link checker in MegaLinter

### DIFF
--- a/.mega-linter.yml
+++ b/.mega-linter.yml
@@ -13,5 +13,9 @@ ENABLE_LINTERS:
   - PROTOBUF_PROTOLINT
   - REPOSITORY_GITLEAKS
   - REPOSITORY_KICS
+  - SPELL_LYCHEE
   - YAML_YAMLLINT
 REPOSITORY_KICS_ARGUMENTS: "--fail-on high"
+SPELL_LYCHEE_FILE_EXTENSIONS:
+  - ".md"
+SPELL_LYCHEE_ARGUMENTS: "--exclude-loopback --exclude-all-private --exclude example\\.com --exclude example\\.org"


### PR DESCRIPTION
## Summary
- Add `SPELL_LYCHEE` to MegaLinter to detect broken URLs in markdown files
- Scope link checking to `.md` files only via `SPELL_LYCHEE_FILE_EXTENSIONS`
- Exclude loopback, private IPs, and placeholder domains (example.com/org) to avoid false positives

## Test plan
- [ ] Verify MegaLinter CI passes with the new lychee linter enabled