### PR TITLE
feat: CPLYTM-1345 - centralize the CRAP load analysis reusable workflow

### DIFF
--- a/.github/workflows/ci_crapload.yml
+++ b/.github/workflows/ci_crapload.yml
@@ -1,0 +1,75 @@
+# CRAP Load Check
+# ===============
+# Runs CRAP load analysis on pull requests targeting main.
+# Consumes the reusable workflow from org-infra.
+#
+# SPDX-License-Identifier: Apache-2.0
+
+name: CRAP Load Check
+
+on:
+  pull_request:
+    branches:
+      - main
+
+permissions:
+  contents: read
+  pull-requests: write
+
+jobs:
+  crapload:
+    name: CRAP Load Analysis
+    uses: complytime/org-infra/.github/workflows/reusable_crapload_analysis.yml@main
+    permissions:
+      contents: read
+
+  post-comment:
+    name: Post PR Comment
+    needs: crapload
+    runs-on: ubuntu-latest
+    permissions:
+      pull-requests: write
+    steps:
+      - name: Download comment body
+        uses: actions/download-artifact@3e5f45b2cfb9172054b4087a40e8e0b5a5461e7c # v8.0.1
+        with:
+          name: crapload-analysis
+          path: artifact
+
+      - name: Post or update PR comment
+        continue-on-error: true
+        uses: actions/github-script@60a0d83039c74a4aee543508d2ffcb1c3799cdea # v7.0.1
+        with:
+          script: |
+            const fs = require('fs');
+            const bodyPath = 'artifact/crapload-comment-body.md';
+            if (!fs.existsSync(bodyPath)) {
+              console.log('No comment body found. Skipping.');
+              return;
+            }
+            const body = fs.readFileSync(bodyPath, 'utf8');
+
+            const { data: comments } = await github.rest.issues.listComments({
+              owner: context.repo.owner,
+              repo: context.repo.repo,
+              issue_number: context.issue.number,
+            });
+
+            const marker = '<!-- crapload-analysis-marker -->';
+            const existing = comments.find(c => c.body.includes(marker));
+
+            if (existing) {
+              await github.rest.issues.updateComment({
+                owner: context.repo.owner,
+                repo: context.repo.repo,
+                comment_id: existing.id,
+                body,
+              });
+            } else {
+              await github.rest.issues.createComment({
+                owner: context.repo.owner,
+                repo: context.repo.repo,
+                issue_number: context.issue.number,
+                body,
+              });
+            }

