### PR TITLE
feat: CPLYTM-1383 - Add reusable github branch protection workflow

### DIFF
--- a/.github/workflows/reusable_compliance.yml
+++ b/.github/workflows/reusable_compliance.yml
@@ -1,111 +1,162 @@
 ---
-name: Reusable Compliance Evaluation
+name: Reusable GitHub Branch Protection Scan
 
+# --------------------------------------------------------------------------
+# This workflow builds complyctl from source and uses it with a local
+# mock-oci-registry to scan GitHub branch protection rules via the
+# ampel-branch-protection policy.
+# --------------------------------------------------------------------------
 on:
   workflow_call:
     inputs:
-      policy_url:
-        description: 'URL to the policy to use for compliance'
+      complytime_config_path:
+        description: 'Relative path of the complytime.yaml file in the calling repository'
         required: true
         type: string
-      push_attestation:
-        description: 'Push the attestation to the repository'
+      policy_id:
+        description: 'Policy ID to use for complyctl generate and scan commands'
         required: false
-        type: boolean
-        default: false
+        type: string
+        default: 'ampel-bp'
     secrets:
       source_token:
-        description: 'GitHub token to use for uploading artifacts and attestations'
+        description: 'GitHub token used by snappy to read branch protection rules via the GitHub API'
         required: true
 
-# {} also works, but making it explicit which permissions are needed is betters.
-# Now I can more easily track where and how they are used in the workflow.
 permissions:
   id-token: none
   attestations: none
   contents: none
 
 jobs:
-  evaluate-repository-compliance:
-    name: Compliance Evaluation
+  github-branch-protection-scan:
+    name: GitHub Branch Protection Scan
     runs-on: ubuntu-latest
 
     permissions:
-      id-token: write
-      attestations: write
       contents: read
 
     steps:
-      - name: Checkout Repository
+      - name: Checkout complyctl source
         uses: actions/checkout@de0fac2e4500dabe0009e67214ff5f5447ce83dd # v6.0.2
         with:
+          repository: complytime/complyctl
           persist-credentials: false
 
-      - name: Setup snappy for API Calls
-        uses: carabiner-dev/actions/install/snappy@e4fb157a59e9b54ffc40979a0b5ff374809a2bc1
+      - name: Checkout calling repository
+        uses: actions/checkout@de0fac2e4500dabe0009e67214ff5f5447ce83dd # v6.0.2
+        with:
+          path: _caller
+          ref: ${{ github.sha }}
+          persist-credentials: false
 
-      - name: Setup bnd to Create Attestations Bundles
-        uses: carabiner-dev/actions/install/bnd@e4fb157a59e9b54ffc40979a0b5ff374809a2bc1
+      - name: Setup Go
+        uses: actions/setup-go@4b73464bb391d4059bd26b0524d20df3927bd417 # v6.3.0
+        with:
+          go-version-file: './go.mod'
 
