### PR TITLE
chore: CPLYTM-1318 - add ampel policies for gitlab branch protection rules

### DIFF
--- a/compliance/ampel/policies/branch-protection-rules/BP-01.01-require-pull-request.json
+++ b/compliance/ampel/policies/branch-protection-rules/BP-01.01-require-pull-request.json
@@ -1,0 +1,29 @@
+{
+  "id": "BP-1.01",
+  "meta": {
+    "description": "Validate branch protection settings require pull/merge requests via GitHub or GitLab API",
+    "controls": [
+      { "framework": "repo-branch-protection", "class": "source-code", "id": "BP-1" },
+      { "framework": "OSPS", "class": "OSPS-QA", "id": "07" }
+    ]
+  },
+  "tenets": [
+    {
+      "id": "01",
+      "code": "(has(predicates[0].data.values) && predicates[0].data.values.exists(rule, rule.type == \"update\")) || (has(predicates[0].data.push_access_levels) && size(predicates[0].data.push_access_levels) == 0)",
+      "predicates": {
+        "types": [
+          "http://github.com/carabiner-dev/snappy/specs/github/branch-rules.yaml",
+          "http://github.com/carabiner-dev/snappy/specs/gitlab/branch-protection.yaml"
+        ]
+      },
+      "assessment": {
+        "message": "Direct pushes are disabled. Pull/Merge requests required."
+      },
+      "error": {
+        "message": "Direct pushes are enabled so Pull/Merge requests are not required.",
+        "guidance": "GitHub: Create a branch ruleset and enable 'Restrict updates'. GitLab: Configure branch protection to remove all push_access_levels."
+      }
+    }
+  ]
+}

--- a/compliance/ampel/policies/branch-protection-rules/BP-02.01-minimum-approvals.json
+++ b/compliance/ampel/policies/branch-protection-rules/BP-02.01-minimum-approvals.json
@@ -1,0 +1,63 @@
+{
+  "id": "BP-2.01",
+  "meta": {
+    "description": "Validate minimum approval count and prevent self-approval via GitHub or GitLab API",
+    "controls": [
+      { "framework": "repo-branch-protection", "class": "source-code", "id": "BP-2" },
+      { "framework": "OSPS", "class": "OSPS-QA", "id": "07" }
+    ]
+  },
+  "tenets": [
+    {
+      "id": "01",
+      "code": "(has(predicates[0].data.values) && predicates[0].data.values.exists(rule, rule.type == \"pull_request\" && rule.parameters.required_approving_review_count >= 1)) || (has(predicates[0].data.approvals_before_merge) && predicates[0].data.approvals_before_merge >= 1)",
+      "predicates": {
+        "types": [
+          "http://github.com/carabiner-dev/snappy/specs/github/branch-rules.yaml",
+          "http://github.com/carabiner-dev/snappy/specs/gitlab/project-approvals.yaml"
+        ]
+      },
+      "assessment": {
+        "message": "Minimum one non-author approval is required"
+      },
+      "error": {
+        "message": "Pull/Merge requests can be merged without peer review.",
+        "guidance": "GitHub: Set required_approving_review_count >= 1. GitLab: Set approvals_before_merge >= 1."
+      }
+    },
+    {
+      "id": "02",
+      "code": "(has(predicates[0].data.values) && predicates[0].data.values.exists(rule, rule.type == \"pull_request\" && rule.parameters.dismiss_stale_reviews_on_push == true)) || (has(predicates[0].data.reset_approvals_on_push) && predicates[0].data.reset_approvals_on_push == true)",
+      "predicates": {
+        "types": [
+          "http://github.com/carabiner-dev/snappy/specs/github/branch-rules.yaml",
+          "http://github.com/carabiner-dev/snappy/specs/gitlab/project-approvals.yaml"
+        ]
+      },
+      "assessment": {
+        "message": "New commits pushed will reset/dismiss approvals."
+      },
+      "error": {
+        "message": "Approvals are not reset when new commits are pushed.",
+        "guidance": "GitHub: Enable 'Dismiss stale pull request approvals when new commits are pushed'. GitLab: Enable 'Remove all approvals when commits are added to the source branch'."
+      }
+    },
+    {
+      "id": "03",
+      "code": "(has(predicates[0].data.values) && predicates[0].data.values.exists(rule, rule.type == \"pull_request\" && rule.parameters.require_last_push_approval == true)) || (has(predicates[0].data.merge_requests_disable_committers_approval) && predicates[0].data.merge_requests_disable_committers_approval == true)",
+      "predicates": {
+        "types": [
+          "http://github.com/carabiner-dev/snappy/specs/github/branch-rules.yaml",
+          "http://github.com/carabiner-dev/snappy/specs/gitlab/project-approvals.yaml"
+        ]
+      },
+      "assessment": {
+        "message": "Pushers/committers cannot approve their own changes."
+      },
+      "error": {
+        "message": "Pushers/committers can approve their own changes.",
+        "guidance": "GitHub: Enable 'Require approval of the most recent reviewable push'. GitLab: Enable 'Prevent approval by author and committers'."
+      }
+    }
+  ]
+}