--- a/.github/workflows/reusable_crapload_analysis.yml
+++ b/.github/workflows/reusable_crapload_analysis.yml
@@ -1,0 +1,377 @@
+# Reusable CRAP Load Analysis Workflow
+# =====================================
+# Runs CRAP (Change Risk Anti-Patterns) analysis on Go code using Gaze.
+# Compares results against a committed baseline and reports regressions,
+# improvements, and new functions. The caller is responsible for posting
+# PR comments using the uploaded artifact.
+#
+# SPDX-License-Identifier: Apache-2.0
+
+name: Reusable CRAP Load Analysis
+
+on:
+  workflow_call:
+    inputs:
+      go-version-file:
+        description: 'Path to go.mod for Go version detection'
+        type: string
+        default: './go.mod'
+      gaze-version:
+        description: 'Gaze version tag to install via go install'
+        type: string
+        default: 'latest'
+      baseline-file:
+        description: 'Path to committed baseline thresholds file'
+        type: string
+        default: '.gaze/baseline.json'
+      packages:
+        description: 'Go packages to analyse'
+        type: string
+        default: './...'
+      coverprofile:
+        description: 'Path to coverage profile'
+        type: string
+        default: 'coverage.out'
+      new-function-threshold:
+        description: 'CRAP score ceiling for new functions with no baseline entry'
+        type: number
+        default: 30
+    outputs:
+      status:
+        description: 'pass or fail'
+        value: ${{ jobs.crapload-analysis.outputs.status }}
+      crapload-count:
+        description: 'Number of functions at or above CRAP threshold'
+        value: ${{ jobs.crapload-analysis.outputs.crapload-count }}
+      gaze-crapload-count:
+        description: 'Number of functions at or above GazeCRAP threshold'
+        value: ${{ jobs.crapload-analysis.outputs.gaze-crapload-count }}
+      regressions-count:
+        description: 'Number of functions that regressed vs baseline'
+        value: ${{ jobs.crapload-analysis.outputs.regressions-count }}
+      improvements-count:
+        description: 'Number of functions that improved vs baseline'
+        value: ${{ jobs.crapload-analysis.outputs.improvements-count }}
+
+permissions:
+  contents: read
+
+jobs:
+  crapload-analysis:
+    name: CRAP Load Analysis
+    runs-on: ubuntu-latest
+    outputs:
+      status: ${{ steps.compare.outputs.status }}
+      crapload-count: ${{ steps.compare.outputs.crapload_count }}
+      gaze-crapload-count: ${{ steps.compare.outputs.gaze_crapload_count }}
+      regressions-count: ${{ steps.compare.outputs.regressions_count }}
+      improvements-count: ${{ steps.compare.outputs.improvements_count }}
+
+    steps:
+      - name: Checkout code
+        uses: actions/checkout@de0fac2e4500dabe0009e67214ff5f5447ce83dd # v6.0.2
+        with:
+          fetch-depth: 0
+
+      - name: Detect changed packages
+        id: detect-changes
+        if: github.event_name == 'pull_request'
+        run: |
+          CHANGED_FILES=$(git diff --name-only "${{ github.event.pull_request.base.sha }}..HEAD" -- '*.go' ':!vendor' || true)
+          if [ -z "$CHANGED_FILES" ]; then
+            echo "has_changes=false" >> "$GITHUB_OUTPUT"
+            echo "packages=" >> "$GITHUB_OUTPUT"
+            echo "No Go files changed in this PR."
+            exit 0
+          fi
+          PACKAGES=$(echo "$CHANGED_FILES" | xargs -I{} dirname {} | grep -v '^vendor' | sort -u | sed 's|^|./|' | paste -sd ' ')
+          echo "has_changes=true" >> "$GITHUB_OUTPUT"
+          echo "packages=$PACKAGES" >> "$GITHUB_OUTPUT"
+          echo "Changed packages: $PACKAGES"
+
+      - name: Handle no code changes
+        if: github.event_name == 'pull_request' && steps.detect-changes.outputs.has_changes == 'false'
+        id: no-changes
+        run: |
+          echo "skip=true" >> "$GITHUB_OUTPUT"
+          printf '%s\n' '<!-- crapload-analysis-marker -->' '## CRAP Load Analysis' '' \
+            'No Go code changes detected in this PR. No CRAP impact.' > /tmp/crapload-comment-body.md
+
+      - name: Set up Go
+        if: steps.no-changes.outputs.skip != 'true'
+        uses: actions/setup-go@4b73464bb391d4059bd26b0524d20df3927bd417 # v6.3.0
+        with:
+          go-version-file: ${{ inputs.go-version-file }}
+
+      - name: Install Gaze
+        if: steps.no-changes.outputs.skip != 'true'
+        id: install-gaze
+        env:
+          GOTOOLCHAIN: auto
+        run: |
+          echo "Installing gaze@${{ inputs.gaze-version }}..."
+          go install "github.com/unbound-force/gaze/cmd/gaze@${{ inputs.gaze-version }}"
+          gaze --version || echo "gaze installed (version flag may not be supported)"
+
+      - name: Generate coverage profile
+        if: steps.no-changes.outputs.skip != 'true'
+        run: |
+          PKGS="${{ steps.detect-changes.outputs.packages || inputs.packages }}"
+          echo "Running tests with coverage for: $PKGS"
+          go test -coverprofile="${{ inputs.coverprofile }}" $PKGS || true
+
+      - name: Run Gaze analysis
+        if: steps.no-changes.outputs.skip != 'true'
+        id: gaze-analysis
+        run: |
+          PKGS="${{ steps.detect-changes.outputs.packages || inputs.packages }}"
+          REPO_ROOT="$(pwd)/"
+          gaze report \
+            --format=json \
+            --coverprofile="${{ inputs.coverprofile }}" \
+            $PKGS 2>/tmp/gaze-stderr.txt \
+            > /tmp/gaze-report.json || true
+          echo "Gaze analysis complete."
+          cat /tmp/gaze-stderr.txt >&2 || true
+          # Extract CRAP data with path normalisation for baseline compatibility
+          jq --arg root "$REPO_ROOT" '.crap | (.scores[],.summary.worst_crap[]?,.summary.worst_gaze_crap[]?) |= (.file |= ltrimstr($root))' \
+            /tmp/gaze-report.json > /tmp/crapload-current.json || true
+
+      - name: Compare against baseline
+        if: steps.no-changes.outputs.skip != 'true'
+        id: compare
+        run: |
+          BASELINE="${{ inputs.baseline-file }}"
+          CURRENT="/tmp/crapload-current.json"
+          NEW_FUNC_THRESHOLD=${{ inputs.new-function-threshold }}
+          REGRESSIONS=""
+          IMPROVEMENTS=""
+          NEW_FUNCTIONS=""
+          REG_COUNT=0
+          IMP_COUNT=0
+          NEW_COUNT=0
+          NEW_VIOLATIONS=0
+
+          CRAPLOAD=$(jq -r '.summary.crapload // 0' "$CURRENT")
+          GAZE_CRAPLOAD=$(jq -r '.summary.gaze_crapload // 0' "$CURRENT")
+          {
+            echo "crapload_count=$CRAPLOAD"
+            echo "gaze_crapload_count=$GAZE_CRAPLOAD"
+          } >> "$GITHUB_OUTPUT"
+
+          if [ ! -f "$BASELINE" ]; then
+            echo "::warning::Baseline file $BASELINE not found. Skipping per-function comparison."
+            {
+              echo "status=pass"
+              echo "regressions_count=0"
+              echo "improvements_count=0"
+            } >> "$GITHUB_OUTPUT"
+            exit 0
+          fi
+
+          # Build lookup from baseline: key = file:function (unique across multi-module repos)
+          jq -r '.scores[] | "\(.file):\(.function)\t\(.crap)\t\(.gaze_crap // 0)"' "$BASELINE" | sort > /tmp/baseline-lookup.tsv
+
+          # Process current scores
+          while IFS=$'\t' read -r key crap gaze_crap; do
+            baseline_line=$(grep "^${key}	" /tmp/baseline-lookup.tsv || true)
+            if [ -z "$baseline_line" ]; then
+              # New function
+              NEW_COUNT=$((NEW_COUNT + 1))
+              status_icon="+"
+              if [ "$(echo "$crap > $NEW_FUNC_THRESHOLD" | bc -l)" = "1" ]; then
+                NEW_VIOLATIONS=$((NEW_VIOLATIONS + 1))
+                status_icon="!+"
+              fi
+              NEW_FUNCTIONS="${NEW_FUNCTIONS}| ${status_icon} | \`${key}\` | ${crap} | ${gaze_crap} | new (threshold: ${NEW_FUNC_THRESHOLD}) |\n"
+            else
+              b_crap=$(echo "$baseline_line" | cut -f2)
+              b_gaze=$(echo "$baseline_line" | cut -f3)
+              crap_diff=$(echo "$crap - $b_crap" | bc -l)
+              gaze_diff=$(echo "$gaze_crap - $b_gaze" | bc -l)
+              has_regression=false
+              has_improvement=false
+
+              if [ "$(echo "$crap > $b_crap" | bc -l)" = "1" ]; then
+                has_regression=true
+              elif [ "$(echo "$crap < $b_crap" | bc -l)" = "1" ]; then
+                has_improvement=true
+              fi
+              if [ "$(echo "$gaze_crap > $b_gaze" | bc -l)" = "1" ]; then
+                has_regression=true
+              elif [ "$(echo "$gaze_crap < $b_gaze" | bc -l)" = "1" ]; then
+                has_improvement=true
+              fi
+
+              if [ "$has_regression" = "true" ]; then
+                REG_COUNT=$((REG_COUNT + 1))
+                REGRESSIONS="${REGRESSIONS}| \`${key}\` | ${b_crap} | ${crap} | ${crap_diff} | ${b_gaze} | ${gaze_crap} | ${gaze_diff} |\n"
+              elif [ "$has_improvement" = "true" ]; then
+                IMP_COUNT=$((IMP_COUNT + 1))
+                IMPROVEMENTS="${IMPROVEMENTS}| \`${key}\` | ${b_crap} | ${crap} | ${crap_diff} | ${b_gaze} | ${gaze_crap} | ${gaze_diff} |\n"
+              fi
+            fi
+          done < <(jq -r '.scores[] | "\(.file):\(.function)\t\(.crap)\t\(.gaze_crap // 0)"' "$CURRENT" | sort)
+
+          {
+            echo "regressions_count=$REG_COUNT"
+            echo "improvements_count=$IMP_COUNT"
+          } >> "$GITHUB_OUTPUT"
+
+          TOTAL_FAILURES=$((REG_COUNT + NEW_VIOLATIONS))
+          if [ "$TOTAL_FAILURES" -gt 0 ]; then
+            echo "status=fail" >> "$GITHUB_OUTPUT"
+          else
+            echo "status=pass" >> "$GITHUB_OUTPUT"
+          fi
+
+          if [ "$TOTAL_FAILURES" -gt 0 ]; then
+            echo "::error::CRAP regressions detected: $REG_COUNT regression(s), $NEW_VIOLATIONS new function violation(s)"
+          fi
+
+          # Build PR comment body
+          STATUS_BADGE="&#x2705;"
+          STATUS_TEXT="PASS"
+          if [ "$TOTAL_FAILURES" -gt 0 ]; then
+            STATUS_BADGE="&#x274C;"
+            STATUS_TEXT="FAIL"
+          fi
+
+          AVG_COMPLEXITY=$(jq -r '(.summary.avg_complexity // 0) * 10 | round / 10' "$CURRENT")
+          AVG_LINE_COV=$(jq -r '(.summary.avg_line_coverage // 0) * 10 | round / 10' "$CURRENT")
+          AVG_CRAP=$(jq -r '(.summary.avg_crap // 0) * 10 | round / 10' "$CURRENT")
+          CRAP_THRESH=$(jq -r '.summary.crap_threshold // 15' "$CURRENT")
+          AVG_CONTRACT_COV=$(jq -r '(.summary.avg_contract_coverage // 0) * 10 | round / 10' "$CURRENT")
+          AVG_GAZE_CRAP=$(jq -r '(.summary.avg_gaze_crap // 0) * 10 | round / 10' "$CURRENT")
+          GAZE_CRAP_THRESH=$(jq -r '.summary.gaze_crap_threshold // 15' "$CURRENT")
+          TOTAL_FUNCS=$(jq -r '.summary.total_functions // 0' "$CURRENT")
+
+          {
+            echo "<!-- crapload-analysis-marker -->"
+            echo "## ${STATUS_BADGE} CRAP Load Analysis: ${STATUS_TEXT}"
+            echo ""
+            echo "### Summary"
+            echo ""
+            echo "| Metric | Value |"
+            echo "|--------|-------|"
+            echo "| Functions analysed | ${TOTAL_FUNCS} |"
+            echo "| Avg complexity | ${AVG_COMPLEXITY} |"
+            echo "| Avg line coverage | ${AVG_LINE_COV}% |"
+            echo "| Avg CRAP score | ${AVG_CRAP} |"
+            echo "| CRAPload (>= ${CRAP_THRESH}) | ${CRAPLOAD} |"
+            echo "| Avg contract coverage | ${AVG_CONTRACT_COV}% |"
+            echo "| Avg GazeCRAP score | ${AVG_GAZE_CRAP} |"
+            echo "| GazeCRAPload (>= ${GAZE_CRAP_THRESH}) | ${GAZE_CRAPLOAD} |"
+            echo "| Regressions | ${REG_COUNT} |"
+            echo "| Improvements | ${IMP_COUNT} |"
+            echo "| New functions | ${NEW_COUNT} |"
+          } > /tmp/crapload-comment-body.md
+
+          # Quality metrics from gaze report
+          QUALITY_COV=$(jq -r '(.quality.summary.average_contract_coverage // empty) * 10 | round / 10' /tmp/gaze-report.json 2>/dev/null || true)
+          if [ -n "$QUALITY_COV" ]; then
+            QUALITY_OVERSPEC=$(jq -r '(.quality.summary.average_over_specification // 0) * 10 | round / 10' /tmp/gaze-report.json 2>/dev/null || echo "0")
+            {
+              echo "| Avg contract coverage (quality) | ${QUALITY_COV}% |"
+              echo "| Avg over-specification | ${QUALITY_OVERSPEC}% |"
+            } >> /tmp/crapload-comment-body.md
+          fi
+
+          # Quadrant distribution from gaze report
+          Q1=$(jq -r '.crap.summary.quadrant_counts.Q1_Safe // empty' /tmp/gaze-report.json 2>/dev/null || true)
+          if [ -n "$Q1" ]; then
+            Q2=$(jq -r '.crap.summary.quadrant_counts.Q2_ComplexButTested // 0' /tmp/gaze-report.json)
+            Q3=$(jq -r '.crap.summary.quadrant_counts.Q3_SimpleButUnderspecified // 0' /tmp/gaze-report.json)
+            Q4=$(jq -r '.crap.summary.quadrant_counts.Q4_Dangerous // 0' /tmp/gaze-report.json)
+            {
+              echo ""
+              echo "### Quadrant Distribution"
+              echo ""
+              echo "| Quadrant | Count |"
+              echo "|----------|-------|"
+              echo "| Q1 Safe | ${Q1} |"
+              echo "| Q2 Complex but Tested | ${Q2} |"
+              echo "| Q3 Simple but Underspecified | ${Q3} |"
+              echo "| Q4 Dangerous | ${Q4} |"
+            } >> /tmp/crapload-comment-body.md
+          fi
+
+          if [ -n "$REGRESSIONS" ]; then
+            {
+              echo ""
+              echo "### Regressions"
+              echo ""
+              echo "| Function | Baseline CRAP | Current CRAP | Delta | Baseline GazeCRAP | Current GazeCRAP | Delta |"
+              echo "|----------|---------------|--------------|-------|-------------------|------------------|-------|"
+              printf '%b' "$REGRESSIONS"
+            } >> /tmp/crapload-comment-body.md
+          fi
+
+          if [ -n "$IMPROVEMENTS" ]; then
+            {
+              echo ""
+              echo "### Improvements"
+              echo ""
+              echo "| Function | Baseline CRAP | Current CRAP | Delta | Baseline GazeCRAP | Current GazeCRAP | Delta |"
+              echo "|----------|---------------|--------------|-------|-------------------|------------------|-------|"
+              printf '%b' "$IMPROVEMENTS"
+            } >> /tmp/crapload-comment-body.md
+          fi
+
+          if [ -n "$NEW_FUNCTIONS" ]; then
+            {
+              echo ""
+              echo "### New Functions"
+              echo ""
+              echo "| Status | Function | CRAP | GazeCRAP | Note |"
+              echo "|--------|----------|------|----------|------|"
+              printf '%b' "$NEW_FUNCTIONS"
+            } >> /tmp/crapload-comment-body.md
+          fi
+
+          # Analysis warnings from gaze report
+          FAILED_STEPS=$(jq -r '.errors | to_entries[] | select(.value != null) | "- **\(.key)**: \(.value)"' /tmp/gaze-report.json 2>/dev/null || true)
+          if [ -n "$FAILED_STEPS" ]; then
+            {
+              echo ""
+              echo "### Analysis Warnings"
+              echo ""
+              echo "$FAILED_STEPS"
+            } >> /tmp/crapload-comment-body.md
+          fi
+
+          {
+            echo ""
+            echo "[View full analysis logs](${GITHUB_SERVER_URL}/${GITHUB_REPOSITORY}/actions/runs/${GITHUB_RUN_ID})"
+          } >> /tmp/crapload-comment-body.md
+
+      - name: Write step summary
+        if: github.event_name == 'pull_request'
+        run: cat /tmp/crapload-comment-body.md >> "$GITHUB_STEP_SUMMARY"
+
+      - name: Upload analysis artifact
+        uses: actions/upload-artifact@bbbca2ddaa5d8feaa63e36b76fdaad77386f024f # v7.0.0
+        with:
+          name: crapload-analysis
+          path: /tmp/crapload-comment-body.md
+          retention-days: 30
+
+      - name: Upload detailed analysis
+        if: steps.no-changes.outputs.skip != 'true'
+        uses: actions/upload-artifact@bbbca2ddaa5d8feaa63e36b76fdaad77386f024f # v7.0.0
+        with:
+          name: crapload-analysis-detailed
+          path: |
+            /tmp/gaze-report.json
+            /tmp/crapload-current.json
+          retention-days: 30
+
+      - name: Enforce threshold
+        if: steps.no-changes.outputs.skip != 'true'
+        run: |
+          STATUS="${{ steps.compare.outputs.status }}"
+          if [ "$STATUS" = "fail" ]; then
+            echo "::error::CRAP load check failed. See PR comment for details."
+            exit 1
+          fi
+          echo "CRAP load check passed."

