### PR TITLE
fix: post CRAP Load comment on analysis failure

### DIFF
--- a/.github/workflows/ci_crapload.yml
+++ b/.github/workflows/ci_crapload.yml
@@ -26,11 +26,14 @@ jobs:
   post-comment:
     name: Post PR Comment
     needs: crapload
+    if: ${{ !cancelled() }}
     runs-on: ubuntu-latest
     permissions:
       pull-requests: write
     steps:
       - name: Download comment body
+        id: download
+        continue-on-error: true
         uses: actions/download-artifact@3e5f45b2cfb9172054b4087a40e8e0b5a5461e7c # v8.0.1
         with:
           name: crapload-analysis
@@ -42,12 +45,37 @@ jobs:
         with:
           script: |
             const fs = require('fs');
+            const marker = '<!-- crapload-analysis-marker -->';
             const bodyPath = 'artifact/crapload-comment-body.md';
-            if (!fs.existsSync(bodyPath)) {
-              console.log('No comment body found. Skipping.');
-              return;
+            const runUrl = [
+              context.serverUrl,
+              context.repo.owner,
+              context.repo.repo,
+              'actions/runs',
+              context.runId,
+            ].join('/');
+            const MAX_COMMENT_LENGTH = 60000;
+
+            let body;
+            if (fs.existsSync(bodyPath)) {
+              body = fs.readFileSync(bodyPath, 'utf8');
+              if (body.length > MAX_COMMENT_LENGTH) {
+                const lastNewline = body.lastIndexOf('\n', MAX_COMMENT_LENGTH);
+                body = body.substring(0, lastNewline > 0 ? lastNewline : MAX_COMMENT_LENGTH);
+                body += '\n\n---\n';
+                body += '> **Note:** This report was truncated due to size.';
+                body += ` [View the full analysis in the Job Summary](${runUrl}).`;
+              }
+            } else {
+              body = [
+                marker,
+                '## &#x274C; CRAP Load Analysis',
+                '',
+                'The CRAP Load analysis could not generate a detailed report.',
+                '',
+                `[View the full analysis in the Job Summary](${runUrl}).`,
+              ].join('\n');
             }
-            const body = fs.readFileSync(bodyPath, 'utf8');
 
             const { data: comments } = await github.rest.issues.listComments({
               owner: context.repo.owner,
@@ -55,7 +83,6 @@ jobs:
               issue_number: context.issue.number,
             });
 
-            const marker = '<!-- crapload-analysis-marker -->';
             const existing = comments.find(c => c.body.includes(marker));
 
             if (existing) {


### PR DESCRIPTION
## Summary

The `post-comment` job in `ci_crapload.yml` was silently skipped whenever the CRAP Load analysis detected regressions, because the implicit `success()` condition on the `needs` dependency prevented it from running when the upstream job failed. This meant PR authors never received the detailed CRAP report comment precisely when they needed it most.

This fix ensures the comment is always posted by:
- Adding `if: !cancelled()` so the comment job runs on both success and failure
- Handling missing artifacts with a fallback comment linking to the Job Summary
- Truncating oversized comments (>60K chars) to stay within GitHub's 65K limit, with a link to the full Job Summary

## Related Issues

- Observed in https://github.com/complytime/complyctl/pull/463 where "CRAP Load Analysis" **failed** but "Post PR Comment" was **skipped**

## Review Hints

- This is a single-file change to `.github/workflows/ci_crapload.yml` (synced to all Go repos via `sync-config.yml`).
- The root cause was the missing `if` condition on the `post-comment` job at line 28. GitHub Actions defaults to `if: success()` for jobs with `needs`, so when the `crapload` job failed at the "Enforce threshold" step (`exit 1`), the comment job was skipped entirely.
- The reusable workflow (`reusable_crapload_analysis.yml`) is unchanged — it already uploads the comment body artifact before the enforce step fails.
- Three scenarios are now handled: (1) artifact available — post the full report, (2) artifact available but oversized — truncate and link to Job Summary, (3) artifact unavailable (early failure) — post a short fallback comment with Job Summary link.