--- a/compliance/ampel/policies/branch-protection-rules/BP-03.01-block-force-push.json
+++ b/compliance/ampel/policies/branch-protection-rules/BP-03.01-block-force-push.json
@@ -1,0 +1,29 @@
+{
+  "id": "BP-3.01",
+  "meta": {
+    "description": "Validate force push blocking is enabled on protected branches via GitHub or GitLab API",
+    "controls": [
+      { "framework": "repo-branch-protection", "class": "source-code", "id": "BP-3" },
+      { "framework": "OSPS", "class": "OSPS-QA", "id": "07" }
+    ]
+  },
+  "tenets": [
+    {
+      "id": "01",
+      "code": "(has(predicates[0].data.values) && predicates[0].data.values.exists(rule, rule.type == \"non_fast_forward\")) || (has(predicates[0].data.allow_force_push) && predicates[0].data.allow_force_push == false)",
+      "predicates": {
+        "types": [
+          "http://github.com/carabiner-dev/snappy/specs/github/branch-rules.yaml",
+          "http://github.com/carabiner-dev/snappy/specs/gitlab/branch-protection.yaml"
+        ]
+      },
+      "assessment": {
+        "message": "Force pushing is disabled in protected branch."
+      },
+      "error": {
+        "message": "Force pushes can be sent to protected branch",
+        "guidance": "GitHub: Create a branch ruleset and enable 'Block force pushes'. GitLab: Set allow_force_push to false in branch protection."
+      }
+    }
+  ]
+}

--- a/compliance/ampel/policies/branch-protection-rules/BP-04.01-admin-bypass-prevention.json
+++ b/compliance/ampel/policies/branch-protection-rules/BP-04.01-admin-bypass-prevention.json
@@ -1,0 +1,29 @@
+{
+  "id": "BP-4.01",
+  "meta": {
+    "description": "Validate admin bypass prevention is enabled via GitHub or GitLab API",
+    "controls": [
+      { "framework": "repo-branch-protection", "class": "source-code", "id": "BP-4" },
+      { "framework": "OSPS", "class": "OSPS-QA", "id": "07" }
+    ]
+  },
+  "tenets": [
+    {
+      "id": "01",
+      "code": "(has(predicates[0].data.values) && predicates[0].data.values.exists(rule, rule.type == \"non_fast_forward\")) || (has(predicates[0].data.push_access_levels) && (size(predicates[0].data.push_access_levels) == 0 || predicates[0].data.push_access_levels.exists(level, level.access_level == 0)))",
+      "predicates": {
+        "types": [
+          "http://github.com/carabiner-dev/snappy/specs/github/branch-rules.yaml",
+          "http://github.com/carabiner-dev/snappy/specs/gitlab/branch-protection.yaml"
+        ]
+      },
+      "assessment": {
+        "message": "Admins cannot bypass branch protection rules. All changes must follow the standard process."
+      },
+      "error": {
+        "message": "Admins can bypass branch protection by pushing directly or force-pushing",
+        "guidance": "GitHub: Enable 'Block force pushes' in branch ruleset. GitLab: Set push_access_levels to empty or access_level 0 (No one)."
+      }
+    }
+  ]
+}

--- a/compliance/ampel/policies/branch-protection-rules/BP-05.01-code-owner-review.json
+++ b/compliance/ampel/policies/branch-protection-rules/BP-05.01-code-owner-review.json
@@ -1,0 +1,28 @@
+{
+  "id": "BP-5.01",
+  "meta": {
+    "description": "Validate code owner review requirements are enabled when CODEOWNERS file exists via GitHub or GitLab API",
+    "controls": [
+      { "framework": "repo-branch-protection", "class": "source-code", "id": "BP-5" }
+    ]
+  },
+  "tenets": [
+    {
+      "id": "01",
+      "code": "(has(predicates[0].data.values) && predicates[0].data.values.exists(rule, rule.type == \"pull_request\" && rule.parameters.require_code_owner_review == true)) || (has(predicates[0].data.code_owner_approval_required) && predicates[0].data.code_owner_approval_required == true)",
+      "predicates": {
+        "types": [
+          "http://github.com/carabiner-dev/snappy/specs/github/branch-rules.yaml",
+          "http://github.com/carabiner-dev/snappy/specs/gitlab/branch-protection.yaml"
+        ]
+      },
+      "assessment": {
+        "message": "CODEOWNER approval is required before merging"
+      },
+      "error": {
+        "message": "CODEOWNER approval is not required before merging",
+        "guidance": "GitHub: Enable 'Require review from Code Owners' in branch ruleset. GitLab: Set code_owner_approval_required to true in branch protection."
+      }
+    }
+  ]
+}


### PR DESCRIPTION
## Summary
This PR added granular Ampel policies for GitLab branch protections rules.

## Related Issues
- Closes CPLYTM-1318

## Review Hints
- New gitLab specs used by snappy could be checked here: https://github.com/carabiner-dev/snappy/pull/41