### PR TITLE
fix: use grep -F for baseline lookup to handle Go pointer receivers

### DIFF
--- a/.github/workflows/reusable_crapload_analysis.yml
+++ b/.github/workflows/reusable_crapload_analysis.yml
@@ -174,7 +174,7 @@ jobs:
 
           # Process current scores
           while IFS=$'\t' read -r key crap gaze_crap; do
-            baseline_line=$(grep "^${key}	" /tmp/baseline-lookup.tsv || true)
+            baseline_line=$(grep -F "${key}	" /tmp/baseline-lookup.tsv || true)
             if [ -z "$baseline_line" ]; then
               # New function
               NEW_COUNT=$((NEW_COUNT + 1))


### PR DESCRIPTION
## Summary

Fixes a regex interpretation bug in the CRAPLoad baseline comparison that
causes all Go pointer receiver methods to be misclassified as "new functions."

Line 177 uses `grep "^${key}<TAB>"` to look up function keys in the baseline
TSV. Go pointer receiver methods have the format `(*Type).Method`, where `(*`
is a BRE (Basic Regular Expression) quantifier meaning "zero or more `(`"
rather than the literal characters `(*`. This causes the lookup to fail for
every pointer receiver function.

The fix switches `grep` to `grep -F` (fixed-string matching). The `^` anchor
is dropped because `-F` does not support anchors. Collisions are not possible
since keys are fully-qualified `file.go:function` paths, unique by construction.

## Related Issues

- Unblocks complytime/complyctl#473 which is currently failing CRAPLoad due to this bug.

## Review Hints

- Single-line change on line 177 of `reusable_crapload_analysis.yml`: `grep` → `grep -F`.

- **Evidence from complytime/complyctl PR [#473](https://github.com/complytime/complyctl/pull/473):**
  113 functions flagged as "new" = exactly 113 pointer receiver functions in
  the baseline. 251 functions matched correctly = all non-pointer-receiver
  functions.

- Reproducible locally:
  ```bash
  # BRE fails on pointer receiver syntax
  key='pkg/foo.go:(*Type).Method'
  echo -e "${key}\t10\t0" | grep "^${key}	"    # NO MATCH
  echo -e "${key}\t10\t0" | grep -F "${key}	"   # MATCH
  ```