--- a/README.md
+++ b/README.md
@@ -35,9 +35,11 @@ org-infra/
 │  │  ├── ci_dependencies.yml               # Workflow to consume `reusable_dependabot_reviewer` and `reusable_deps_reviewer`
 │  │  │                                     # plus local jobs to auto-approve and comment on dependabot PRs.
 │  │  ├── ci_scheduled.yml                  # Scheduled OSV-Scanner and OpenSSF Scorecards via `reusable_scheduled`.
+│  │  ├── ci_crapload.yml                   # Workflow to consume `reusable_crapload_analysis` for CRAP load analysis.
 │  │  ├── ci_security.yml                   # Workflow to consume `reusable_vuln_scan` and `reusable_security`.
 │  │  ├── reusable_ci.yml                   # Generic CI checks, such as linters, typos and PR titles.
 │  │  ├── reusable_compliance.yml           # Compliance evaluation with attestation-based policy checks.
+│  │  ├── reusable_crapload_analysis.yml    # CRAP (Change Risk Anti-Patterns) load analysis for Go code using Gaze.
 │  │  ├── reusable_dependabot_reviewer.yml  # Specific for dependabot PRs. Classify risk and checks dependency adoption.
 │  │  ├── reusable_deps_reviewer.yml        # Check for vulnerabilities, license issues, and OpenSSF Scorecard Level.
 │  │  ├── reusable_gemini_review.yml        # AI-powered code review using Google Gemini to review pull requests.

