### PR TITLE
chore: improve tenets code in BP-02

### DIFF
--- a/compliance/ampel/policies/branch-protection-rules/BP-02.01-minimum-approvals.json
+++ b/compliance/ampel/policies/branch-protection-rules/BP-02.01-minimum-approvals.json
@@ -10,7 +10,7 @@
   "tenets": [
     {
       "id": "01",
-      "code": "(has(predicates[0].data.values) && type(predicates[0].data.values) == list && predicates[0].data.values.exists(rule, rule.type == \"pull_request\" && rule.parameters.required_approving_review_count >= 1)) || (has(predicates[0].data.values.approvals_before_merge) && predicates[0].data.values.approvals_before_merge >= 1)",
+      "code": "(has(predicates[0].data.values) && type(predicates[0].data.values) == list && predicates[0].data.values.exists(rule, rule.type == \"pull_request\" && rule.parameters.required_approving_review_count >= 1)) || (has(predicates[0].data.values) && type(predicates[0].data.values) != list && has(predicates[0].data.values.approvals_before_merge) && predicates[0].data.values.approvals_before_merge >= 1)",
       "predicates": {
         "types": [
           "http://github.com/carabiner-dev/snappy/specs/github/branch-rules.yaml",
@@ -27,7 +27,7 @@
     },
     {
       "id": "02",
-      "code": "(has(predicates[0].data.values) && type(predicates[0].data.values) == list && predicates[0].data.values.exists(rule, rule.type == \"pull_request\" && rule.parameters.dismiss_stale_reviews_on_push == true)) || (has(predicates[0].data.values.reset_approvals_on_push) && predicates[0].data.values.reset_approvals_on_push == true)",
+      "code": "(has(predicates[0].data.values) && type(predicates[0].data.values) == list && predicates[0].data.values.exists(rule, rule.type == \"pull_request\" && rule.parameters.dismiss_stale_reviews_on_push == true)) || (has(predicates[0].data.values) && type(predicates[0].data.values) != list && has(predicates[0].data.values.reset_approvals_on_push) && predicates[0].data.values.reset_approvals_on_push == true)",
       "predicates": {
         "types": [
           "http://github.com/carabiner-dev/snappy/specs/github/branch-rules.yaml",
@@ -44,7 +44,7 @@
     },
     {
       "id": "03",
-      "code": "(has(predicates[0].data.values) && type(predicates[0].data.values) == list && predicates[0].data.values.exists(rule, rule.type == \"pull_request\" && rule.parameters.require_last_push_approval == true)) || (has(predicates[0].data.values.merge_requests_disable_committers_approval) && predicates[0].data.values.merge_requests_disable_committers_approval == true)",
+      "code": "(has(predicates[0].data.values) && type(predicates[0].data.values) == list && predicates[0].data.values.exists(rule, rule.type == \"pull_request\" && rule.parameters.require_last_push_approval == true)) || (has(predicates[0].data.values) && type(predicates[0].data.values) != list && has(predicates[0].data.values.merge_requests_disable_committers_approval) && predicates[0].data.values.merge_requests_disable_committers_approval == true)",
       "predicates": {
         "types": [
           "http://github.com/carabiner-dev/snappy/specs/github/branch-rules.yaml",


### PR DESCRIPTION
## Summary
There is an error in running scan on github repos with speicified settings, error from BP-02 assessment,
Evaluating policy code: CEL evaluation error
Guidance: unsupported index type 'string' in list

This is because that when code checking for GitHub is failed in BP-02, it will continue the checking for GitLab, which should be not and will raise above error, thus here adds more restrictions on code checking for GitLab to avoid this corner case.