### PR TITLE
fix: enable Trivy source scanning by removing stale TODO

### DIFF
--- a/.github/workflows/ci_security.yml
+++ b/.github/workflows/ci_security.yml
@@ -25,10 +25,9 @@ jobs:
       packages: write
       id-token: write
     uses: complytime/org-infra/.github/workflows/reusable_vuln_scan.yml@main
-    # TODO: Re-add 'enable_trivy_source: true' once reusable_vuln_scan.yml is merged to main
-    # with:
-    #   # OSV focuses on known CVEs in dependencies; Trivy adds broader coverage
-    #   enable_trivy_source: true
+    with:
+      # OSV focuses on known CVEs in dependencies; Trivy adds broader coverage
+      enable_trivy_source: true
 
   call_reusable_security:
     name: OpenSSF Scorecards


### PR DESCRIPTION
## Summary

Enable Trivy source scanning (secrets + misconfig) by removing a stale TODO comment in `ci_security.yml`. The `reusable_vuln_scan.yml` workflow has been on `main` for some time, satisfying the condition the TODO was waiting for.

The `enable_trivy_source: true` input was commented out with:
```yaml
# TODO: Re-add 'enable_trivy_source: true' once reusable_vuln_scan.yml is merged to main
```

This is now uncommented since the reusable workflow exists and supports the input.

## Related Issues

- Reported by @hbraswelrh in https://github.com/complytime/complyscribe/pull/824#discussion_r3100762512

## Review Hints

- Single file change: `.github/workflows/ci_security.yml`
- This file is synced to all org repos via `sync-config.yml`, so the change will propagate on the next sync run.
- The `reusable_vuln_scan.yml` workflow defaults `enable_trivy_source` to `false`, so only repos that explicitly opt in (via this consumer workflow) will run Trivy source scans.