--- a/specs/001-crapload-workflow/checklists/requirements.md
+++ b/specs/001-crapload-workflow/checklists/requirements.md
@@ -1,0 +1,34 @@
+# Specification Quality Checklist: Centralize CRAP Load Analysis Workflow
+
+**Purpose**: Validate specification completeness and quality before proceeding to planning
+**Created**: 2026-03-18
+**Feature**: [spec.md](../spec.md)
+
+## Content Quality
+
+- [x] No implementation details (languages, frameworks, APIs)
+- [x] Focused on user value and business needs
+- [x] Written for non-technical stakeholders
+- [x] All mandatory sections completed
+
+## Requirement Completeness
+
+- [x] No [NEEDS CLARIFICATION] markers remain
+- [x] Requirements are testable and unambiguous
+- [x] Success criteria are measurable
+- [x] Success criteria are technology-agnostic (no implementation details)
+- [x] All acceptance scenarios are defined
+- [x] Edge cases are identified
+- [x] Scope is clearly bounded
+- [x] Dependencies and assumptions identified
+
+## Feature Readiness
+
+- [x] All functional requirements have clear acceptance criteria
+- [x] User scenarios cover primary flows
+- [x] Feature meets measurable outcomes defined in Success Criteria
+- [x] No implementation details leak into specification
+
+## Notes
+
+- All items pass. Spec is ready for `/speckit.clarify` or `/speckit.plan`.

--- a/specs/001-crapload-workflow/data-model.md
+++ b/specs/001-crapload-workflow/data-model.md
@@ -1,0 +1,33 @@
+# Data Model: Centralize CRAP Load Analysis Workflow
+
+**Date**: 2026-03-18
+
+This feature does not introduce a traditional data model. The relevant data structures are defined by the Gaze tool and consumed as intermediate artifacts within the workflow.
+
+## Workflow Inputs (configuration interface)
+
+| Input | Type | Required | Default | Description |
+|-------|------|----------|---------|-------------|
+| go-version-file | string | no | `./go.mod` | Path to go.mod for Go version detection |
+| gaze-version | string | no | `latest` | Gaze version tag for `go install` |
+| baseline-file | string | no | `.gaze/baseline.json` | Path to committed baseline thresholds |
+| packages | string | no | `./...` | Go packages to analyze |
+| coverprofile | string | no | `coverage.out` | Path to coverage profile |
+| new-function-threshold | number | no | `30` | CRAP score ceiling for new functions |
+| post-comment | boolean | no | `true` | Whether to post/update PR comment |
+
+## Workflow Outputs
+
+| Output | Type | Description |
+|--------|------|-------------|
+| status | string | `pass` or `fail` |
+| crapload-count | number | Functions at or above CRAP threshold |
+| gaze-crapload-count | number | Functions at or above GazeCRAP threshold |
+| regressions-count | number | Functions that regressed vs baseline |
+| improvements-count | number | Functions that improved vs baseline |
+
+## Intermediate Artifacts
+
+- **gaze-report.json**: Full Gaze analysis output (uploaded as artifact)
+- **crapload-current.json**: Extracted CRAP scores with normalized paths (uploaded as artifact)
+- **baseline-lookup.tsv**: Baseline scores keyed by `file:function` (ephemeral, not uploaded)

