### PR TITLE
fix: remove invalid $CHANGES variable from category-template

### DIFF
--- a/.github/release-drafter.yml
+++ b/.github/release-drafter.yml
@@ -6,8 +6,6 @@ tag-template: "v$RESOLVED_VERSION"
 category-template: |
   ### $TITLE
 
-  $CHANGES
-
 template: |
   ## org-infra $RESOLVED_VERSION
 


### PR DESCRIPTION
## Summary

- Removes the invalid `$CHANGES` variable from the `category-template` field in `.github/release-drafter.yml`
- `$CHANGES` is only valid in release-drafter's `template`, `header`, and `footer` fields — the only supported variable in `category-template` is `$TITLE`
- The invalid reference caused the literal string `$CHANGES` to appear in every category section of the generated release notes

## Verification

- yamllint passes clean against `.yamllint.yml`
- `release_notes_preview.yml` workflow [ran successfully](https://github.com/complytime/org-infra/actions/runs/24722922325) with the fix — output contains no literal `$CHANGES` strings