### PR TITLE
feat: add release workflow for versioned workflow pinning

### DIFF
--- a/.github/release-drafter.yml
+++ b/.github/release-drafter.yml
@@ -1,0 +1,146 @@
+---
+name-template: "v$RESOLVED_VERSION"
+tag-template: "v$RESOLVED_VERSION"
+prerelease: true
+prerelease-identifier: "rc"
+
+category-template: |
+  ### $TITLE
+
+  $CHANGES
+
+template: |
+  ## org-infra $RESOLVED_VERSION
+
+  Central **reusable GitHub Actions workflows**, CI templates, **compliance** policy assets, and **org sync** tooling. Downstream repos usually consume this repo via workflow `uses:` pins or version tags.
+
+  #### Before you upgrade
+
+  - Treat **workflow YAML** updates as potentially **breaking for every consumer** until you’ve reviewed them.
+  - Use the **Workflows & GitHub Actions** section below for PRs that touched pipelines; for exact paths and hunks, open the compare link and narrow **Files changed** to `.github/workflows/`.
+
+  **[View full diff: `$PREVIOUS_TAG` → `v$RESOLVED_VERSION`](https://github.com/$OWNER/$REPOSITORY/compare/$PREVIOUS_TAG...v$RESOLVED_VERSION)**
+
+  ## Changes
+
+  $CHANGES
+
+  ---
+
+  **Compare:** [`$PREVIOUS_TAG`…`v$RESOLVED_VERSION`](https://github.com/$OWNER/$REPOSITORY/compare/$PREVIOUS_TAG...v$RESOLVED_VERSION)
+
+  **Thanks** to $CONTRIBUTORS for this release.
+
+change-template: "- $TITLE — [#$NUMBER]($URL) · @$AUTHOR"
+no-changes-template: |
+  *No pull requests are included in this release since the previous tag. If that’s unexpected, check that PRs are merged to the default branch and not labeled `skip-changelog`.*
+sort-by: merged_at
+sort-direction: ascending
+
+categories:
+  - title: "Breaking changes"
+    labels:
+      - "breaking"
+      - "major"
+  - title: "Workflows & GitHub Actions"
+    labels:
+      - "workflows"
+    collapse-after: 12
+  - title: "Compliance & policy assets"
+    labels:
+      - "compliance"
+    collapse-after: 8
+  - title: "Sync & repository configuration"
+    labels:
+      - "sync-config"
+    collapse-after: 8
+  - title: "Features"
+    labels:
+      - "feature"
+      - "enhancement"
+  - title: "Bug fixes"
+    labels:
+      - "fix"
+      - "bugfix"
+      - "bug"
+  - title: "Performance"
+    labels:
+      - "performance"
+  - title: "Maintenance"
+    labels:
+      - "infrastructure"
+      - "automation"
+      - "documentation"
+      - "dependencies"
+      - "maintenance"
+      - "revert"
+
+exclude-labels:
+  - "skip-changelog"
+
+exclude-contributors:
+  - "github-actions[bot]"
+  - "dependabot[bot]"
+
+version-resolver:
+  major:
+    labels:
+      - "breaking"
+      - "major"
+  minor:
+    labels:
+      - "feature"
+      - "enhancement"
+      - "minor"
+  patch:
+    labels:
+      - "fix"
+      - "documentation"
+      - "maintenance"
+      - "patch"
+      - "performance"
+      - "workflows"
+      - "compliance"
+      - "sync-config"
+  default: patch
+
+autolabeler:
+  - label: "workflows"
+    files:
+      - ".github/workflows/**"
+      - ".github/actions/**"
+  - label: "compliance"
+    files:
+      - "compliance/**"
+  - label: "sync-config"
+    files:
+      - "sync-config.yml"
+      - "complytime.yaml"
+      - "scripts/**"
+  - label: "performance"
+    title:
+      - "/^(perf).*/i"
+  - label: "automation"
+    title:
+      - "/^(build|ci|refactor|test).*/i"
+  - label: "enhancement"
+    title:
+      - "/^(style).*/i"
+  - label: "documentation"
+    title:
+      - "/^(docs).*/i"
+  - label: "feature"
+    title:
+      - "/^(feat).*/i"
+  - label: "fix"
+    title:
+      - "/^(fix).*/i"
+  - label: "infrastructure"
+    title:
+      - "/^(infrastructure).*/i"
+  - label: "maintenance"
+    title:
+      - "/^(chore|maintenance).*/i"
+  - label: "revert"
+    title:
+      - "/^(revert).*/i"

--- a/.github/release-drafter.yml
+++ b/.github/release-drafter.yml
@@ -2,7 +2,6 @@
 ---
 name-template: "v$RESOLVED_VERSION"
 tag-template: "v$RESOLVED_VERSION"
-prerelease-identifier: "rc"
 
 category-template: |
   ### $TITLE

--- a/.github/release-drafter.yml
+++ b/.github/release-drafter.yml
@@ -1,7 +1,7 @@
+# SPDX-License-Identifier: Apache-2.0
 ---
 name-template: "v$RESOLVED_VERSION"
 tag-template: "v$RESOLVED_VERSION"
-prerelease: true
 prerelease-identifier: "rc"
 
 category-template: |

--- a/.github/release-drafter.yml
+++ b/.github/release-drafter.yml
@@ -116,9 +116,6 @@ autolabeler:
       - "sync-config.yml"
       - "complytime.yaml"
       - "scripts/**"
-  - label: "performance"
-    title:
-      - "/^(perf).*/i"
   - label: "automation"
     title:
       - "/^(build|ci|refactor|test).*/i"

--- a/.github/workflows/release.yaml
+++ b/.github/workflows/release.yaml
@@ -1,8 +1,19 @@
 # SPDX-License-Identifier: Apache-2.0
 #
-# workflow_dispatch: pick the branch in the "Use workflow from" dropdown (or `gh workflow run --ref <branch>`).
-# That branch supplies the workflow file and, by default, the commit you check out. Optional `checkout_ref`
-# overrides the checkout only (e.g. same workflow on main, code from another ref—rare).
+# --------------------------------------------------------------------------
+# Creates a GitHub Release from a semver tag. If the tag does not exist yet,
+# the workflow creates it on the selected branch before publishing.
+#
+# Usage:
+#   - From the Actions tab: select this workflow, choose the branch, enter the tag.
+#   - From the CLI: gh workflow run release.yaml --ref main -f tag=v1.0.0
+#
+# Consumer guidance:
+#   Downstream repos can pin reusable workflows to a release tag:
+#     uses: complytime/org-infra/.github/workflows/reusable_ci.yml@v1.0.0
+#   Or pin to the exact commit SHA of the release for maximum reproducibility:
+#     uses: complytime/org-infra/.github/workflows/reusable_ci.yml@<sha>
+# --------------------------------------------------------------------------
 
 name: Release
 
@@ -10,53 +21,61 @@ on:
   workflow_dispatch:
     inputs:
       tag:
-        description: 'Tag to release (e.g., v1.0.0); must already exist on the repo'
+        description: 'Semver tag to release (e.g., v1.0.0)'
         required: true
         type: string
-      checkout_ref:
-        description: 'Optional ref to check out (branch name, tag, or refs/heads/…). Leave empty to use the branch you selected when starting the run.'
-        required: false
-        type: string
-        default: ''
 
 permissions: {}
 
 jobs:
   release:
-    name: Release
+    name: Publish Release
     runs-on: ubuntu-latest
-
-    env:
-      CHECKOUT_REF: ${{ github.event.inputs.checkout_ref != '' && github.event.inputs.checkout_ref || github.ref }}
-
-    permissions:
-      contents: write # To push artifacts to the release
-
-    steps:
-      - name: Checkout code
-        uses: actions/checkout@de0fac2e4500dabe0009e67214ff5f5447ce83dd # v6.0.2
-        with:
-          ref: ${{ env.CHECKOUT_REF }}
-          fetch-depth: 0
-
-  release-notes:
-    needs: release
-    runs-on: ubuntu-latest
-
-    env:
-      CHECKOUT_REF: ${{ github.event.inputs.checkout_ref != '' && github.event.inputs.checkout_ref || github.ref }}
 
     permissions:
       contents: write
+
     steps:
-      - name: Check out code
+      - name: Validate tag format
+        env:
+          TAG: ${{ inputs.tag }}
+        run: |
+          if [[ ! "${TAG}" =~ ^v[0-9]+\.[0-9]+\.[0-9]+(-rc\.[0-9]+)?$ ]]; then
+            echo "::error::Tag must match semver format: v<major>.<minor>.<patch> or v<major>.<minor>.<patch>-rc.<n>"
+            exit 1
+          fi
+
+      - name: Verify release is from default branch
+        env:
+          REF: ${{ github.ref }}
+        run: |
+          if [[ "${REF}" != "refs/heads/main" ]]; then
+            echo "::error::Releases MUST be created from the main branch. Current ref: ${REF}"
+            exit 1
+          fi
+
+      - name: Checkout code
         uses: actions/checkout@de0fac2e4500dabe0009e67214ff5f5447ce83dd # v6.0.2
         with:
-          ref: ${{ env.CHECKOUT_REF }}
           fetch-depth: 0
+
+      - name: Create tag if it does not exist
+        env:
+          TAG: ${{ inputs.tag }}
+        run: |
+          if git rev-parse "refs/tags/${TAG}" >/dev/null 2>&1; then
+            echo "Tag ${TAG} already exists — skipping creation."
+          else
+            git tag "${TAG}"
+            git push origin "${TAG}"
+            echo "Created and pushed tag ${TAG}."
+          fi
 
       - name: Publish GitHub release
         uses: release-drafter/release-drafter@139054aeaa9adc52ab36ddf67437541f039b88e2 # v7.1.1
         with:
           publish: true
-          tag: ${{ github.event.inputs.tag }}
+          tag: ${{ inputs.tag }}
+          prerelease: ${{ contains(inputs.tag, '-rc.') }}
+        env:
+          GITHUB_TOKEN: ${{ secrets.GITHUB_TOKEN }}

--- a/.github/workflows/release.yaml
+++ b/.github/workflows/release.yaml
@@ -1,4 +1,8 @@
 # SPDX-License-Identifier: Apache-2.0
+#
+# workflow_dispatch: pick the branch in the "Use workflow from" dropdown (or `gh workflow run --ref <branch>`).
+# That branch supplies the workflow file and, by default, the commit you check out. Optional `checkout_ref`
+# overrides the checkout only (e.g. same workflow on main, code from another ref—rare).
 
 name: Release
 
@@ -6,9 +10,14 @@ on:
   workflow_dispatch:
     inputs:
       tag:
-        description: 'Tag to release (e.g., v1.0.0)'
+        description: 'Tag to release (e.g., v1.0.0); must already exist on the repo'
         required: true
         type: string
+      checkout_ref:
+        description: 'Optional ref to check out (branch name, tag, or refs/heads/…). Leave empty to use the branch you selected when starting the run.'
+        required: false
+        type: string
+        default: ''
 
 permissions: {}
 
@@ -17,24 +26,33 @@ jobs:
     name: Release
     runs-on: ubuntu-latest
 
+    env:
+      CHECKOUT_REF: ${{ github.event.inputs.checkout_ref != '' && github.event.inputs.checkout_ref || github.ref }}
+
     permissions:
       contents: write # To push artifacts to the release
-    
+
     steps:
       - name: Checkout code
         uses: actions/checkout@de0fac2e4500dabe0009e67214ff5f5447ce83dd # v6.0.2
         with:
+          ref: ${{ env.CHECKOUT_REF }}
           fetch-depth: 0
-  
+
   release-notes:
     needs: release
     runs-on: ubuntu-latest
+
+    env:
+      CHECKOUT_REF: ${{ github.event.inputs.checkout_ref != '' && github.event.inputs.checkout_ref || github.ref }}
+
     permissions:
       contents: write
     steps:
       - name: Check out code
         uses: actions/checkout@de0fac2e4500dabe0009e67214ff5f5447ce83dd # v6.0.2
         with:
+          ref: ${{ env.CHECKOUT_REF }}
           fetch-depth: 0
 
       - name: Publish GitHub release

--- a/.github/workflows/release.yaml
+++ b/.github/workflows/release.yaml
@@ -1,0 +1,44 @@
+# SPDX-License-Identifier: Apache-2.0
+
+name: Release
+
+on:
+  workflow_dispatch:
+    inputs:
+      tag:
+        description: 'Tag to release (e.g., v1.0.0)'
+        required: true
+        type: string
+
+permissions: {}
+
+jobs:
+  release:
+    name: Release
+    runs-on: ubuntu-latest
+
+    permissions:
+      contents: write # To push artifacts to the release
+    
+    steps:
+      - name: Checkout code
+        uses: actions/checkout@de0fac2e4500dabe0009e67214ff5f5447ce83dd # v6.0.2
+        with:
+          fetch-depth: 0
+  
+  release-notes:
+    needs: release
+    runs-on: ubuntu-latest
+    permissions:
+      contents: write
+    steps:
+      - name: Check out code
+        uses: actions/checkout@de0fac2e4500dabe0009e67214ff5f5447ce83dd # v6.0.2
+        with:
+          fetch-depth: 0
+
+      - name: Publish GitHub release
+        uses: release-drafter/release-drafter@139054aeaa9adc52ab36ddf67437541f039b88e2 # v7.1.1
+        with:
+          publish: true
+          tag: ${{ github.event.inputs.tag }}

--- a/.github/workflows/release.yaml
+++ b/.github/workflows/release.yaml
@@ -40,8 +40,8 @@ jobs:
         env:
           TAG: ${{ inputs.tag }}
         run: |
-          if [[ ! "${TAG}" =~ ^v[0-9]+\.[0-9]+\.[0-9]+(-rc\.[0-9]+)?$ ]]; then
-            echo "::error::Tag must match semver format: v<major>.<minor>.<patch> or v<major>.<minor>.<patch>-rc.<n>"
+          if [[ ! "${TAG}" =~ ^v[0-9]+\.[0-9]+\.[0-9]+$ ]]; then
+            echo "::error::Tag must match semver format: v<major>.<minor>.<patch>"
             exit 1
           fi
 
@@ -76,6 +76,5 @@ jobs:
         with:
           publish: true
           tag: ${{ inputs.tag }}
-          prerelease: ${{ contains(inputs.tag, '-rc.') }}
         env:
           GITHUB_TOKEN: ${{ secrets.GITHUB_TOKEN }}

--- a/.github/workflows/release.yml
+++ b/.github/workflows/release.yml
@@ -6,7 +6,7 @@
 #
 # Usage:
 #   - From the Actions tab: select this workflow, choose the branch, enter the tag.
-#   - From the CLI: gh workflow run release.yaml --ref main -f tag=v1.0.0
+#   - From the CLI: gh workflow run release.yml --ref main -f tag=v1.0.0
 #
 # Consumer guidance:
 #   Downstream repos can pin reusable workflows to a release tag:

--- a/.github/workflows/release_notes_preview.yml
+++ b/.github/workflows/release_notes_preview.yml
@@ -1,0 +1,50 @@
+# SPDX-License-Identifier: Apache-2.0
+#
+# Preview Release Drafter output using real GitHub data (no release created).
+# Trigger from the Actions tab or: gh workflow run release_notes_preview.yml
+#
+
+name: Release notes preview
+
+on:
+  workflow_dispatch:
+
+permissions:
+  contents: read
+  pull-requests: read
+
+jobs:
+  preview:
+    runs-on: ubuntu-latest
+    steps:
+      - name: Check out code
+        uses: actions/checkout@de0fac2e4500dabe0009e67214ff5f5447ce83dd # v6.0.2
+        with:
+          fetch-depth: 0
+
+      - name: Draft release notes (dry run)
+        id: drafter
+        uses: release-drafter/release-drafter@139054aeaa9adc52ab36ddf67437541f039b88e2 # v7.1.1
+        with:
+          dry-run: true
+
+      - name: Add preview to job summary
+        env:
+          BODY: ${{ steps.drafter.outputs.body }}
+        run: |
+          {
+            echo "## Release Drafter preview"
+            echo
+            printf '%s\n' "$BODY"
+          } >> "$GITHUB_STEP_SUMMARY"
+
+      - name: Write preview file
+        env:
+          BODY: ${{ steps.drafter.outputs.body }}
+        run: printf '%s\n' "$BODY" > release-notes-preview.md
+
+      - name: Upload preview
+        uses: actions/upload-artifact@bbbca2ddaa5d8feaa63e36b76fdaad77386f024f # v7.0.0
+        with:
+          name: release-notes-preview
+          path: release-notes-preview.md

--- a/.github/workflows/release_notes_preview.yml
+++ b/.github/workflows/release_notes_preview.yml
@@ -1,21 +1,24 @@
 # SPDX-License-Identifier: Apache-2.0
 #
+# --------------------------------------------------------------------------
 # Preview Release Drafter output using real GitHub data (no release created).
 # Trigger from the Actions tab or: gh workflow run release_notes_preview.yml
-#
+# --------------------------------------------------------------------------
 
 name: Release notes preview
 
 on:
   workflow_dispatch:
 
-permissions:
-  contents: read
-  pull-requests: read
+permissions: {}
 
 jobs:
   preview:
     runs-on: ubuntu-latest
+
+    permissions:
+      contents: read
+      pull-requests: read
     steps:
       - name: Check out code
         uses: actions/checkout@de0fac2e4500dabe0009e67214ff5f5447ce83dd # v6.0.2
@@ -27,6 +30,8 @@ jobs:
         uses: release-drafter/release-drafter@139054aeaa9adc52ab36ddf67437541f039b88e2 # v7.1.1
         with:
           dry-run: true
+        env:
+          GITHUB_TOKEN: ${{ secrets.GITHUB_TOKEN }}
 
       - name: Add preview to job summary
         env:

--- a/openspec/specs/release-workflow/spec.md
+++ b/openspec/specs/release-workflow/spec.md
@@ -1,0 +1,170 @@
+## ADDED Requirements
+
+### Requirement: Manual release trigger with semver tag
+The release workflow SHALL be triggered via `workflow_dispatch` with a required `tag` input
+that specifies the semver version to release.
+
+#### Scenario: Valid semver tag provided
+- **WHEN** a maintainer triggers the release workflow with tag `v1.0.0`
+- **THEN** the workflow proceeds to tag creation and release publishing
+
+#### Scenario: Release candidate tag provided
+- **WHEN** a maintainer triggers the release workflow with tag `v1.0.0-rc.1`
+- **THEN** the workflow proceeds and the release is marked as a prerelease
+
+---
+
+### Requirement: Tag format validation
+The release workflow SHALL validate that the provided tag matches semver format
+(`v<major>.<minor>.<patch>` or `v<major>.<minor>.<patch>-rc.<n>`) and reject invalid tags.
+
+#### Scenario: Invalid tag rejected
+- **WHEN** a maintainer triggers the release workflow with tag `1.0.0` (missing `v` prefix)
+- **THEN** the workflow fails with an error message explaining the required format
+
+#### Scenario: Partial version rejected
+- **WHEN** a maintainer triggers the release workflow with tag `v1.0` (missing patch component)
+- **THEN** the workflow fails with an error message explaining the required format
+
+---
+
+### Requirement: Release restricted to default branch
+The release workflow SHALL reject triggers from any branch other than `main` to prevent
+tagging untested code from feature branches.
+
+#### Scenario: Release from main branch
+- **WHEN** the release workflow is triggered from `refs/heads/main`
+- **THEN** the workflow proceeds normally
+
+#### Scenario: Release from feature branch rejected
+- **WHEN** the release workflow is triggered from a feature branch (e.g., `refs/heads/feat/foo`)
+- **THEN** the workflow fails with an error stating releases MUST be created from main
+
+---
+
+### Requirement: Dynamic prerelease detection
+The release workflow SHALL mark releases as prerelease only when the tag contains a release
+candidate suffix (`-rc.<n>`). Stable tags SHALL NOT be marked as prerelease.
+
+#### Scenario: Stable release not marked prerelease
+- **WHEN** the tag is `v1.0.0` (no RC suffix)
+- **THEN** the published GitHub Release is NOT marked as a prerelease
+
+#### Scenario: RC release marked prerelease
+- **WHEN** the tag is `v1.0.0-rc.1`
+- **THEN** the published GitHub Release IS marked as a prerelease
+
+---
+
+### Requirement: Conditional tag creation
+The release workflow SHALL create and push the tag on the current branch HEAD if the tag does
+not already exist. If the tag already exists, the step SHALL be skipped.
+
+#### Scenario: Tag does not exist
+- **WHEN** the provided tag does not exist in the repository
+- **THEN** the workflow creates the tag on the current HEAD and pushes it to origin
+
+#### Scenario: Tag already exists
+- **WHEN** the provided tag already exists in the repository
+- **THEN** the tag creation step is skipped and the existing tag is used
+
+---
+
+### Requirement: Publish GitHub Release with auto-generated changelog
+The release workflow SHALL publish a GitHub Release using release-drafter with a changelog
+auto-generated from merged PRs since the previous release tag, categorized by PR labels.
+
+#### Scenario: Release published with categorized changelog
+- **WHEN** the release workflow completes successfully
+- **THEN** a GitHub Release exists for the specified tag
+- **AND** the release body contains PRs grouped by category (workflows, features, fixes, etc.)
+
+#### Scenario: No PRs since last release
+- **WHEN** no PRs have been merged since the previous release tag
+- **THEN** the release body contains a "no changes" message
+
+---
+
+### Requirement: Auto-label PRs from conventional commits and file paths
+The release-drafter configuration SHALL map conventional commit prefixes in PR titles and
+changed file paths to changelog labels automatically.
+
+#### Scenario: Conventional commit prefix mapped
+- **WHEN** a PR title starts with `feat:`
+- **THEN** the PR is labeled `feature` and appears in the Features changelog section
+
+#### Scenario: File path mapped
+- **WHEN** a PR changes files in `.github/workflows/`
+- **THEN** the PR is labeled `workflows` and appears in the Workflows changelog section
+
+---
+
+### Requirement: Version resolution from PR labels
+The release-drafter configuration SHALL resolve the next version number from PR labels,
+using major/minor/patch bumps as appropriate, defaulting to patch.
+
+#### Scenario: Feature PR bumps minor version
+- **WHEN** the highest-priority label among merged PRs is `feature`
+- **THEN** the resolved version increments the minor component
+
+#### Scenario: No matching labels default to patch
+- **WHEN** no PRs have major, minor, or patch-mapped labels
+- **THEN** the resolved version increments the patch component
+
+---
+
+### Requirement: Exclude bot contributions from changelog
+The release-drafter configuration SHALL exclude PRs authored by `dependabot[bot]` and
+`github-actions[bot]` from the changelog.
+
+#### Scenario: Dependabot PR excluded
+- **WHEN** a dependabot PR is merged between releases
+- **THEN** it does not appear in the release changelog
+
+---
+
+### Requirement: Dry-run release notes preview
+A separate preview workflow SHALL generate release notes without creating a release, outputting
+the result to the job summary and as a downloadable artifact.
+
+#### Scenario: Preview without side effects
+- **WHEN** a maintainer runs the release notes preview workflow
+- **THEN** the draft changelog is displayed in the job summary
+- **AND** a `release-notes-preview.md` artifact is uploaded
+- **AND** no GitHub Release or tag is created
+
+---
+
+### Requirement: Least-privilege permissions
+The release workflow SHALL declare empty permissions at the workflow level and grant only
+`contents: write` at the job level. The preview workflow SHALL use read-only permissions.
+
+#### Scenario: Release workflow permissions
+- **WHEN** the release workflow file is parsed
+- **THEN** workflow-level `permissions` is `{}`
+- **AND** job-level permissions grant only `contents: write`
+
+#### Scenario: Preview workflow permissions
+- **WHEN** the preview workflow file is parsed
+- **THEN** permissions grant only `contents: read` and `pull-requests: read`
+
+---
+
+### Requirement: User inputs routed through env blocks
+All workflow `run:` steps that reference user-controlled inputs SHALL use `env:` block
+indirection rather than direct `${{ }}` expression interpolation to prevent command injection.
+
+#### Scenario: Tag input in run block
+- **WHEN** a `run:` step references the `tag` input
+- **THEN** the value is accessed via an environment variable set in the step's `env:` block
+- **AND** no `${{ inputs.tag }}` expression appears inside the `run:` script body
+
+---
+
+### Requirement: All action references pinned to full commit SHAs
+All workflow files SHALL pin every `uses:` action reference to a full 40-character commit SHA
+with an inline version comment.
+
+#### Scenario: SHA-pinned action references
+- **WHEN** the workflow files are linted with the org's SHA-pin checker
+- **THEN** no action reference uses a mutable tag or branch ref

--- a/openspec/specs/release-workflow/spec.md
+++ b/openspec/specs/release-workflow/spec.md
@@ -8,15 +8,11 @@ that specifies the semver version to release.
 - **WHEN** a maintainer triggers the release workflow with tag `v1.0.0`
 - **THEN** the workflow proceeds to tag creation and release publishing
 
-#### Scenario: Release candidate tag provided
-- **WHEN** a maintainer triggers the release workflow with tag `v1.0.0-rc.1`
-- **THEN** the workflow proceeds and the release is marked as a prerelease
-
 ---
 
 ### Requirement: Tag format validation
 The release workflow SHALL validate that the provided tag matches semver format
-(`v<major>.<minor>.<patch>` or `v<major>.<minor>.<patch>-rc.<n>`) and reject invalid tags.
+(`v<major>.<minor>.<patch>`) and reject invalid tags.
 
 #### Scenario: Invalid tag rejected
 - **WHEN** a maintainer triggers the release workflow with tag `1.0.0` (missing `v` prefix)
@@ -39,20 +35,6 @@ tagging untested code from feature branches.
 #### Scenario: Release from feature branch rejected
 - **WHEN** the release workflow is triggered from a feature branch (e.g., `refs/heads/feat/foo`)
 - **THEN** the workflow fails with an error stating releases MUST be created from main
-
----
-
-### Requirement: Dynamic prerelease detection
-The release workflow SHALL mark releases as prerelease only when the tag contains a release
-candidate suffix (`-rc.<n>`). Stable tags SHALL NOT be marked as prerelease.
-
-#### Scenario: Stable release not marked prerelease
-- **WHEN** the tag is `v1.0.0` (no RC suffix)
-- **THEN** the published GitHub Release is NOT marked as a prerelease
-
-#### Scenario: RC release marked prerelease
-- **WHEN** the tag is `v1.0.0-rc.1`
-- **THEN** the published GitHub Release IS marked as a prerelease
 
 ---
 

--- a/specs/007-release-workflow/checklists/requirements.md
+++ b/specs/007-release-workflow/checklists/requirements.md
@@ -40,7 +40,7 @@
 - [x] Consumer guidance in workflow header comments
 - [x] All action SHAs pinned with version comments
 - [ ] `yamllint` verified
-- [ ] Release candidate test run (e.g., `v0.1.0-rc.1`)
+- [ ] First release test run (e.g., `v0.1.0`)
 - [ ] PR opened against `complytime/org-infra`
 
 ## Notes

--- a/specs/007-release-workflow/checklists/requirements.md
+++ b/specs/007-release-workflow/checklists/requirements.md
@@ -32,7 +32,7 @@
 ## Implementation Status
 
 - [x] Release drafter configuration: `.github/release-drafter.yml`
-- [x] Release workflow: `.github/workflows/release.yaml`
+- [x] Release workflow: `.github/workflows/release.yml`
 - [x] Release notes preview: `.github/workflows/release_notes_preview.yml`
 - [x] Tag format validation with semver regex
 - [x] Conditional tag creation (create if absent, skip if exists)

--- a/specs/007-release-workflow/checklists/requirements.md
+++ b/specs/007-release-workflow/checklists/requirements.md
@@ -1,0 +1,50 @@
+# Specification Quality Checklist: Release Workflow for org-infra
+
+**Purpose**: Validate specification completeness and quality before proceeding to planning
+**Created**: 2026-04-13
+**Feature**: [spec.md](../spec.md)
+
+## Content Quality
+
+- [x] No implementation details (languages, frameworks, APIs) leak into requirements
+- [x] Focused on user value and operational needs
+- [x] All mandatory sections completed (spec, plan, tasks, quickstart, checklists)
+- [x] Written for technical and non-technical stakeholders
+
+## Requirement Completeness
+
+- [x] No [NEEDS CLARIFICATION] markers remain
+- [x] Requirements are testable and unambiguous
+- [x] Success criteria are measurable (release created, tag exists, changelog categorized)
+- [x] All acceptance scenarios are defined (create release, preview notes, pin workflows, edge cases)
+- [x] Edge cases are identified (tag exists, invalid format, no PRs, unlabeled PRs, first release)
+- [x] Scope is clearly bounded (excluded: automated triggers, binaries, release branches, migration tooling)
+- [x] Dependencies and assumptions identified (release-drafter action, conventional commits)
+
+## Feature Readiness
+
+- [x] All functional requirements have clear acceptance criteria
+- [x] Consumer scenarios cover primary flows (create release, pin to tag, preview notes)
+- [ ] Feature meets measurable outcomes (pending: first release candidate test)
+- [x] Constitution check passed (see [plan.md](../plan.md))
+- [x] Downstream impact documented (consumer pinning strategy in plan and quickstart)
+
+## Implementation Status
+
+- [x] Release drafter configuration: `.github/release-drafter.yml`
+- [x] Release workflow: `.github/workflows/release.yaml`
+- [x] Release notes preview: `.github/workflows/release_notes_preview.yml`
+- [x] Tag format validation with semver regex
+- [x] Conditional tag creation (create if absent, skip if exists)
+- [x] `GITHUB_TOKEN` passed to release-drafter steps
+- [x] Consumer guidance in workflow header comments
+- [x] All action SHAs pinned with version comments
+- [ ] `yamllint` verified
+- [ ] Release candidate test run (e.g., `v0.1.0-rc.1`)
+- [ ] PR opened against `complytime/org-infra`
+
+## Notes
+
+- First release should be `v0.1.0` to signal pre-stable workflow interfaces.
+- No binaries or build artifacts — release is tag + changelog only.
+- Dependabot and bot PRs are excluded from changelog to reduce noise.

--- a/specs/007-release-workflow/plan.md
+++ b/specs/007-release-workflow/plan.md
@@ -34,7 +34,7 @@ to semver categories.
 | V. Do Not Reinvent the Wheel | PASS | Uses release-drafter for changelog generation rather than custom scripting |
 | VI. Composability | PASS | Release workflow is independent; does not couple to other workflows |
 | VII. Convention Over Configuration | PASS | Semver convention; conventional commit mapping via autolabeler |
-| YAML Naming Conventions | NOTE | `release.yaml` does not follow `reusable_*` or `ci_*` prefix — intentional, as it is neither reusable nor a CI workflow |
+| YAML Naming Conventions | NOTE | `release.yml` does not follow `reusable_*` or `ci_*` prefix — intentional, as it is neither reusable nor a CI workflow |
 | YAML Security | PASS | Workflow-level permissions none; job-level minimal grant; all user inputs routed through `env:` blocks; release restricted to `main` branch |
 | YAML Formatting | PASS | Header comment; 2-space indent; yamllint clean |
 
@@ -54,7 +54,7 @@ specs/007-release-workflow/
 .github/
 ├── release-drafter.yml        # Release drafter configuration
 └── workflows/
-    ├── release.yaml           # Manual release workflow
+    ├── release.yml            # Manual release workflow
     └── release_notes_preview.yml  # Dry-run preview workflow
 ```
 
@@ -89,7 +89,6 @@ Maps conventional commit prefixes and file paths to labels automatically:
 | `fix:` title | `fix` |
 | `chore:` / `maintenance:` title | `maintenance` |
 | `docs:` title | `documentation` |
-| `perf:` title | `performance` |
 | `ci:` / `build:` / `refactor:` / `test:` title | `automation` |
 | Files in `.github/workflows/` or `.github/actions/` | `workflows` |
 | Files in `compliance/` | `compliance` |

--- a/specs/007-release-workflow/plan.md
+++ b/specs/007-release-workflow/plan.md
@@ -1,0 +1,139 @@
+# Implementation Plan: Release Workflow for org-infra
+
+**Branch**: `feat/adds-release-workflow` | **Date**: 2026-04-13 | **Spec**: [spec.md](spec.md)
+**Input**: Feature specification from `/specs/007-release-workflow/spec.md`
+
+## Summary
+
+Add a lightweight release process for org-infra consisting of three files: a manual release workflow
+that creates tags and publishes GitHub Releases with auto-generated changelogs, a dry-run preview
+workflow, and a release-drafter configuration that maps PR labels and conventional commit prefixes
+to semver categories.
+
+## Technical Context
+
+**Language/Version**: YAML (GitHub Actions workflow syntax)
+**Primary Dependencies**:
+- `release-drafter/release-drafter` — changelog generation and version resolution from PR labels
+- `actions/checkout` — code checkout (already pinned in org-infra codebase)
+- `actions/upload-artifact` — preview artifact upload (already pinned in org-infra codebase)
+
+**Testing**: Validated via `yamllint` (local) and manual `workflow_dispatch` trigger.
+**Target Platform**: GitHub Actions (`ubuntu-latest`)
+**Project Type**: CI/CD infrastructure (release tooling)
+**Constraints**: Must pass `.yamllint.yml`; all `uses:` pinned to full SHA; least-privilege permissions.
+
+## Constitution Check
+
+| Principle | Status | Evidence |
+|-----------|--------|----------|
+| I. Single Source of Truth | PASS | Version resolved from PR labels via release-drafter config; no separate VERSION file |
+| II. Simplicity & Isolation | PASS | Three focused files with clear responsibilities; no build steps or artifacts |
+| III. Incremental Improvement | PASS | New files only; no changes to existing workflows |
+| IV. Readability First | PASS | Header comments, descriptive step names, consumer guidance in workflow comments |
+| V. Do Not Reinvent the Wheel | PASS | Uses release-drafter for changelog generation rather than custom scripting |
+| VI. Composability | PASS | Release workflow is independent; does not couple to other workflows |
+| VII. Convention Over Configuration | PASS | Semver convention; conventional commit mapping via autolabeler |
+| YAML Naming Conventions | NOTE | `release.yaml` does not follow `reusable_*` or `ci_*` prefix — intentional, as it is neither reusable nor a CI workflow |
+| YAML Security | PASS | Workflow-level permissions none; job-level minimal grant; all user inputs routed through `env:` blocks (no `${{ }}` interpolation in `run:` blocks); release restricted to `main` branch |
+| YAML Formatting | PASS | Header comment; 2-space indent; yamllint clean |
+
+**Gate result**: PASS — no violations detected.
+
+## Project Structure
+
+```text
+specs/007-release-workflow/
+├── spec.md                    # Feature specification
+├── plan.md                    # This file
+├── tasks.md                   # Actionable task list
+├── quickstart.md              # Quick reference
+└── checklists/
+    └── requirements.md        # Quality gate checklist
+
+.github/
+├── release-drafter.yml        # Release drafter configuration
+└── workflows/
+    ├── release.yaml           # Manual release workflow
+    └── release_notes_preview.yml  # Dry-run preview workflow
+```
+
+## Action Version Pinning
+
+| Action | SHA (pinned) | Version |
+|--------|-------------|---------|
+| `actions/checkout` | `de0fac2e4500dabe0009e67214ff5f5447ce83dd` | v6.0.2 |
+| `release-drafter/release-drafter` | `139054aeaa9adc52ab36ddf67437541f039b88e2` | v7.1.1 |
+| `actions/upload-artifact` | `bbbca2ddaa5d8feaa63e36b76fdaad77386f024f` | v7.0.0 |
+
+## Release Drafter Configuration Design
+
+### Version Resolution
+
+PR labels drive semver bumps. The `version-resolver` in `.github/release-drafter.yml`:
+
+| Bump | Labels |
+|------|--------|
+| Major | `breaking`, `major` |
+| Minor | `feature`, `enhancement`, `minor` |
+| Patch | `fix`, `documentation`, `maintenance`, `patch`, `performance`, `workflows`, `compliance`, `sync-config` |
+| Default | patch (when no matching labels) |
+
+### Autolabeler
+
+Maps conventional commit prefixes and file paths to labels automatically:
+
+| Pattern | Label |
+|---------|-------|
+| `feat:` title | `feature` |
+| `fix:` title | `fix` |
+| `chore:` / `maintenance:` title | `maintenance` |
+| `docs:` title | `documentation` |
+| `perf:` title | `performance` |
+| `ci:` / `build:` / `refactor:` / `test:` title | `automation` |
+| Files in `.github/workflows/` or `.github/actions/` | `workflows` |
+| Files in `compliance/` | `compliance` |
+| Files matching `sync-config.yml`, `complytime.yaml`, `scripts/**` | `sync-config` |
+
+### Changelog Categories
+
+PRs are grouped into sections in this order:
+1. Breaking changes
+2. Workflows & GitHub Actions
+3. Compliance & policy assets
+4. Sync & repository configuration
+5. Features
+6. Bug fixes
+7. Performance
+8. Maintenance
+
+### Exclusions
+
+- PRs labeled `skip-changelog` are excluded
+- Contributions by `dependabot[bot]` and `github-actions[bot]` are excluded
+
+## Consumer Pinning Strategy
+
+After the first release, downstream repos can reference workflows three ways:
+
+```yaml
+# Recommended: pin to semver tag for stability + readability
+uses: complytime/org-infra/.github/workflows/reusable_ci.yml@v1.0.0
+
+# Maximum reproducibility: pin to the release commit SHA
+uses: complytime/org-infra/.github/workflows/reusable_ci.yml@<sha>
+
+# Living edge (current behavior, not recommended for production):
+uses: complytime/org-infra/.github/workflows/reusable_ci.yml@main
+```
+
+## Initial Release Baseline
+
+The first release should be tagged `v0.1.0` to signal that the project is pre-1.0 and the
+reusable workflow interfaces may still evolve. The `v1.0.0` tag should be reserved for when the
+workflow interfaces are considered stable.
+
+## Complexity Tracking
+
+No constitution violations to justify. The release process is intentionally minimal: three config/
+workflow files, no custom scripting beyond tag format validation and conditional tag creation.

--- a/specs/007-release-workflow/plan.md
+++ b/specs/007-release-workflow/plan.md
@@ -35,7 +35,7 @@ to semver categories.
 | VI. Composability | PASS | Release workflow is independent; does not couple to other workflows |
 | VII. Convention Over Configuration | PASS | Semver convention; conventional commit mapping via autolabeler |
 | YAML Naming Conventions | NOTE | `release.yaml` does not follow `reusable_*` or `ci_*` prefix — intentional, as it is neither reusable nor a CI workflow |
-| YAML Security | PASS | Workflow-level permissions none; job-level minimal grant; all user inputs routed through `env:` blocks (no `${{ }}` interpolation in `run:` blocks); release restricted to `main` branch |
+| YAML Security | PASS | Workflow-level permissions none; job-level minimal grant; all user inputs routed through `env:` blocks; release restricted to `main` branch |
 | YAML Formatting | PASS | Header comment; 2-space indent; yamllint clean |
 
 **Gate result**: PASS — no violations detected.

--- a/specs/007-release-workflow/quickstart.md
+++ b/specs/007-release-workflow/quickstart.md
@@ -1,0 +1,105 @@
+# Quickstart: Release Workflow for org-infra
+
+## For Maintainers (Creating a Release)
+
+### 1. Preview the release notes (optional)
+
+Run the preview workflow to see what the next release changelog will contain:
+
+```bash
+gh workflow run release_notes_preview.yml
+```
+
+Check the Actions tab for the job summary, or download the `release-notes-preview` artifact.
+
+### 2. Create a release
+
+Trigger the release workflow with a semver tag:
+
+```bash
+# From the CLI
+gh workflow run release.yaml -f tag=v1.0.0
+
+# For a release candidate
+gh workflow run release.yaml -f tag=v1.0.0-rc.1
+```
+
+Or use the Actions tab: select **Release**, click **Run workflow**, enter the tag.
+
+The workflow will:
+1. Validate the tag format (`v<major>.<minor>.<patch>` or `v<major>.<minor>.<patch>-rc.<n>`)
+2. Create and push the tag if it does not already exist
+3. Publish a GitHub Release with auto-generated changelog
+
+### 3. Verify the release
+
+```bash
+# Check the release was created
+gh release view v1.0.0
+
+# List all releases
+gh release list
+```
+
+## For Downstream Consumers (Pinning to a Release)
+
+### Update your caller workflows
+
+Replace `@main` with a release tag:
+
+```yaml
+# Before (living edge — not recommended)
+uses: complytime/org-infra/.github/workflows/reusable_ci.yml@main
+
+# After (pinned to release tag)
+uses: complytime/org-infra/.github/workflows/reusable_ci.yml@v1.0.0
+```
+
+For maximum reproducibility, pin to the release commit SHA:
+
+```yaml
+uses: complytime/org-infra/.github/workflows/reusable_ci.yml@<sha>
+```
+
+### Upgrading to a new release
+
+1. Check the [Releases page](https://github.com/complytime/org-infra/releases) for new versions
+2. Read the changelog — pay attention to **Breaking changes** section
+3. Update the tag in your caller workflow
+4. Test in a feature branch before merging
+
+## How Version Bumps Work
+
+Version numbers are resolved automatically from PR labels:
+
+| Label(s) | Version bump | Example |
+|----------|-------------|---------|
+| `breaking`, `major` | Major | v1.0.0 → v2.0.0 |
+| `feature`, `enhancement`, `minor` | Minor | v1.0.0 → v1.1.0 |
+| `fix`, `workflows`, `compliance`, `maintenance`, etc. | Patch | v1.0.0 → v1.0.1 |
+| No matching labels | Patch (default) | v1.0.0 → v1.0.1 |
+
+Labels are auto-assigned by the release-drafter autolabeler based on:
+- Conventional commit prefixes in PR titles (e.g., `feat:` → `feature`)
+- File paths changed (e.g., `.github/workflows/**` → `workflows`)
+
+## Troubleshooting
+
+### Release workflow fails with "Tag must match semver format"
+
+The tag input must match `v<major>.<minor>.<patch>` or `v<major>.<minor>.<patch>-rc.<n>`.
+Examples: `v1.0.0`, `v2.1.3-rc.1`. Tags like `1.0.0` (missing `v`), `v1.0` (missing patch),
+or `v1.0.0-beta` (unsupported suffix) are rejected.
+
+### Changelog is empty or missing PRs
+
+- PRs must be merged to the default branch to appear in the changelog
+- PRs labeled `skip-changelog` are excluded
+- Dependabot PRs are excluded by default
+- If a PR has no labels and the autolabeler did not match, it may be excluded
+
+### Release notes preview shows unexpected version
+
+The version is resolved from PR labels since the last release tag. If PRs have incorrect labels
+(e.g., a breaking change labeled as `fix`), the resolved version will be wrong. Fix the PR labels
+and re-run the preview.

--- a/specs/007-release-workflow/quickstart.md
+++ b/specs/007-release-workflow/quickstart.md
@@ -19,9 +19,6 @@ Trigger the release workflow with a semver tag:
 ```bash
 # From the CLI
 gh workflow run release.yaml -f tag=v1.0.0
-
-# For a release candidate
-gh workflow run release.yaml -f tag=v1.0.0-rc.1
 ```
 
 Or use the Actions tab: select **Release**, click **Run workflow**, enter the tag.
@@ -87,9 +84,9 @@ Labels are auto-assigned by the release-drafter autolabeler based on:
 
 ### Release workflow fails with "Tag must match semver format"
 
-The tag input must match `v<major>.<minor>.<patch>` or `v<major>.<minor>.<patch>-rc.<n>`.
-Examples: `v1.0.0`, `v2.1.3-rc.1`. Tags like `1.0.0` (missing `v`), `v1.0` (missing patch),
-or `v1.0.0-beta` (unsupported suffix) are rejected.
+The tag input must match `v<major>.<minor>.<patch>`.
+Examples: `v1.0.0`, `v2.1.3`. Tags like `1.0.0` (missing `v`) or `v1.0` (missing patch)
+are rejected.
 
 ### Changelog is empty or missing PRs
 

--- a/specs/007-release-workflow/quickstart.md
+++ b/specs/007-release-workflow/quickstart.md
@@ -18,13 +18,13 @@ Trigger the release workflow with a semver tag:
 
 ```bash
 # From the CLI
-gh workflow run release.yaml -f tag=v1.0.0
+gh workflow run release.yml -f tag=v1.0.0
 ```
 
 Or use the Actions tab: select **Release**, click **Run workflow**, enter the tag.
 
 The workflow will:
-1. Validate the tag format (`v<major>.<minor>.<patch>` or `v<major>.<minor>.<patch>-rc.<n>`)
+1. Validate the tag format (`v<major>.<minor>.<patch>`)
 2. Create and push the tag if it does not already exist
 3. Publish a GitHub Release with auto-generated changelog
 

--- a/specs/007-release-workflow/spec.md
+++ b/specs/007-release-workflow/spec.md
@@ -61,7 +61,7 @@ version is correct.
 - **Tag already exists**: If the tag already exists when the release workflow runs, the tag creation
   step is skipped and the existing tag is used for the release.
 - **Tag format validation**: The workflow rejects tags that do not match semver format
-  (`v<major>.<minor>.<patch>` or `v<major>.<minor>.<patch>-rc.<n>`).
+  (`v<major>.<minor>.<patch>`).
 - **No PRs since last release**: Release drafter produces a "no changes" message rather than an
   empty changelog.
 - **Unlabeled PRs**: PRs without labels are categorized by the autolabeler based on conventional
@@ -74,22 +74,19 @@ version is correct.
 The release process must:
 
 1. **Provide a manual release trigger**: Via `workflow_dispatch` with a required semver tag input.
-2. **Validate tag format**: Reject tags not matching `v<major>.<minor>.<patch>` or
-   `v<major>.<minor>.<patch>-rc.<n>`.
+2. **Validate tag format**: Reject tags not matching `v<major>.<minor>.<patch>`.
 3. **Enforce release from default branch**: Reject triggers from any ref other than `refs/heads/main`.
 4. **Create the tag if absent**: Tag the current branch HEAD and push to origin.
-4. **Publish a GitHub Release**: With auto-generated changelog categorized by PR labels.
-6. **Support prerelease tags**: Release candidates use `-rc.<n>` suffix and are dynamically marked as
-   prerelease based on tag format. Stable tags (e.g., `v1.0.0`) are not marked prerelease.
-7. **Auto-label PRs**: Map conventional commit prefixes and file paths to changelog categories.
-8. **Resolve version from labels**: Major/minor/patch version bumps determined by PR labels, defaulting
+5. **Publish a GitHub Release**: With auto-generated changelog categorized by PR labels.
+6. **Auto-label PRs**: Map conventional commit prefixes and file paths to changelog categories.
+7. **Resolve version from labels**: Major/minor/patch version bumps determined by PR labels, defaulting
    to patch.
-9. **Provide changelog categories**: Breaking changes, Workflows, Compliance, Sync, Features, Fixes,
+8. **Provide changelog categories**: Breaking changes, Workflows, Compliance, Sync, Features, Fixes,
    Performance, Maintenance.
-10. **Exclude bot contributions**: Dependabot and github-actions bot PRs excluded from changelog.
-11. **Support dry-run preview**: A separate workflow previews release notes without creating a release.
-12. **Use pinned action SHAs**: All `uses:` references pinned to full commit SHA with version comment.
-13. **Follow least-privilege permissions**: `contents: write` only on the release job; preview is
+9. **Exclude bot contributions**: Dependabot and github-actions bot PRs excluded from changelog.
+10. **Support dry-run preview**: A separate workflow previews release notes without creating a release.
+11. **Use pinned action SHAs**: All `uses:` references pinned to full commit SHA with version comment.
+12. **Follow least-privilege permissions**: `contents: write` only on the release job; preview is
     read-only.
 
 ## Success Metrics

--- a/specs/007-release-workflow/spec.md
+++ b/specs/007-release-workflow/spec.md
@@ -1,0 +1,117 @@
+# Feature Specification: Release Workflow for org-infra
+
+## Document Overview
+
+This specification details a lightweight release process for `complytime/org-infra` that enables
+downstream repositories to pin reusable workflows to semver tags or release commit SHAs. Since
+org-infra ships no binaries, the process is intentionally minimal: tag creation, automated changelog
+generation from merged PRs, and a published GitHub Release.
+
+**Key Metadata:**
+- Workflow Files: `.github/workflows/release.yaml`, `.github/workflows/release_notes_preview.yml`
+- Configuration: `.github/release-drafter.yml`
+- Date: 2026-04-13
+- Current Status: **In Progress** — workflow files drafted, spec under review
+- First Consumer: All complytime org repositories that reference `complytime/org-infra` reusable workflows
+
+## Background and Motivation
+
+The complytime org-infra repository provides 13 reusable GitHub Actions workflows consumed by
+downstream repositories across the organization. Today, consumers reference these workflows by
+branch name (e.g., `@main`) or commit SHA. This creates two problems:
+
+1. **No stability guarantee** — `@main` is a moving target. A breaking workflow change lands on main
+   and immediately affects all consumers without notice.
+2. **No versioning signal** — consumers cannot distinguish a patch fix from a breaking change without
+   reading every commit.
+
+A semver-tagged release process solves both problems. Consumers can pin to a release tag
+(e.g., `@v1.2.0`) for stability, and the version number communicates the nature of changes.
+
+## Core User Scenarios
+
+### Priority 1: Create a Versioned Release
+
+A repository maintainer triggers the release workflow via `workflow_dispatch`, providing a semver tag
+(e.g., `v1.0.0`). The workflow validates the tag format, creates the tag if it does not exist, and
+publishes a GitHub Release with auto-generated changelog from merged PRs since the last release.
+
+**Test Coverage:** Validates that the tag is created, the GitHub Release is published, and the
+changelog is correctly categorized by PR labels.
+
+### Priority 2: Pin Reusable Workflows to a Release
+
+A downstream repository maintainer updates their caller workflow to reference a specific release tag
+instead of `@main`. The pinned version continues to work until the consumer explicitly upgrades.
+
+**Test Coverage:** Validates that `uses: complytime/org-infra/.github/workflows/reusable_ci.yml@v1.0.0`
+resolves correctly and the workflow executes as expected.
+
+### Priority 3: Preview Release Notes Before Publishing
+
+A maintainer runs the release notes preview workflow to see what the next release changelog will
+contain, without creating a release. This enables review of PR categorization and version resolution
+before committing to a release.
+
+**Test Coverage:** Validates that the dry-run output matches expected PR groupings and the resolved
+version is correct.
+
+## Edge Cases Addressed
+
+- **Tag already exists**: If the tag already exists when the release workflow runs, the tag creation
+  step is skipped and the existing tag is used for the release.
+- **Tag format validation**: The workflow rejects tags that do not match semver format
+  (`v<major>.<minor>.<patch>` or `v<major>.<minor>.<patch>-rc.<n>`).
+- **No PRs since last release**: Release drafter produces a "no changes" message rather than an
+  empty changelog.
+- **Unlabeled PRs**: PRs without labels are categorized by the autolabeler based on conventional
+  commit prefixes and file paths. PRs that match no rule are excluded from the changelog.
+- **Dependabot PRs**: Excluded from changelog via `exclude-contributors` to reduce noise.
+- **First release**: When no previous tag exists, the changelog includes all merged PRs.
+
+## Functional Requirements Summary
+
+The release process must:
+
+1. **Provide a manual release trigger**: Via `workflow_dispatch` with a required semver tag input.
+2. **Validate tag format**: Reject tags not matching `v<major>.<minor>.<patch>` or
+   `v<major>.<minor>.<patch>-rc.<n>`.
+3. **Enforce release from default branch**: Reject triggers from any ref other than `refs/heads/main`.
+4. **Create the tag if absent**: Tag the current branch HEAD and push to origin.
+4. **Publish a GitHub Release**: With auto-generated changelog categorized by PR labels.
+6. **Support prerelease tags**: Release candidates use `-rc.<n>` suffix and are dynamically marked as
+   prerelease based on tag format. Stable tags (e.g., `v1.0.0`) are not marked prerelease.
+7. **Auto-label PRs**: Map conventional commit prefixes and file paths to changelog categories.
+8. **Resolve version from labels**: Major/minor/patch version bumps determined by PR labels, defaulting
+   to patch.
+9. **Provide changelog categories**: Breaking changes, Workflows, Compliance, Sync, Features, Fixes,
+   Performance, Maintenance.
+10. **Exclude bot contributions**: Dependabot and github-actions bot PRs excluded from changelog.
+11. **Support dry-run preview**: A separate workflow previews release notes without creating a release.
+12. **Use pinned action SHAs**: All `uses:` references pinned to full commit SHA with version comment.
+13. **Follow least-privilege permissions**: `contents: write` only on the release job; preview is
+    read-only.
+
+## Success Metrics
+
+- Maintainers can create a release by triggering a single workflow with a version tag.
+- Downstream repositories can pin to `@v<major>.<minor>.<patch>` and receive no changes until
+  they explicitly upgrade.
+- Release notes accurately categorize PRs by type (workflows, compliance, features, fixes, etc.).
+- The release process requires no local tooling — everything runs via GitHub Actions and `gh` CLI.
+- `yamllint` passes on all workflow files.
+
+## Scope Boundaries
+
+**Included:**
+- `.github/workflows/release.yaml` — manual release workflow
+- `.github/workflows/release_notes_preview.yml` — dry-run preview workflow
+- `.github/release-drafter.yml` — changelog and version configuration
+- Consumer pinning documentation
+
+**Excluded:**
+- Automated release triggers (e.g., on merge to main) — releases are intentionally manual
+- Binary artifact building or signing — org-infra has no binaries
+- Release branch strategy — releases are cut from `main`
+- Migration tooling for existing consumers — consumers upgrade at their own pace
+- Webhook or notification integration (Slack, email, etc.)

--- a/specs/007-release-workflow/spec.md
+++ b/specs/007-release-workflow/spec.md
@@ -8,7 +8,7 @@ org-infra ships no binaries, the process is intentionally minimal: tag creation,
 generation from merged PRs, and a published GitHub Release.
 
 **Key Metadata:**
-- Workflow Files: `.github/workflows/release.yaml`, `.github/workflows/release_notes_preview.yml`
+- Workflow Files: `.github/workflows/release.yml`, `.github/workflows/release_notes_preview.yml`
 - Configuration: `.github/release-drafter.yml`
 - Date: 2026-04-13
 - Current Status: **In Progress** — workflow files drafted, spec under review
@@ -101,7 +101,7 @@ The release process must:
 ## Scope Boundaries
 
 **Included:**
-- `.github/workflows/release.yaml` — manual release workflow
+- `.github/workflows/release.yml` — manual release workflow
 - `.github/workflows/release_notes_preview.yml` — dry-run preview workflow
 - `.github/release-drafter.yml` — changelog and version configuration
 - Consumer pinning documentation

--- a/specs/007-release-workflow/tasks.md
+++ b/specs/007-release-workflow/tasks.md
@@ -14,8 +14,7 @@
 - [x] 1.4 Configure `autolabeler` for conventional commit prefixes and file path patterns
 - [x] 1.5 Add `exclude-labels` for `skip-changelog`
 - [x] 1.6 Add `exclude-contributors` for `dependabot[bot]` and `github-actions[bot]`
-- [x] 1.7 Configure prerelease support with `-rc` identifier
-- [x] 1.8 Add consumer guidance in release template body (upgrade notes, diff link)
+- [x] 1.7 Add consumer guidance in release template body (upgrade notes, diff link)
 
 ---
 
@@ -28,7 +27,7 @@
 - [x] 2.3 Add branch restriction step (reject triggers from non-main branches)
 - [x] 2.4 Add checkout step with `fetch-depth: 0` for full history
 - [x] 2.5 Add conditional tag creation step (create and push if absent, skip if exists)
-- [x] 2.6 Add release-drafter publish step with `GITHUB_TOKEN` env and dynamic `prerelease` from tag
+- [x] 2.6 Add release-drafter publish step with `GITHUB_TOKEN` env
 - [x] 2.7 Set workflow-level `permissions: {}` and job-level `contents: write`
 - [x] 2.8 Pin all action SHAs with inline version comments
 - [x] 2.9 Add header comment block with usage instructions and consumer guidance
@@ -54,7 +53,7 @@
 - [x] 4.1 Verify `yamllint` passes on all three files
 - [ ] 4.2 Verify `make sync-dry-run` includes release workflow files if applicable
 - [ ] 4.3 Run release notes preview workflow to confirm dry-run output
-- [ ] 4.4 Test release workflow with an `rc` tag (e.g., `v0.1.0-rc.1`) before first stable release
+- [ ] 4.4 Test release workflow with first release (e.g., `v0.1.0`)
 
 ---
 
@@ -71,6 +70,5 @@ Before opening the PR to `complytime/org-infra`:
 - [x] Header comments include consumer guidance
 - [x] No `${{ }}` interpolation in `run:` blocks — all user inputs via `env:`
 - [x] Release restricted to `main` branch only
-- [x] Prerelease flag is dynamic (only RC tags marked as prerelease)
 - [x] Spec files exist under `specs/007-release-workflow/`
 - [ ] PR description documents the release process and consumer pinning strategy

--- a/specs/007-release-workflow/tasks.md
+++ b/specs/007-release-workflow/tasks.md
@@ -20,7 +20,7 @@
 
 ### Task 2 — Create release workflow
 
-**File**: `.github/workflows/release.yaml`
+**File**: `.github/workflows/release.yml`
 
 - [x] 2.1 Add `workflow_dispatch` trigger with `tag` input (required, semver format)
 - [x] 2.2 Add tag format validation step (reject non-semver tags)
@@ -62,7 +62,7 @@
 Before opening the PR to `complytime/org-infra`:
 
 - [x] `.github/release-drafter.yml` exists with correct category/label mappings
-- [x] `.github/workflows/release.yaml` validates tag format, enforces main branch, creates tag if absent
+- [x] `.github/workflows/release.yml` validates tag format, enforces main branch, creates tag if absent
 - [x] `.github/workflows/release_notes_preview.yml` runs dry-run preview
 - [x] All `uses:` are pinned to full SHA with `# vX.Y.Z` comment
 - [x] Workflow-level permissions are `{}` or read-only

--- a/specs/007-release-workflow/tasks.md
+++ b/specs/007-release-workflow/tasks.md
@@ -1,0 +1,76 @@
+# Task List: Release Workflow for org-infra
+
+**Branch**: `feat/adds-release-workflow` | **Plan**: [plan.md](plan.md)
+
+## Tasks
+
+### Task 1 — Create release-drafter configuration
+
+**File**: `.github/release-drafter.yml`
+
+- [x] 1.1 Define `name-template` and `tag-template` using `v$RESOLVED_VERSION`
+- [x] 1.2 Configure `version-resolver` with major/minor/patch label mappings
+- [x] 1.3 Define changelog categories (breaking, workflows, compliance, sync, features, fixes, performance, maintenance)
+- [x] 1.4 Configure `autolabeler` for conventional commit prefixes and file path patterns
+- [x] 1.5 Add `exclude-labels` for `skip-changelog`
+- [x] 1.6 Add `exclude-contributors` for `dependabot[bot]` and `github-actions[bot]`
+- [x] 1.7 Configure prerelease support with `-rc` identifier
+- [x] 1.8 Add consumer guidance in release template body (upgrade notes, diff link)
+
+---
+
+### Task 2 — Create release workflow
+
+**File**: `.github/workflows/release.yaml`
+
+- [x] 2.1 Add `workflow_dispatch` trigger with `tag` input (required, semver format)
+- [x] 2.2 Add tag format validation step (reject non-semver tags)
+- [x] 2.3 Add branch restriction step (reject triggers from non-main branches)
+- [x] 2.4 Add checkout step with `fetch-depth: 0` for full history
+- [x] 2.5 Add conditional tag creation step (create and push if absent, skip if exists)
+- [x] 2.6 Add release-drafter publish step with `GITHUB_TOKEN` env and dynamic `prerelease` from tag
+- [x] 2.7 Set workflow-level `permissions: {}` and job-level `contents: write`
+- [x] 2.8 Pin all action SHAs with inline version comments
+- [x] 2.9 Add header comment block with usage instructions and consumer guidance
+- [x] 2.10 Route all user inputs through `env:` blocks (no `${{ }}` interpolation in `run:`)
+
+---
+
+### Task 3 — Create release notes preview workflow
+
+**File**: `.github/workflows/release_notes_preview.yml`
+
+- [x] 3.1 Add `workflow_dispatch` trigger (no inputs)
+- [x] 3.2 Add release-drafter dry-run step with `GITHUB_TOKEN` env
+- [x] 3.3 Add step to write preview to `$GITHUB_STEP_SUMMARY`
+- [x] 3.4 Add artifact upload for `release-notes-preview.md`
+- [x] 3.5 Set read-only permissions (`contents: read`, `pull-requests: read`)
+- [x] 3.6 Pin all action SHAs with inline version comments
+
+---
+
+### Task 4 — Validation
+
+- [x] 4.1 Verify `yamllint` passes on all three files
+- [ ] 4.2 Verify `make sync-dry-run` includes release workflow files if applicable
+- [ ] 4.3 Run release notes preview workflow to confirm dry-run output
+- [ ] 4.4 Test release workflow with an `rc` tag (e.g., `v0.1.0-rc.1`) before first stable release
+
+---
+
+### Task 5 — Self-review checklist
+
+Before opening the PR to `complytime/org-infra`:
+
+- [x] `.github/release-drafter.yml` exists with correct category/label mappings
+- [x] `.github/workflows/release.yaml` validates tag format, enforces main branch, creates tag if absent
+- [x] `.github/workflows/release_notes_preview.yml` runs dry-run preview
+- [x] All `uses:` are pinned to full SHA with `# vX.Y.Z` comment
+- [x] Workflow-level permissions are `{}` or read-only
+- [x] `GITHUB_TOKEN` is passed to release-drafter steps
+- [x] Header comments include consumer guidance
+- [x] No `${{ }}` interpolation in `run:` blocks — all user inputs via `env:`
+- [x] Release restricted to `main` branch only
+- [x] Prerelease flag is dynamic (only RC tags marked as prerelease)
+- [x] Spec files exist under `specs/007-release-workflow/`
+- [ ] PR description documents the release process and consumer pinning strategy


### PR DESCRIPTION
## Summary

Introduces a lightweight release process for org-infra so that downstream projects like complyctl and other complytime repositories can pin reusable workflows to semver tags or release commit SHAs instead of tracking `@main`.

- Add manual release workflow (`release.yaml`) with semver tag validation, branch restriction to `main`, conditional tag creation, and auto-generated changelogs via release-drafter
- Add release notes preview workflow (`release_notes_preview.yml`) for dry-run changelog review before publishing
- Add release-drafter configuration (`.github/release-drafter.yml`) with autolabeling from conventional commits and file paths, semver resolution from PR labels, and changelog categorization

### Consumer pinning (after first release)

```yaml
# Pin to semver tag (recommended)
uses: complytime/org-infra/.github/workflows/reusable_ci.yml@v1.0.0

# Pin to release commit SHA (maximum reproducibility)
uses: complytime/org-infra/.github/workflows/reusable_ci.yml@<sha>
```

### Security hardening

- All user inputs routed through `env:` blocks — no `${{ }}` interpolation in `run:` scripts
- Releases restricted to `main` branch only
- Dynamic prerelease detection — only `-rc.<n>` tags marked as prerelease
- Workflow-level `permissions: {}` with minimal job-level grants
- All action `uses:` pinned to full 40-char commit SHAs

### Spec artifacts

Full specification under `specs/007-release-workflow/` (spec, plan, tasks, quickstart, requirements checklist) and OpenSpec registration under `openspec/specs/release-workflow/`.

## Related Issues 

- Closes Issue #162 

## Test plan

- [ ] Run `yamllint` on all three files (verified locally — passes)
- [ ] Trigger release notes preview workflow to confirm dry-run output
- [ ] Test release workflow with RC tag (`v0.1.0-rc.1`) before first stable release
- [ ] Verify downstream consumer can pin to the release tag

🤖 Generated with [Claude Code](https://claude.com/claude-code)