### PR TITLE
ci(deps): migrate attest-sbom to attest

### DIFF
--- a/.github/workflows/reusable_publish_ghcr.yml
+++ b/.github/workflows/reusable_publish_ghcr.yml
@@ -155,7 +155,7 @@ jobs:
 
       - name: Attest SBOM
         if: ${{ github.ref_protected }}
-        uses: actions/attest-sbom@07e74fc4e78d1aad915e867f9a094073a9f71527 # v4.0.0
+        uses: actions/attest@c32b4b8b198b65d0bd9d63490e847ff7b53989d4 # v4.0.0
         with:
           subject-name: ${{ steps.images.outputs.image }}
           subject-digest: ${{ steps.build.outputs.digest }}

--- a/.github/workflows/reusable_sign_and_verify.yml
+++ b/.github/workflows/reusable_sign_and_verify.yml
@@ -4,7 +4,7 @@
 #
 # Prerequisites (attestations must exist before calling this workflow):
 #   - SLSA provenance: from reusable_push_ghcr.yml (actions/attest-build-provenance)
-#   - SBOM:            from reusable_push_ghcr.yml (actions/attest-sbom)
+#   - SBOM:            from reusable_push_ghcr.yml (actions/attest)
 #   - Vuln scan:       from reusable_vuln_scan.yml (cosign attest --type vuln)
 #
 # Security guarantees:


### PR DESCRIPTION
## Summary

Replace deprecated `actions/attest-sbom` with `actions/attest` v4.0.0.

### Updates

- Update reusable_publish_ghcr.yml
- Depreciation warning - https://github.com/complytime/org-infra/pull/110
- Same inputs: subject-name, subject-digest, sbom-path, push-to-registry
- Removes deprecation warning from workflow runs
- Updated comment in reusable_sign_and_verify.yml 