--- a/specs/001-crapload-workflow/plan.md
+++ b/specs/001-crapload-workflow/plan.md
@@ -1,0 +1,94 @@
+# Implementation Plan: Centralize CRAP Load Analysis Workflow
+
+**Branch**: `001-crapload-workflow` | **Date**: 2026-03-18 | **Spec**: [spec.md](spec.md)
+**Input**: Feature specification from `/specs/001-crapload-workflow/spec.md`
+
+## Summary
+
+Move the reusable CRAP Load Analysis workflow from complyctl to org-infra, provide a consumer workflow template, and add sync configuration to distribute it to Go repositories across the organization. This is a workflow migration — the existing implementation is proven and requires only path reference changes, not logic changes.
+
+## Technical Context
+
+**Language/Version**: YAML (GitHub Actions workflow syntax)
+**Primary Dependencies**: Gaze (`github.com/unbound-force/gaze`), Go toolchain (detected from `go.mod`), `jq`, `bc`
+**Storage**: N/A
+**Testing**: Validated via yamllint (local), MegaLinter (CI), and dry-run sync verification
+**Target Platform**: GitHub Actions (ubuntu-latest runners)
+**Project Type**: CI/CD infrastructure (reusable workflow + consumer template + sync config)
+**Performance Goals**: N/A (CI workflow — runtime bounded by repository test suite)
+**Constraints**: Workflow MUST follow least-privilege permissions; MUST pass yamllint
+**Scale/Scope**: Targets all Go repositories in the ComplyTime organization (~8 repos based on golangci exclusion list)
+
+## Constitution Check
+
+*GATE: Must pass before Phase 0 research. Re-check after Phase 1 design.*
+
+| Principle | Status | Evidence |
+|-----------|--------|----------|
+| I. Single Source of Truth | PASS | Moving workflow to org-infra centralizes it as the single source; eliminates duplicate in complyctl |
+| II. Simplicity & Isolation | PASS | Reusable workflow has single responsibility (CRAP analysis); consumer workflow is a thin caller |
+| III. Incremental Improvement | PASS | This PR only moves the workflow and adds sync config — no unrelated changes |
+| IV. Readability First | PASS | Workflow has descriptive step names, header comment, and clear input descriptions |
+| V. Do Not Reinvent the Wheel | PASS | Uses existing Gaze tool; leverages established org-infra sync mechanism |
+| VI. Composability | PASS | Reusable workflow outputs status/counts for downstream composition; consumer workflow is modular |
+| VII. Convention Over Configuration | PASS | Sensible defaults for all inputs (go.mod path, packages, threshold, etc.) |
+| YAML Naming Conventions | PASS | `reusable_crapload_analysis.yml` and `ci_crapload.yml` follow org conventions |
+| YAML Security | PASS | Permissions scoped to `contents: read` + `pull-requests: write` (minimum required) |
+| YAML Design | PASS | All inputs have descriptions, required flags, and defaults where appropriate |
+| YAML Formatting | PASS | Header comment present; linted with yamllint |
+| Lint Configuration Awareness | PASS | Must pass `.yamllint.yml` and MegaLinter CI checks |
+
+**Gate result**: PASS — no violations detected.
+
+## Project Structure
+
+### Documentation (this feature)
+
+```text
+specs/001-crapload-workflow/
+├── plan.md              # This file
+├── research.md          # Phase 0 output
+├── data-model.md        # Phase 1 output (minimal — no data model)
+├── quickstart.md        # Phase 1 output
+└── tasks.md             # Phase 2 output (/speckit.tasks command)
+```
+
+### Source Code (repository root)
+
+```text
+.github/workflows/
+├── reusable_crapload_analysis.yml   # NEW — reusable workflow (moved from complyctl)
+└── ci_crapload.yml                  # NEW — consumer workflow template (synced to Go repos)
+
+sync-config.yml                      # MODIFIED — add ci_crapload.yml sync entry
+```
+
+**Structure Decision**: This feature adds two workflow files to the existing `.github/workflows/` directory and modifies the sync configuration. No new directories or structural changes needed — follows the established org-infra pattern.
+
+## Migration Details
+
+### Consumer Workflow Reference Change
+
+When the reusable workflow moves from complyctl to org-infra, consumer workflows in other repositories must reference it cross-repository:
+
+- **Before** (local in complyctl): `uses: ./.github/workflows/reusable_crapload_analysis.yml`
+- **After** (centralized in org-infra): `uses: complytime/org-infra/.github/workflows/reusable_crapload_analysis.yml@main`
+
+### Sync Configuration
+
+The consumer workflow (`ci_crapload.yml`) will be synced to Go repositories. Non-Go repositories must be excluded. The exclusion list mirrors the `ruff.toml` sync entry (which targets Python repos — inverse of Go repos):
+
+**Exclude from ci_crapload.yml sync**:
+- `complyscribe` — Python-only
+- `complytime-demos` — demo/docs repository
+- `complytime-policies` — policy definitions, no Go code
+- `vagrant-boxes` — infrastructure, no Go code
+- `community` — community docs, no Go code
+
+### Indentation Normalization
+
+The source workflow in complyctl uses 4-space indentation. Org-infra workflows use 2-space indentation. The workflow MUST be normalized to 2-space indentation to pass yamllint with the org-infra `.yamllint.yml` configuration (which enforces `spaces: consistent` and the repo standard is 2 spaces).
+
+## Complexity Tracking
+
+No constitution violations to justify. Feature is a straightforward migration with no architectural complexity.

--- a/specs/001-crapload-workflow/quickstart.md
+++ b/specs/001-crapload-workflow/quickstart.md
@@ -1,0 +1,58 @@
+# Quickstart: CRAP Load Analysis
+
+## For Repository Maintainers (Adopting the Workflow)
+
+### 1. Add the consumer workflow
+
+Create `.github/workflows/ci_crapload.yml` in your repository:
+
+```yaml
+# SPDX-License-Identifier: Apache-2.0
+
+name: CRAP Load Check
+
+on:
+  pull_request:
+    branches:
+      - main
+
+permissions:
+  contents: read
+  pull-requests: write
+
+jobs:
+  crapload:
+    name: CRAP Load Analysis
+    uses: complytime/org-infra/.github/workflows/reusable_crapload_analysis.yml@main
+    permissions:
+      contents: read
+      pull-requests: write
+```
+
+### 2. (Optional) Commit a baseline file
+
+To enable regression detection, commit a baseline at `.gaze/baseline.json`. This file contains per-function CRAP scores from a known-good state. Without it, the workflow still runs but skips per-function comparison.
+
+### 3. Open a pull request
+
+The workflow runs automatically on PRs targeting `main` that modify Go files. Results appear as a PR comment with a summary table.
+
+## Customizing Inputs
+
+Override defaults by passing `with:` in the consumer workflow:
+
+```yaml
+jobs:
+  crapload:
+    uses: complytime/org-infra/.github/workflows/reusable_crapload_analysis.yml@main
+    with:
+      new-function-threshold: 20    # Stricter threshold
+      packages: './cmd/... ./pkg/...'  # Specific packages only
+      post-comment: false            # Disable PR comments
+```
+
+## For org-infra Contributors
+
+The reusable workflow lives at `.github/workflows/reusable_crapload_analysis.yml`. Changes here affect all consuming repositories. Follow the constitution's Amendment Procedure for workflow modifications.
+
+The consumer template at `.github/workflows/ci_crapload.yml` is distributed to Go repositories via the sync mechanism defined in `sync-config.yml`.

