### PR TITLE
fix(crapload): exclude vendored dependencies in sub-directories

### DIFF
--- a/.github/workflows/reusable_crapload_analysis.yml
+++ b/.github/workflows/reusable_crapload_analysis.yml
@@ -77,14 +77,14 @@ jobs:
         id: detect-changes
         if: github.event_name == 'pull_request'
         run: |
-          CHANGED_FILES=$(git diff --name-only "${{ github.event.pull_request.base.sha }}..HEAD" -- '*.go' ':!vendor' || true)
+          CHANGED_FILES=$(git diff --name-only "${{ github.event.pull_request.base.sha }}..HEAD" -- '*.go' ':!vendor' ':!*/vendor' || true)
           if [ -z "$CHANGED_FILES" ]; then
             echo "has_changes=false" >> "$GITHUB_OUTPUT"
             echo "packages=" >> "$GITHUB_OUTPUT"
             echo "No Go files changed in this PR."
             exit 0
           fi
-          PACKAGES=$(echo "$CHANGED_FILES" | xargs -I{} dirname {} | grep -v '^vendor' | sort -u | sed 's|^|./|' | paste -sd ' ')
+          PACKAGES=$(echo "$CHANGED_FILES" | xargs -I{} dirname {} | grep -v '/vendor/' | grep -v '^vendor' | sort -u | sed 's|^|./|' | paste -sd ' ')
           echo "has_changes=true" >> "$GITHUB_OUTPUT"
           echo "packages=$PACKAGES" >> "$GITHUB_OUTPUT"
           echo "Changed packages: $PACKAGES"


### PR DESCRIPTION
## Summary

The vendor exclusion in the "Detect changed packages" step only matched the top-level vendor/ directory.
Repos with sub-module vendor directories (e.g. cmd/openscap-plugin/vendor/) were not excluded, causing false failures when Dependabot bumped dependencies in those sub-modules.

Add `':!*/vendor'` git pathspec and `'grep -v /vendor/'` to exclude vendor directories at any depth.

## Related Issues

- Fixes: complytime/complyctl#446

## Review Hints

It is more about increasing the filter criteria.
