### PR TITLE
fix: use fromJSON for numeric comparison in auto-approval condition

### DIFF
--- a/.github/workflows/ci_dependencies.yml
+++ b/.github/workflows/ci_dependencies.yml
@@ -64,7 +64,7 @@ jobs:
             | **Release Age** | **${{ (env.RELEASE_AGE_HOURS == '-1' || env.RELEASE_AGE_HOURS == '') && 'unknown' || format('{0}h', env.RELEASE_AGE_HOURS) }}** | ${{ (env.RELEASE_AGE_HOURS == '-1' || env.RELEASE_AGE_HOURS == '') && 'Release date unavailable — manual review required' || format('Released {0} hours ago', env.RELEASE_AGE_HOURS) }} |
             | **Dependency Usage** | ${{ env.UPDATES_COUNT == '0' && 'unavailable' || format('{0} repos', env.UPDATES_COUNT) }} | Informational only — does not affect approval |
 
-            **Auto-approval:** ${{ env.RISK_LEVEL != 'high' && env.REVIEW_CONCLUSION == 'success' && env.RELEASE_AGE_HOURS != '-1' && env.RELEASE_AGE_HOURS >= env.MIN_RELEASE_AGE_HOURS && '✅ Approved' || '⏳ Manual review required' }}
+            **Auto-approval:** ${{ env.RISK_LEVEL != 'high' && env.REVIEW_CONCLUSION == 'success' && env.RELEASE_AGE_HOURS != '-1' && fromJSON(env.RELEASE_AGE_HOURS) >= fromJSON(env.MIN_RELEASE_AGE_HOURS) && '✅ Approved' || '⏳ Manual review required' }}
 
             ---
 
@@ -88,7 +88,7 @@ jobs:
           needs.call_dependabot_reviewer.outputs.risk_level != 'high' &&
           needs.call_deps_reviewer.outputs.review_conclusion == 'success' &&
           needs.call_dependabot_reviewer.outputs.release_age_hours != '-1' &&
-          needs.call_dependabot_reviewer.outputs.release_age_hours >= env.MIN_RELEASE_AGE_HOURS
+          fromJSON(needs.call_dependabot_reviewer.outputs.release_age_hours) >= fromJSON(env.MIN_RELEASE_AGE_HOURS)
         uses: actions/github-script@3a2844b7e9c422d3c10d287c895573f7108da1b3 # v9.0.0
         with:
           script: |


### PR DESCRIPTION
## Summary

Fix the dependabot auto-approval condition that silently fails on every PR due to lexicographic string comparison instead of numeric comparison.

GitHub Actions `>=` operator performs **lexicographic string comparison** when both operands come from the `env` context (both are strings). This causes `"117" >= "24"` to evaluate as `false` because `'1' < '2'` in ASCII order — even though numerically `117 >= 24` is `true`.

The fix wraps both operands in `fromJSON()` to force numeric casting:
- `fromJSON(env.RELEASE_AGE_HOURS) >= fromJSON(env.MIN_RELEASE_AGE_HOURS)`
- `fromJSON(needs...release_age_hours) >= fromJSON(env.MIN_RELEASE_AGE_HOURS)`

**Impact**: Without this fix, **no dependabot PR can be auto-approved** because the release age comparison always fails. This affects all org repos consuming `ci_dependencies.yml`.

**Evidence**: PR #197 (`actions/upload-artifact` 7.0.0 → 7.0.1) meets all criteria (risk=low, review=success, release_age=117h) but the auto-approve step was [skipped](https://github.com/complytime/org-infra/actions/runs/24461173549).

## Related Issues

- Fixes auto-approval regression introduced in #189
- Unblocks #197 (and all pending dependabot PRs across org repos)

## Review Hints

- Single file changed: `.github/workflows/ci_dependencies.yml` (2 lines)
- Two `fromJSON()` wrappers added: one in the step `if:` condition (L91), one in the PR comment auto-approval display (L67)
- The `MIN_RELEASE_AGE_HOURS` env constant remains centralized (Principle I) — only the comparison method changed
- After merging, re-run the Dependencies workflow on #197 to verify the fix