--- a/specs/001-crapload-workflow/research.md
+++ b/specs/001-crapload-workflow/research.md
@@ -1,0 +1,42 @@
+# Research: Centralize CRAP Load Analysis Workflow
+
+**Date**: 2026-03-18
+
+## R1: Cross-Repository Workflow Reference Syntax
+
+**Decision**: Use `complytime/org-infra/.github/workflows/reusable_crapload_analysis.yml@main` as the workflow reference in consumer workflows.
+
+**Rationale**: This is the standard GitHub Actions syntax for cross-repository reusable workflow calls. Using `@main` ensures consumers always get the latest version. This matches how other org-infra reusable workflows are consumed.
+
+**Alternatives considered**:
+- `@<sha>` pinning — more secure but creates maintenance burden for every update. Not used by other org-infra workflows.
+- `@<tag>` pinning — requires a release tagging workflow. Org-infra does not currently use release tags for workflows.
+
+## R2: Sync Exclusion List for Go-Only Workflow
+
+**Decision**: Exclude non-Go repositories from `ci_crapload.yml` sync using per-file `exclude_repos` in `sync-config.yml`.
+
+**Rationale**: The existing `.golangci.yml` sync entry already excludes non-Go repos (`complyscribe`, `complytime-demos`, `complytime-policies`, `vagrant-boxes`). The CRAP analysis consumer workflow should use the same exclusion list plus `community` (which was added to the org after the golangci entry). This pattern is already established in the sync config.
+
+**Alternatives considered**:
+- Syncing to all repos and relying on the workflow to skip (no Go files detected) — wasteful, creates noise in non-Go repos.
+- Creating a separate "go-repos" list in sync config — over-engineering for current needs; can be introduced later if more Go-specific workflows are added.
+
+## R3: Indentation Standard
+
+**Decision**: Normalize the workflow from 4-space to 2-space indentation.
+
+**Rationale**: The source workflow in complyctl uses 4-space YAML indentation. Org-infra's `.yamllint.yml` enforces `spaces: consistent`, and all existing org-infra workflows use 2 spaces. The migrated workflow MUST be normalized to 2-space indentation for consistency and to pass linting.
+
+**Alternatives considered**:
+- Keeping 4-space — would pass yamllint (consistent within file) but would be inconsistent with every other workflow in org-infra. Violates Constitution Principle IV (Readability First) due to inconsistency.
+
+## R4: Gaze Tool Dependency
+
+**Decision**: Accept Gaze as an external dependency installed via `go install` at runtime.
+
+**Rationale**: Gaze is the established tool for CRAP/GazeCRAP analysis in the ComplyTime ecosystem. It's actively maintained, publicly available on GitHub, and already validated in complyctl's CI. Installing via `go install` is the standard Go tool distribution pattern.
+
+**Alternatives considered**:
+- Pre-built binary download — Gaze distributes via `go install`, not binary releases. Would require maintaining a fork or custom build.
+- Container-based Gaze — over-engineering; `go install` is simpler and aligns with Constitution Principle II (Simplicity).

