### PR TITLE
chore: remove filter-like string from query

### DIFF
--- a/.github/workflows/reusable_dependabot_reviewer.yml
+++ b/.github/workflows/reusable_dependabot_reviewer.yml
@@ -77,7 +77,7 @@ jobs:
                 from_ref="${old_entry#*@}"
                 if [[ "$oname" == "$name" && "$from_ref" != "$to_ref" ]]; then
                   dep_name="$name"
-                  uses_query="uses: ${name}@${to_ref}"
+                  uses_query=" ${name}@${to_ref}"
                   extracted_from_diff=true
                   old_line="$(echo "$DIFF" | grep -F -- "${name}@${from_ref}" | head -1)"
                   new_line="$(echo "$DIFF" | grep -F -- "${name}@${to_ref}" | head -1)"


### PR DESCRIPTION
## Summary
Removed the "uses:" from gh query since it was interpreted as a filter instead of literal string and therefore impacting the results.
The simple ways to scape it didn't work and removing is not risk in this context, so opted for the simple solution.

## Related Issues

- Many dependabot PRs are not automatically approved due to this.

## Review Hints

```bash
gh search code "uses: aquasecurity/trivy-action@97e0b3872f55f89b95b2f65b3dbab56962816478 path:.github/workflows/" --json repository --limit 25

gh search code " aquasecurity/trivy-action@97e0b3872f55f89b95b2f65b3dbab56962816478 path:.github/workflows/" --json repository --limit 25
```