-      - name: Generate Branch Protection Rules Attestation
-        id: attestation
+      - name: Build
+        run: |
+          make build
+
+      - name: Install snappy
+        uses: carabiner-dev/actions/install/snappy@1745afdfe30ebe15d2ffafbe659376241a37dbb1
+
+      - name: Install ampel
+        uses: carabiner-dev/actions/install/ampel@1745afdfe30ebe15d2ffafbe659376241a37dbb1
+
+      - name: Register ampel-plugin provider with complyctl
+        run: |
+          mkdir -p ~/.complytime/providers
+          cp bin/ampel-plugin ~/.complytime/providers/complyctl-provider-ampel
+
+      - name: Start mock-oci-registry in background
+        run: |
+          ./bin/mock-oci-registry &
+          echo "MOCK_REGISTRY_PID=$!" >> "$GITHUB_ENV"
+
+          # Wait up to 15 seconds for the registry to be ready
+          for _ in $(seq 1 30); do
+            if curl -sf http://localhost:8765/v2/ >/dev/null 2>&1; then
+              echo "Mock registry is ready."
+              break
+            fi
+            sleep 0.5
+          done
+
+          if ! curl -sf http://localhost:8765/v2/ >/dev/null 2>&1; then
+            echo "ERROR: mock-oci-registry did not start in time."
+            exit 1
+          fi
+
+      - name: Copy workspace configuration
+        run: cp "_caller/${{ inputs.complytime_config_path }}" complytime.yaml
+
+      - name: Copy ampel policy files
+        run: |
+          mkdir -p .complytime/ampel/granular-policies
+          cp cmd/ampel-plugin/convert/testdata/policies/* .complytime/ampel/granular-policies/
+
+      - name: Fetch ampel-branch-protection policy from mock registry
+        run: ./bin/complyctl get
+
+      - name: Generate policy graph
+        run: ./bin/complyctl generate --policy-id ${{ inputs.policy_id }}
+
+      - name: Scan branch protection rules
         env:
           GITHUB_TOKEN: "${{ secrets.source_token }}"
+        run: ./bin/complyctl scan --policy-id ${{ inputs.policy_id }} --format pretty
+
+      - name: Publish report to GitHub Step Summary
         run: |
-          mkdir -p attestations
+          for f in .complytime/ampel/results/*-ampel.intoto.json; do
+            [ -f "$f" ] || continue
+            label=$(basename "$f" -ampel.intoto.json)
 
-          # Use snappy to make the API call to the branch rules endpoint
-          # and save the result to a file with the option to hide sensitive data.
-          snappy snap builtin:github/branch-rules.yaml \
-          -v BRANCH="${{ github.ref_name }}" \
-          -v REPO="${{ github.event.repository.name }}" \
-          -v ORG="${{github.repository_owner}}" \
-          --attest > attestations/branch_protection_rules.intoto.json
+            jq -r --arg label "$label" '
+              .predicate |
+              "## Branch Protection Scan: \($label)",
+              "",
+              ("**Overall Status:** " + (if .status == "PASS" then "✅ PASS" else "❌ FAIL" end)),
+              "",
+              "| Policy | Description | Status |",
+              "|--------|-------------|--------|",
+              (.results[] | "| \(.policy.id) | \(.meta.description) | \(if .status == "PASS" then "✅ PASS" else "❌ FAIL" end) |"),
+              "",
+              (.results[] |
+                "### \(.policy.id) — \(.meta.description)",
+                "",
+                (.eval_results[] |
+                  if .status == "PASS" then
+                    "- ✅ **Tenet \(.id):** \(.assessment.message)"
+                  else
+                    "- ❌ **Tenet \(.id):** \(.error.message)",
+                    (if (.error.guidance? // "") != "" then "  > **Guidance:** \(.error.guidance)" else empty end)
+                  end
+                ),
+                ""
+              )
+            ' "$f" >> "$GITHUB_STEP_SUMMARY"
+          done
 
-          # Extract SHA256 digest
-          SHA256=$(jq -r '.subject[0].digest.sha256' attestations/branch_protection_rules.intoto.json)
-          echo "sha256=$SHA256" >> "$GITHUB_OUTPUT"
-
-          # Create a bundle from the intoto.json file
-          bnd statement attestations/branch_protection_rules.intoto.json --out attestations/branch_protection_rules.bundle.json
-
-      - name: Upload Branch Protection Rules Results
+      - name: Upload scan results
         uses: actions/upload-artifact@bbbca2ddaa5d8feaa63e36b76fdaad77386f024f # v7.0.0
         with:
-          name: branch-protection-rules.intoto.json
-          path: attestations/branch_protection_rules.intoto.json
+          name: report-policies-ampel-branch-protection.md
+          path: report-*.md
+          if-no-files-found: warn
 
-      - name: Push Branch Protection Rules Attestation Bundle
-        if: "${{ inputs.push_attestation }}"
-        env:
-          GITHUB_TOKEN: "${{ secrets.source_token }}"
-        run: |
-          bnd push github "${{github.repository}}" attestations/branch_protection_rules.bundle.json
-
-      - name: Pack Attestations
-        run: |
-          # Pack the attestations into a single file.
-          # It is using a directory as input but it could also be multiple explicit files.
-          bnd pack attestations/ > attestations_package.jsonl
-
-      - name: Upload Attestation Pack for Analysis
-        uses: actions/upload-artifact@bbbca2ddaa5d8feaa63e36b76fdaad77386f024f # v7.0.0
-        with:
-          name: attestations_package.jsonl
-          path: attestations_package.jsonl
-
-      - name: Evaluate Compliance
-        id: compliance
-        uses: carabiner-dev/actions/ampel/verify@e4fb157a59e9b54ffc40979a0b5ff374809a2bc1
-        with:
-          subject: "sha256:${{ steps.attestation.outputs.sha256 }}"
-          collector: "jsonl:attestations_package.jsonl"
-          policy: "git+${{ inputs.policy_url }}"
-          attest: true
-          fail: false
-
-      - name: Upload Compliance Results
+      - name: Upload Ample Results
         uses: actions/upload-artifact@bbbca2ddaa5d8feaa63e36b76fdaad77386f024f # v7.0.0
         with:
           name: ampel.intoto.json
-          path: ampel.intoto.json
+          path: .complytime/ampel/results/*-ampel.intoto.json
+          if-no-files-found: warn
+
+      - name: Upload Snappy Results
+        uses: actions/upload-artifact@bbbca2ddaa5d8feaa63e36b76fdaad77386f024f # v7.0.0
+        with:
+          name: snappy.intoto.json
+          path: .complytime/ampel/results/*-snappy.intoto.json
+          if-no-files-found: warn

--- a/specs/003-github-branch-protection-workflow/quickstart.md
+++ b/specs/003-github-branch-protection-workflow/quickstart.md
@@ -1,0 +1,163 @@
+# GitHub Branch Protection Scan Quickstart
+
+This guide covers implementing GitHub branch protection scanning for repository maintainers adopting the reusable workflow.
+
+## Prerequisites
+
+Before setting up the workflow, ensure you have:
+
+1. **GitHub Token**: A token with permission to read branch protection rules for the target repository (typically `secrets.GITHUB_TOKEN` for the same repository, or a PAT for cross-repository scanning)
+2. **complytime.yaml**: A workspace configuration file defining the policy and target repository
+
+## Setup Steps
+
+### Step 1: Create the complytime.yaml Configuration
+
+Add a `complytime.yaml` file to your repository that points to the `ampel-branch-protection` policy and defines the target repository to scan:
+
+```yaml
+policies:
+  - url: http://localhost:8765/policies/ampel-branch-protection
+    id: ampel-bp
+targets:
+  - id: my-target
+    policies:
+      - ampel-bp
+    variables:
+      url: https://github.com/<org>/<repo>
+      branches: main
+      specs: builtin:github/branch-rules.yaml
+```
+
+Replace `<org>/<repo>` with the GitHub organization and repository name to scan. The `branches` variable defaults to `main` if omitted.
+
+> **Note:** The policy URL `http://localhost:8765/policies/ampel-branch-protection` always points to the mock-oci-registry started by the reusable workflow. Do not change this URL.
+
+### Step 2: Add Consumer Workflow
+
+Create `.github/workflows/github-bp-scan.yml` in your repository:
+
+```yaml
+name: GitHub Branch Protection Scan
+
+on:
+  push:
+    branches:
+      - main
+  pull_request:
+
+permissions:
+  contents: none
+
+jobs:
+  branch-protection-scan:
+    name: Branch Protection Scan
+    permissions:
+      contents: read
+    uses: complytime/org-infra/.github/workflows/reusable_compliance.yml@main
+    with:
+      complytime_config_path: complytime.yaml
+      # policy_id: ampel-bp  # optional, defaults to 'ampel-bp'
+    secrets:
+      source_token: ${{ secrets.GITHUB_TOKEN }}
+```
+
+Adjust `complytime_config_path` to the path of your `complytime.yaml` relative to the repository root.
+
+## Configuration Options
+
+### Required Inputs
+
+| Input | Description |
+|-------|-------------|
+| `complytime_config_path` | Relative path to your `complytime.yaml` file in the repository (e.g., `complytime.yaml` or `config/complytime.yaml`) |
+
+### Optional Inputs
+
+| Input | Default | Description |
+|-------|---------|-------------|
+| `policy_id` | `ampel-bp` | Policy ID passed to `complyctl generate` and `complyctl scan`; must match the `id` field in your `complytime.yaml` |
+
+### Required Secrets
+
+| Secret | Description |
+|--------|-------------|
+| `source_token` | GitHub token for snappy to read branch protection rules via the GitHub API |
+
+### complytime.yaml Variables
+
+| Variable | Required | Description |
+|----------|----------|-------------|
+| `url` | Yes | Full GitHub repository URL to scan (e.g., `https://github.com/myorg/myrepo`) |
+| `branches` | No | Comma-separated list of branch names to scan (default: `main`) |
+| `specs` | Yes | Spec file to use — use `builtin:github/branch-rules.yaml` for standard GitHub branch rules |
+
+## Scanning Multiple Repositories
+
+To scan multiple repositories or branches, add additional targets to your `complytime.yaml`. The `branches` variable accepts a comma-separated list:
+
+```yaml
+policies:
+  - url: http://localhost:8765/policies/ampel-branch-protection
+    id: ampel-bp
+targets:
+  - id: repo-a
+    policies:
+      - ampel-bp
+    variables:
+      url: https://github.com/myorg/repo-a
+      branches: main
+      specs: builtin:github/branch-rules.yaml
+  - id: repo-b
+    policies:
+      - ampel-bp
+    variables:
+      url: https://github.com/myorg/repo-b
+      branches: main,release
+      specs: builtin:github/branch-rules.yaml
+```
+
+## Viewing Results
+
+After the workflow runs:
+
+1. **Job Summary**: Open the workflow run in the GitHub Actions UI. The compliance report is published directly to the job summary — no artifact download required.
+2. **Artifacts**: Download the following artifacts from the workflow run:
+   - `report-policies-ampel-branch-protection.md` — Full Markdown compliance report
+   - `ampel.intoto.json` — ampel in-toto attestation with policy evaluation results
+   - `snappy.intoto.json` — snappy in-toto attestation with raw branch protection data
+
+## Branch Protection Requirements
+
+The `ampel-branch-protection` policy checks the following requirements:
+
+| ID | Tenet | Description | Pass Condition | Guidance on Failure |
+|----|-------|-------------|----------------|---------------------|
+| BP-1.01 | 01 | Require pull/merge requests — direct pushes are disabled | A `update` ruleset rule exists (GitHub) or `push_access_levels` is empty (GitLab) | GitHub: create a branch ruleset and enable **Restrict updates**. GitLab: remove all `push_access_levels`. |
+| BP-2.01 | 01 | Minimum one approval required before merge | `required_approving_review_count >= 1` (GitHub) or `approvals_before_merge >= 1` (GitLab) | GitHub: set `required_approving_review_count >= 1`. GitLab: set `approvals_before_merge >= 1`. |
+| BP-2.01 | 02 | Stale approvals dismissed on new commits | `dismiss_stale_reviews_on_push == true` (GitHub) or `reset_approvals_on_push == true` (GitLab) | GitHub: enable **Dismiss stale pull request approvals when new commits are pushed**. GitLab: enable **Remove all approvals when commits are added to the source branch**. |
+| BP-2.01 | 03 | Author/committer cannot approve their own changes | `require_last_push_approval == true` (GitHub) or `merge_requests_disable_committers_approval == true` (GitLab) | GitHub: enable **Require approval of the most recent reviewable push**. GitLab: enable **Prevent approval by author and committers**. |
+| BP-3.01 | 01 | Force pushes are blocked on protected branches | A `non_fast_forward` ruleset rule exists (GitHub) or `allow_force_push == false` (GitLab) | GitHub: create a branch ruleset and enable **Block force pushes**. GitLab: set `allow_force_push` to `false`. |
+| BP-4.01 | 01 | Admins cannot bypass branch protection | A `non_fast_forward` ruleset rule exists (GitHub) or `push_access_levels` is empty / set to access level 0 (GitLab) | GitHub: enable **Block force pushes** in branch ruleset. GitLab: set `push_access_levels` to empty or access level 0 (No one). |
+| BP-5.01 | 01 | Code owner review required when CODEOWNERS file exists | `require_code_owner_review == true` (GitHub) or `code_owner_approval_required == true` (GitLab) | GitHub: enable **Require review from Code Owners** in branch ruleset. GitLab: set `code_owner_approval_required` to `true`. |
+
+## Troubleshooting
+
+### `cp: cannot stat '_caller/...' : No such file or directory`
+
+Ensure your `complytime.yaml` file is committed to the branch that triggered the workflow. The reusable workflow checks out the caller repository at the exact triggering commit SHA.
+
+### All requirements show "required attestations missing to verify subject"
+
+This indicates snappy could not collect branch protection data. Verify:
+- The `source_token` secret has permission to read the target repository's branch protection rules
+- The `url` in `complytime.yaml` points to a valid GitHub repository
+- The repository has branch protection rules configured on the default branch
+
+### Workflow fails at "Fetch ampel-branch-protection policy from mock registry"
+
+The mock-oci-registry failed to start in time. This is a transient runner issue — re-run the workflow.
+
+## Infrastructure Notes
+
+The reusable workflow resides in the org-infra repository at `.github/workflows/reusable_compliance.yml`. It builds `complyctl` from source at `complytime/complyctl` on every run to ensure it always uses the latest version. Changes to the workflow should follow the repository's contribution guidelines and be tested before merging.

--- a/specs/003-github-branch-protection-workflow/spec.md
+++ b/specs/003-github-branch-protection-workflow/spec.md
@@ -1,0 +1,105 @@
+# Feature Specification: Reusable GitHub Branch Protection Scan Workflow
+
+## Document Overview
+
+This specification details a centralized, reusable workflow for scanning GitHub branch protection rules using [complyctl](https://github.com/complytime/complyctl) and the `ampel-branch-protection` policy. The workflow builds `complyctl` from source, runs it against a target repository's branch protection configuration, and publishes results as a GitHub Actions job summary and downloadable artifacts.
+
+**Key Metadata:**
+- Workflow File: `.github/workflows/reusable_compliance.yml`
+- Date: 2026-03-26
+- Current Status: Active
+
+## Core User Scenarios
+
+### Priority 1: Branch Protection Rule Scanning
+
+Repository maintainers can enable branch protection scanning by creating a consumer workflow that references the org-infra reusable workflow. The system automatically scans branch protection rules using the `ampel-branch-protection` policy and surfaces a compliance report in the GitHub Actions job summary.
+
+**Test Coverage:** Verifies that `complyctl get → generate → scan` executes successfully, the report is published to `$GITHUB_STEP_SUMMARY`, and result artifacts are uploaded.
+
+### Priority 2: User-Supplied Workspace Configuration
+
+The caller provides a `complytime.yaml` workspace configuration file checked into their repository. This file defines the policy URL, policy ID, and scan targets (repository URL, branch, spec). The reusable workflow checks out the caller's repository at the exact triggering commit SHA and copies the file before running `complyctl`.
+
+**Test Coverage:** Validates that the workspace config is correctly copied from the caller's checkout, and that scans respect the targets defined by the caller.
+
+### Priority 3: Attestation Artifact Collection
+
+The workflow uploads three artifact types: the human-readable Markdown scan report, snappy in-toto attestations, and ampel in-toto attestations. These support downstream audit and compliance workflows.
+
+**Test Coverage:** Ensures artifacts are uploaded with predictable names and the `if-no-files-found: warn` flag is set so missing artifacts produce warnings rather than failures.
+
+## Edge Cases Addressed
+
+- **PR branch not yet merged**: The caller checkout uses `ref: ${{ github.sha }}` to check out the exact triggering commit, ensuring files added on a PR branch are available even before merge.
+- **mock-oci-registry startup latency**: The workflow polls `http://localhost:8765/v2/` for up to 15 seconds (30 × 0.5 s) before failing, preventing race conditions.
+- **Policy evaluation failures**: Non-zero exit from `ampel verify` (policy checks failed) is treated as a compliance finding, not a tool error; the scan step does not exit non-zero on policy failures.
+- **Unknown artifact filenames**: Artifact paths use glob patterns (`report-*.md`, `*-snappy.intoto.json`, `*-ampel.intoto.json`) because filenames are derived at runtime from the target URL, branch, and spec name.
+
+## Functional Requirements Summary
+
+The workflow must:
+
+1. **Build complyctl from source**: Check out `complytime/complyctl` and run `make build` to produce all binaries (`complyctl`, `ampel-plugin`, `mock-oci-registry`).
+2. **Register the ampel provider**: Copy `bin/ampel-plugin` to `~/.complytime/providers/complyctl-provider-ampel`.
+3. **Serve the policy via mock-oci-registry**: Start `./bin/mock-oci-registry` in the background, wait for it to be ready, then proceed.
+4. **Accept caller-supplied workspace config**: Accept a `complytime_config_path` input (relative path within the caller repo) and copy it to `complytime.yaml` at the complyctl workspace root.
+5. **Copy granular policy files**: Copy `cmd/ampel-plugin/convert/testdata/policies/*` to `.complytime/ampel/granular-policies/` before running `generate`.
+6. **Run the complyctl pipeline**: Execute `complyctl get`, `complyctl generate --policy-id ampel-bp`, and `complyctl scan --policy-id ampel-bp --format pretty`.
+7. **Pass GITHUB_TOKEN to snappy**: Expose the `source_token` secret as `GITHUB_TOKEN` in the scan step environment so snappy can call the GitHub API.
+8. **Publish the report**: Append `report-*.md` contents to `$GITHUB_STEP_SUMMARY`.
+9. **Upload artifacts**: Upload the scan report, snappy attestations, and ampel attestations as named artifacts.
+10. **Maintain security**: Use least-privilege permissions; the job requires only `contents: read`.
+11. **Use pinned actions**: Reference all GitHub Actions by commit SHA for supply chain security.
+
+## Inputs and Secrets
+
+### Required Inputs
+
+| Name | Type | Description |
+|------|------|-------------|
+| `complytime_config_path` | `string` | Relative path of the `complytime.yaml` file in the calling repository (e.g., `config/complytime.yaml`) |
+
+### Optional Inputs
+
+| Name | Type | Default | Description |
+|------|------|---------|-------------|
+| `policy_id` | `string` | `ampel-bp` | Policy ID passed to `complyctl generate` and `complyctl scan` via `--policy-id`; must match the `id` defined in `complytime.yaml` |
+
+### Required Secrets
+
+| Name | Description |
+|------|-------------|
+| `source_token` | GitHub token used by snappy to read branch protection rules via the GitHub API |
+
+## Artifacts Produced
+
+| Artifact Name | Content |
+|---------------|---------|
+| `report-policies-ampel-branch-protection.md` | Human-readable Markdown compliance report |
+| `ampel.intoto.json` | ampel in-toto attestation(s) with policy evaluation results |
+| `snappy.intoto.json` | snappy in-toto attestation(s) with raw branch protection data |
+
+## Success Metrics
+
+- Any repository can enable branch protection scanning with a single consumer workflow file and a `complytime.yaml` config.
+- The compliance report is visible directly in the GitHub Actions job summary without downloading artifacts.
+- Scan results clearly indicate which branch protection requirements pass or fail.
+- The workflow runs without requiring any pre-installed tools beyond what GitHub-hosted runners provide.
+
+## Scope Boundaries
+
+**Included:**
+- Building complyctl and all plugins from source
+- Serving the `ampel-branch-protection` policy via the embedded mock-oci-registry
+- Installing `snappy` and `ampel` CLI tools
+- Scanning branch protection rules for targets defined in the caller's `complytime.yaml`
+- Uploading scan reports and in-toto attestations as artifacts
+- Publishing the report to the GitHub Actions job summary
+
+**Excluded:**
+- Pushing attestations to the GitHub attestation store (see `reusable_compliance.yml` for that pattern)
+- Scanning GitLab repositories (GitHub only via this workflow)
+- Generating the `complytime.yaml` workspace config (responsibility of the caller)
+- Posting scan results as pull request comments (callers can add this step to their own workflow)
+- Organization-level branch protection configuration management


### PR DESCRIPTION
## Summary

Add reusable github branch protection workflow. It will scan github branch protection rules using complyctl with ampel plugin and post scan result to the comment section.

## Related Issues

- Closes https://redhat.atlassian.net/browse/CPLYTM-1383

## Review Hints

- Add reusable github branch protection workflow
- Specs docs.

- Call `.github/workflows/reusable_github_bp.yml` in other repo and check the workflow result , example https://github.com/AlexXuan233/test-repo/pull/1 

## How to test

Check `specs/003-github-branch-protection-workflow/quickstart.md`