--- a/specs/001-crapload-workflow/spec.md
+++ b/specs/001-crapload-workflow/spec.md
@@ -1,0 +1,106 @@
+# Feature Specification: Centralize CRAP Load Analysis Workflow
+
+**Feature Branch**: `001-crapload-workflow`
+**Created**: 2026-03-18
+**Status**: Draft
+**Input**: User description: "Move reusable CRAP Load Analysis workflow from complyctl to org-infra so Go repositories across the organization can adopt it."
+
+## User Scenarios & Testing *(mandatory)*
+
+### User Story 1 - Adopt CRAP Load Analysis in a Go Repository (Priority: P1)
+
+A maintainer of a Go repository within the ComplyTime organization wants to add CRAP (Change Risk Anti-Patterns) load analysis to their CI pipeline. They add a consumer workflow to their repository that references the reusable workflow from org-infra, and CRAP analysis runs automatically on pull requests.
+
+**Why this priority**: This is the core value proposition — enabling any Go repository to adopt CRAP load analysis without duplicating workflow code.
+
+**Independent Test**: Can be fully tested by creating a consumer workflow in a Go repository that calls the reusable workflow from org-infra and verifying that CRAP analysis results appear on a pull request.
+
+**Acceptance Scenarios**:
+
+1. **Given** a Go repository with a consumer workflow referencing the org-infra reusable workflow, **When** a pull request is opened that modifies Go files, **Then** the CRAP load analysis runs and posts a summary comment on the PR.
+2. **Given** a Go repository with a consumer workflow, **When** a pull request is opened that does not modify any Go files, **Then** the workflow reports "No Go code changes detected" without running analysis.
+3. **Given** a Go repository with a committed baseline file, **When** CRAP analysis runs on a PR, **Then** the results include regressions, improvements, and new function comparisons against the baseline.
+
+---
+
+### User Story 2 - Detect CRAP Score Regressions on Pull Requests (Priority: P1)
+
+A maintainer wants to prevent code quality degradation. When a contributor submits a pull request that increases the CRAP score of existing functions or introduces new functions exceeding the threshold, the workflow blocks the PR and clearly reports which functions regressed.
+
+**Why this priority**: Regression detection is the primary quality gate that makes the workflow actionable, not just informational.
+
+**Independent Test**: Can be tested by submitting a PR that intentionally increases complexity without adding test coverage, and verifying the workflow fails with a clear regression report.
+
+**Acceptance Scenarios**:
+
+1. **Given** a baseline file exists and a PR increases the CRAP score of an existing function, **When** the analysis completes, **Then** the workflow status is "fail" and the PR comment lists the regressed functions with before/after scores.
+2. **Given** a PR introduces a new function with a CRAP score above the configured threshold, **When** the analysis completes, **Then** the workflow status is "fail" and the new function is flagged as a violation.
+3. **Given** a PR improves CRAP scores (adds tests or reduces complexity), **When** the analysis completes, **Then** the workflow status is "pass" and improvements are listed in the PR comment.
+
+---
+
+### User Story 3 - Sync Consumer Workflow to Go Repositories (Priority: P2)
+
+The org-infra sync mechanism distributes a consumer workflow template to Go repositories across the organization, so new repositories automatically get CRAP load analysis without manual setup.
+
+**Why this priority**: Automates adoption across the organization but depends on the reusable workflow (P1) being available first.
+
+**Independent Test**: Can be tested by adding the consumer workflow to the sync configuration and running a dry-run sync to verify it targets the correct repositories.
+
+**Acceptance Scenarios**:
+
+1. **Given** the consumer workflow is added to the sync configuration, **When** the sync script runs, **Then** Go repositories receive the consumer workflow file.
+2. **Given** the sync configuration excludes non-Go repositories, **When** the sync runs, **Then** Python-only repositories do not receive the consumer workflow.
+
+---
+
+### Edge Cases
+
+- What happens when no baseline file exists in a repository? The workflow skips per-function comparison and passes, logging a warning.
+- What happens when the Gaze tool fails to install or produce output? The workflow steps use failure guards and the analysis continues gracefully, uploading whatever data is available.
+- What happens when a repository uses a non-standard Go module structure (e.g., multi-module monorepo)? The workflow accepts a configurable `packages` input to specify which packages to analyze.
+
+## Requirements *(mandatory)*
+
+### Functional Requirements
+
+- **FR-001**: The reusable workflow MUST be hosted in org-infra and callable via `workflow_call` by any repository in the organization.
+- **FR-002**: A consumer workflow template MUST be provided for repositories to invoke the reusable workflow on pull requests targeting `main`.
+- **FR-003**: The workflow MUST detect which Go packages were changed in a pull request and scope analysis to only those packages.
+- **FR-004**: The workflow MUST generate a coverage profile, run CRAP analysis, and compare results against a committed baseline file when available.
+- **FR-005**: The workflow MUST post or update a single PR comment (idempotent) with a summary table including metrics such as average complexity, coverage, CRAP scores, regressions, improvements, and new functions.
+- **FR-006**: The workflow MUST fail the check when regressions or new-function threshold violations are detected.
+- **FR-007**: The workflow MUST support configurable inputs for Go version detection, analysis tool version, baseline file path, target packages, coverage profile path, new-function threshold, and PR comment toggle.
+- **FR-008**: The consumer workflow template MUST be added to the org-infra sync configuration to distribute it to Go repositories, excluding non-Go repositories.
+- **FR-009**: The workflow MUST upload analysis artifacts for retention.
+- **FR-010**: The workflow MUST follow the Principle of Least Privilege, requesting only the minimum permissions required for reading source code and writing PR comments.
+
+### Key Entities
+
+- **CRAP Score**: A metric combining cyclomatic complexity and code coverage to identify risky functions. Higher scores indicate higher risk.
+- **Baseline File**: A committed JSON file containing per-function CRAP scores from a known-good state, used for regression detection.
+- **Consumer Workflow**: A repository-level workflow file that invokes the reusable workflow with repository-specific configuration.
+
+## Success Criteria *(mandatory)*
+
+### Measurable Outcomes
+
+- **SC-001**: Any Go repository in the organization can adopt CRAP load analysis by adding a single consumer workflow file, with no other setup required beyond having Go tests.
+- **SC-002**: CRAP score regressions are detected and reported within the standard CI pipeline run, without requiring a separate review step.
+- **SC-003**: The workflow produces actionable PR comments that clearly identify which functions regressed, improved, or are new, with before/after scores.
+- **SC-004**: The reusable workflow is adopted by at least the complyctl repository (migrating from its local copy) as validation of the centralization.
+
+## Assumptions
+
+- The CRAP analysis tool is publicly available and installable in CI environments.
+- Go repositories in the organization have existing test suites that produce meaningful coverage data.
+- The org-infra sync mechanism is the established method for distributing workflow files to organization repositories.
+- The main-branch workflow for baseline updates and metrics publishing is repository-specific and will NOT be centralized — each repository manages its own baseline publishing strategy.
+- Non-Go repositories are excluded from sync via the exclusion list in the sync configuration.
+
+## Out of Scope
+
+- Baseline file generation or initialization — repositories are responsible for committing their own baseline files.
+- Main-branch metrics publishing workflows — these are repository-specific and stay in each repository.
+- CRAP analysis tool development or bug fixes — the workflow consumes it as an external dependency.
+- Customization of CRAP thresholds beyond the existing input parameters.

