### PR TITLE
chore: update ampel granular policy BP-02

### DIFF
--- a/compliance/ampel/policies/branch-protection-rules/BP-02.01-minimum-approvals.json
+++ b/compliance/ampel/policies/branch-protection-rules/BP-02.01-minimum-approvals.json
@@ -10,7 +10,7 @@
   "tenets": [
     {
       "id": "01",
-      "code": "(has(predicates[0].data.values) && predicates[0].data.values.exists(rule, rule.type == \"pull_request\" && rule.parameters.required_approving_review_count >= 1)) || (has(predicates[0].data.approvals_before_merge) && predicates[0].data.approvals_before_merge >= 1)",
+      "code": "(has(predicates[0].data.values) && type(predicates[0].data.values) == list && predicates[0].data.values.exists(rule, rule.type == \"pull_request\" && rule.parameters.required_approving_review_count >= 1)) || (has(predicates[0].data.values.approvals_before_merge) && predicates[0].data.values.approvals_before_merge >= 1)",
       "predicates": {
         "types": [
           "http://github.com/carabiner-dev/snappy/specs/github/branch-rules.yaml",
@@ -27,7 +27,7 @@
     },
     {
       "id": "02",
-      "code": "(has(predicates[0].data.values) && predicates[0].data.values.exists(rule, rule.type == \"pull_request\" && rule.parameters.dismiss_stale_reviews_on_push == true)) || (has(predicates[0].data.reset_approvals_on_push) && predicates[0].data.reset_approvals_on_push == true)",
+      "code": "(has(predicates[0].data.values) && type(predicates[0].data.values) == list && predicates[0].data.values.exists(rule, rule.type == \"pull_request\" && rule.parameters.dismiss_stale_reviews_on_push == true)) || (has(predicates[0].data.values.reset_approvals_on_push) && predicates[0].data.values.reset_approvals_on_push == true)",
       "predicates": {
         "types": [
           "http://github.com/carabiner-dev/snappy/specs/github/branch-rules.yaml",
@@ -44,7 +44,7 @@
     },
     {
       "id": "03",
-      "code": "(has(predicates[0].data.values) && predicates[0].data.values.exists(rule, rule.type == \"pull_request\" && rule.parameters.require_last_push_approval == true)) || (has(predicates[0].data.merge_requests_disable_committers_approval) && predicates[0].data.merge_requests_disable_committers_approval == true)",
+      "code": "(has(predicates[0].data.values) && type(predicates[0].data.values) == list && predicates[0].data.values.exists(rule, rule.type == \"pull_request\" && rule.parameters.require_last_push_approval == true)) || (has(predicates[0].data.values.merge_requests_disable_committers_approval) && predicates[0].data.values.merge_requests_disable_committers_approval == true)",
       "predicates": {
         "types": [
           "http://github.com/carabiner-dev/snappy/specs/github/branch-rules.yaml",


### PR DESCRIPTION
## Summary
The PR is for maintaining the latest policies files we used in `complyctl`. The original `BP-02` has some problems in getting data. 

The problem:
 - GitHub branch-rules.yaml returns values as an array of rules
 - GitLab project-approvals.yaml returns values as a flat object  
 - The CEL code was calling .exists() on values without first checking if it's a list
 
With this change, we could get related data for all its tenets.

For GitLab we may need to update `approval_before_merge` (tenet 01) to use another API endpoint in the future. Although it is working now, the `approval_before_merge` in the current API endpoint was deprecated.