--- a/specs/001-crapload-workflow/tasks.md
+++ b/specs/001-crapload-workflow/tasks.md
@@ -1,0 +1,154 @@
+# Tasks: Centralize CRAP Load Analysis Workflow
+
+**Input**: Design documents from `/specs/001-crapload-workflow/`
+**Prerequisites**: plan.md (required), spec.md (required for user stories), research.md, data-model.md
+
+## Format: `[ID] [P?] [Story] Description`
+
+- **[P]**: Can run in parallel (different files, no dependencies)
+- **[Story]**: Which user story this task belongs to (e.g., US1, US2, US3)
+- Include exact file paths in descriptions
+
+## Phase 1: Setup
+
+**Purpose**: No project initialization needed — org-infra already exists. This phase reads lint configuration per constitution requirements.
+
+- [x] T001 Read lint configuration files (.yamllint.yml, .mega-linter.yml) to understand enforced rules before making changes
+
+---
+
+## Phase 2: Foundational (Reusable Workflow Migration)
+
+**Purpose**: Move the reusable workflow from complyctl to org-infra. This MUST be complete before any consumer workflow or sync config can reference it.
+
+**CRITICAL**: No user story work can begin until this phase is complete.
+
+- [x] T002 Copy reusable_crapload_analysis.yml from complyctl (local path: /home/maburgha/GIT/ProdSec/complyctl/.github/workflows/reusable_crapload_analysis.yml) to .github/workflows/reusable_crapload_analysis.yml
+- [x] T003 Normalize indentation from 4-space to 2-space throughout .github/workflows/reusable_crapload_analysis.yml
+- [x] T004 Add SPDX license header comment and workflow purpose description header to .github/workflows/reusable_crapload_analysis.yml (verify header comment block exists per constitution YAML Formatting standards)
+- [x] T005 Validate .github/workflows/reusable_crapload_analysis.yml passes yamllint with .yamllint.yml configuration
+
+**Checkpoint**: Reusable workflow is in org-infra, properly formatted, and passes linting.
+
+---
+
+## Phase 3: User Story 1 - Adopt CRAP Load Analysis in a Go Repository (Priority: P1)
+
+**Goal**: Enable any Go repository to adopt CRAP load analysis by adding a consumer workflow that references the org-infra reusable workflow.
+
+**Independent Test**: Create the consumer workflow, verify it references the org-infra reusable workflow correctly, and passes yamllint.
+
+### Implementation for User Story 1
+
+- [x] T006 [US1] Create consumer workflow template at .github/workflows/ci_crapload.yml that calls complytime/org-infra/.github/workflows/reusable_crapload_analysis.yml@main on pull_request targeting main, with contents:read and pull-requests:write permissions
+- [x] T007 [US1] Validate .github/workflows/ci_crapload.yml passes yamllint with .yamllint.yml configuration
+
+**Checkpoint**: Consumer workflow template exists and can be used by any Go repository to invoke CRAP load analysis.
+
+---
+
+## Phase 4: User Story 2 - Detect CRAP Score Regressions (Priority: P1)
+
+**Goal**: The reusable workflow detects regressions and fails the check when CRAP scores increase or new functions exceed the threshold.
+
+**Independent Test**: This functionality is already implemented in the reusable workflow logic (baseline comparison, threshold enforcement). Verify the workflow outputs include status, regressions-count, and improvements-count.
+
+### Implementation for User Story 2
+
+- [x] T008 [US2] Verify the reusable workflow in .github/workflows/reusable_crapload_analysis.yml correctly outputs status (pass/fail), crapload-count, gaze-crapload-count, regressions-count, and improvements-count
+- [x] T009 [US2] Verify the Enforce threshold step in .github/workflows/reusable_crapload_analysis.yml exits with code 1 on status=fail
+
+**Checkpoint**: Regression detection logic is verified in the migrated workflow. No code changes expected — this is validation of existing functionality after migration.
+
+---
+
+## Phase 5: User Story 3 - Sync Consumer Workflow to Go Repositories (Priority: P2)
+
+**Goal**: Add the consumer workflow to the org-infra sync configuration so it is automatically distributed to Go repositories across the organization.
+
+**Independent Test**: Run `make sync-dry-run` or `python3 scripts/sync-org-repositories.py --org complytime --dry-run` and verify ci_crapload.yml is listed for Go repos and excluded from non-Go repos.
+
+### Implementation for User Story 3
+
+- [x] T010 [US3] Add ci_crapload.yml sync entry to sync-config.yml with source .github/workflows/ci_crapload.yml, destination .github/workflows/ci_crapload.yml, and exclude_repos list for non-Go repositories (complyscribe, complytime-demos, complytime-policies, vagrant-boxes, community)
+
+**Checkpoint**: Sync configuration is updated. Running a dry-run sync confirms the consumer workflow targets only Go repositories.
+
+---
+
+## Phase 6: Polish & Cross-Cutting Concerns
+
+**Purpose**: Documentation and final validation.
+
+- [x] T011 [P] Update README.md to add ci_crapload.yml and reusable_crapload_analysis.yml to the directory structure table and workflow descriptions
+- [x] T012 Run make lint-yaml to verify all new and modified files pass linting
+- [x] T013 Verify quickstart.md adoption instructions in specs/001-crapload-workflow/quickstart.md match the actual consumer workflow created in T006
+
+---
+
+## Dependencies & Execution Order
+
+### Phase Dependencies
+
+- **Setup (Phase 1)**: No dependencies — read-only lint config review
+- **Foundational (Phase 2)**: Depends on Phase 1 — BLOCKS all user stories
+- **User Story 1 (Phase 3)**: Depends on Phase 2 (reusable workflow must exist)
+- **User Story 2 (Phase 4)**: Depends on Phase 2 (validates migrated workflow)
+- **User Story 3 (Phase 5)**: Depends on Phase 3 (consumer workflow must exist to sync)
+- **Polish (Phase 6)**: Depends on Phases 3 and 5
+
+### User Story Dependencies
+
+- **User Story 1 (P1)**: Depends on Foundational — reusable workflow must be in org-infra
+- **User Story 2 (P1)**: Depends on Foundational — validates the migrated workflow, can run in parallel with US1
+- **User Story 3 (P2)**: Depends on US1 — consumer workflow must exist before adding to sync config
+
+### Parallel Opportunities
+
+- T008 and T009 (US2 validation) can run in parallel with T006-T007 (US1 consumer workflow creation) since they operate on different files
+- T011 (README update) can run in parallel with T012 (lint validation)
+
+---
+
+## Parallel Example: User Stories 1 and 2
+
+```text
+# After Phase 2 (Foundational) completes, these can run in parallel:
+
+# Stream A - User Story 1 (consumer workflow):
+Task T006: Create consumer workflow at .github/workflows/ci_crapload.yml
+Task T007: Validate ci_crapload.yml passes yamllint
+
+# Stream B - User Story 2 (regression detection validation):
+Task T008: Verify workflow outputs in reusable_crapload_analysis.yml
+Task T009: Verify threshold enforcement step
+```
+
+---
+
+## Implementation Strategy
+
+### MVP First (User Stories 1 + 2)
+
+1. Complete Phase 1: Read lint config
+2. Complete Phase 2: Migrate reusable workflow (T002-T005)
+3. Complete Phase 3: Create consumer workflow (T006-T007)
+4. Complete Phase 4: Validate regression detection (T008-T009)
+5. **STOP and VALIDATE**: Consumer workflow works, regression detection verified
+6. Can be merged and used immediately by repositories adding the consumer workflow manually
+
+### Full Delivery (Add Sync)
+
+7. Complete Phase 5: Add sync configuration (T010)
+8. Complete Phase 6: Documentation and final lint check (T011-T013)
+9. **VALIDATE**: Dry-run sync confirms correct targeting
+
+---
+
+## Notes
+
+- [P] tasks = different files, no dependencies
+- [Story] label maps task to specific user story for traceability
+- US2 is primarily validation — the regression detection logic already exists in the source workflow
+- Commit after each phase completion
+- The reusable workflow is copied as-is (with indentation normalization) — no logic changes

--- a/sync-config.yml
+++ b/sync-config.yml
@@ -33,6 +33,15 @@ files_to_sync:
   - source: .github/workflows/ci_security.yml
     destination: .github/workflows/ci_security.yml
 
+  - source: .github/workflows/ci_crapload.yml
+    destination: .github/workflows/ci_crapload.yml
+    exclude_repos:
+      - complyscribe
+      - complytime-demos
+      - complytime-policies
+      - vagrant-boxes
+      - community
+
   # Configuration Files
   - source: .github/dependabot.yml
     destination: .github/dependabot.yml


### PR DESCRIPTION
## Summary                                                                                                                                                 
                                                                                                                                                          
Centralize the CRAP load analysis reusable workflow from complyctl to org-infra so all Go repositories can adopt it via a lightweight consumer workflow

## Related Issues

- https://redhat.atlassian.net/browse/CPLYTM-1345

## Review Hints

This PR was created on top of https://github.com/complytime/org-infra/pull/143 and depends on it to be merged first.

- Migrate reusable_crapload_analysis.yml from complyctl with 2-space indentation normalization and SPDX header
- Create ci_crapload.yml consumer workflow template
- Add ci_crapload.yml to sync-config.yml excluding non-Go repos (complyscribe, complytime-demos, complytime-policies, vagrant-boxes, community)
- Update README.md directory structure with new workflow entries