### PR TITLE
feat: pin reusable workflow references to v0.1.0 release SHA

### DIFF
--- a/.github/workflows/ci_checks.yml
+++ b/.github/workflows/ci_checks.yml
@@ -16,7 +16,7 @@ permissions:
 jobs:
   call_reusable_ci:
     name: Standardized CI
-    uses: complytime/org-infra/.github/workflows/reusable_ci.yml@main
+    uses: complytime/org-infra/.github/workflows/reusable_ci.yml@baf5b2e21e61581b4a3a129795286e8592e6afbb # v0.1.0
     permissions:
       contents: read
       issues: read

--- a/.github/workflows/ci_compliance.yml
+++ b/.github/workflows/ci_compliance.yml
@@ -24,7 +24,7 @@ jobs:
     name: Compliance Evaluation
     permissions:
       contents: read
-    uses: complytime/org-infra/.github/workflows/reusable_compliance.yml@main
+    uses: complytime/org-infra/.github/workflows/reusable_compliance.yml@baf5b2e21e61581b4a3a129795286e8592e6afbb # v0.1.0
     with:
       complytime_config_path: ${{ inputs.complytime_config_path || 'complytime.yaml' }}
       policy_id: ${{ inputs.policy_id || 'ampel-bp' }}

--- a/.github/workflows/ci_crapload.yml
+++ b/.github/workflows/ci_crapload.yml
@@ -19,7 +19,7 @@ permissions:
 jobs:
   crapload:
     name: CRAP Load Analysis
-    uses: complytime/org-infra/.github/workflows/reusable_crapload_analysis.yml@main
+    uses: complytime/org-infra/.github/workflows/reusable_crapload_analysis.yml@baf5b2e21e61581b4a3a129795286e8592e6afbb # v0.1.0
     permissions:
       contents: read
 

--- a/.github/workflows/ci_dependencies.yml
+++ b/.github/workflows/ci_dependencies.yml
@@ -25,11 +25,11 @@ env:
 jobs:
   call_deps_reviewer:
     name: General
-    uses: complytime/org-infra/.github/workflows/reusable_deps_reviewer.yml@main
+    uses: complytime/org-infra/.github/workflows/reusable_deps_reviewer.yml@baf5b2e21e61581b4a3a129795286e8592e6afbb # v0.1.0
 
   call_dependabot_reviewer:
     name: Dependabot
-    uses: complytime/org-infra/.github/workflows/reusable_dependabot_reviewer.yml@main
+    uses: complytime/org-infra/.github/workflows/reusable_dependabot_reviewer.yml@baf5b2e21e61581b4a3a129795286e8592e6afbb # v0.1.0
 
   comment_on_dependabot_prs:
     name: Dependabot Comment

--- a/.github/workflows/ci_scheduled.yml
+++ b/.github/workflows/ci_scheduled.yml
@@ -18,4 +18,4 @@ jobs:
       actions: read           # Required to upload SARIF file to CodeQL. See: https://github.com/github/codeql-action/issues/2117
       security-events: write  # Require writing security events to upload SARIF file to security tab
       id-token: write         # Needed to access GitHub's OIDC token which verifies the authenticity of the result when publishing it.
-    uses: complytime/org-infra/.github/workflows/reusable_scheduled.yml@main
+    uses: complytime/org-infra/.github/workflows/reusable_scheduled.yml@baf5b2e21e61581b4a3a129795286e8592e6afbb # v0.1.0

--- a/.github/workflows/ci_security.yml
+++ b/.github/workflows/ci_security.yml
@@ -24,7 +24,7 @@ jobs:
       security-events: write
       packages: write
       id-token: write
-    uses: complytime/org-infra/.github/workflows/reusable_vuln_scan.yml@main
+    uses: complytime/org-infra/.github/workflows/reusable_vuln_scan.yml@baf5b2e21e61581b4a3a129795286e8592e6afbb # v0.1.0
     with:
       # OSV focuses on known CVEs in dependencies; Trivy adds broader coverage
       enable_trivy_source: true
@@ -35,4 +35,4 @@ jobs:
       contents: read
       id-token: write
       security-events: write
-    uses: complytime/org-infra/.github/workflows/reusable_security.yml@main
+    uses: complytime/org-infra/.github/workflows/reusable_security.yml@baf5b2e21e61581b4a3a129795286e8592e6afbb # v0.1.0

--- a/.github/workflows/reusable_scheduled.yml
+++ b/.github/workflows/reusable_scheduled.yml
@@ -41,4 +41,4 @@ jobs:
       contents: read
       security-events: write  # Needed to upload the results to code-scanning dashboard.
       id-token: write         # Needed to access GitHub's OIDC token which verifies the authenticity of the result when publishing it.
-    uses: complytime/org-infra/.github/workflows/reusable_security.yml@main
+    uses: complytime/org-infra/.github/workflows/reusable_security.yml@baf5b2e21e61581b4a3a129795286e8592e6afbb # v0.1.0

--- a/openspec/changes/pin-workflows-to-release/.openspec.yaml
+++ b/openspec/changes/pin-workflows-to-release/.openspec.yaml
@@ -1,0 +1,2 @@
+schema: spec-driven
+created: 2026-04-21

--- a/openspec/changes/pin-workflows-to-release/design.md
+++ b/openspec/changes/pin-workflows-to-release/design.md
@@ -1,0 +1,81 @@
+## Context
+
+Consumer workflows (`ci_*`) in org-infra call reusable workflows via
+`uses: complytime/org-infra/.github/workflows/reusable_*.yml@main`. This mutable
+reference means any push to `main` that modifies a reusable workflow immediately changes
+behavior in all downstream repos -- with no review gate and no rollback path.
+
+The org already enforces SHA-pinning for all third-party actions (e.g.,
+`actions/checkout@<sha> # v6.0.2`). The v0.1.0 release
+(`baf5b2e21e61581b4a3a129795286e8592e6afbb`) provides the first stable tag to pin against.
+
+Nine `@main` references exist across 7 consumer workflows and 1 reusable workflow
+(`reusable_scheduled.yml` calls `reusable_security.yml`).
+
+## Goals / Non-Goals
+
+**Goals:**
+
+- Pin all 9 reusable-workflow `@main` references to the v0.1.0 release SHA.
+- Use the same `@<sha> # v0.1.0` format already established for third-party action pins.
+- Ensure downstream repos receive the pinned references on the next org sync.
+
+**Non-Goals:**
+
+- Adding automated sync triggers (remains `workflow_dispatch` only).
+- Creating a major-version floating tag strategy (e.g., `@v1`).
+- Modifying the sync script or `sync-config.yml`.
+- Changing any third-party action pins.
+
+## Decisions
+
+### 1. Pin format: `@<full-sha> # v0.1.0`
+
+Use the full 40-character commit SHA with an inline version comment, matching the
+existing convention for third-party actions.
+
+**Alternatives considered:**
+- **Tag reference (`@v0.1.0`)**: Mutable -- tags can be moved or deleted. Rejected
+  because the org constitution explicitly prohibits mutable tags in `uses:` references.
+- **Short SHA (`@baf5b2e`)**: GitHub resolves short SHAs but they can become ambiguous
+  as the commit history grows. Rejected for consistency with existing full-SHA pins.
+
+### 2. Pin the reusable-to-reusable reference too
+
+`reusable_scheduled.yml` calls `reusable_security.yml@main`. This is pinned to the same
+SHA to maintain consistency -- all cross-workflow references within org-infra follow the
+same pinning convention.
+
+**Alternatives considered:**
+- **Leave `@main` for internal calls**: Would create an inconsistency where consumer
+  workflows are pinned but internal calls are not. Rejected for uniformity and because
+  `reusable_scheduled.yml` is also synced to downstream repos.
+
+### 3. Single atomic change across all files
+
+All 9 references are updated in one change rather than per-file or per-workflow.
+
+**Alternatives considered:**
+- **Per-workflow PRs**: Would create 7 separate PRs for a uniform find-and-replace.
+  Rejected as unnecessary overhead for a mechanical change.
+
+## Risks / Trade-offs
+
+- **[Risk] Future reusable workflow changes require a release cycle to propagate.**
+  Previously, pushing to `main` was enough. Now a new release must be cut and the SHA
+  updated in consumer workflows before syncing.
+  -> Mitigation: This is the intended behavior. It adds a deliberate review gate.
+  Document the release-then-sync workflow in the repo's contributing guide.
+
+- **[Risk] Circular dependency for org-infra's own CI.** The consumer workflows in
+  org-infra itself reference reusable workflows from the same repo. After pinning,
+  changes to a reusable workflow won't be tested by org-infra's own CI until a new
+  release is cut.
+  -> Mitigation: org-infra can test reusable workflow changes on feature branches using
+  `@<branch>` temporarily, then pin to the new release SHA before merging. Alternatively,
+  accept that org-infra's `main` CI uses the last-released version of its own reusable
+  workflows.
+
+- **[Trade-off] Increased maintenance cost per release.** Each release requires updating
+  9 SHA references. This is a small, mechanical cost offset by the supply-chain security
+  benefit.

--- a/openspec/changes/pin-workflows-to-release/proposal.md
+++ b/openspec/changes/pin-workflows-to-release/proposal.md
@@ -1,0 +1,48 @@
+## Why
+
+Consumer workflows (`ci_*`) and one reusable workflow (`reusable_scheduled.yml`) reference
+org-infra reusable workflows at `@main`, creating a mutable, unpinned dependency. With the
+v0.1.0 release now cut, these references should be pinned to the release commit SHA
+(`baf5b2e21e61581b4a3a129795286e8592e6afbb`) to align with the org's existing security
+convention of pinning all `uses:` references to full 40-character SHAs.
+
+## What Changes
+
+- Replace all 9 `@main` reusable-workflow references with
+  `@baf5b2e21e61581b4a3a129795286e8592e6afbb # v0.1.0` across 7 workflow files.
+- Affected files:
+  - `ci_checks.yml` (1 reference)
+  - `ci_compliance.yml` (1 reference)
+  - `ci_crapload.yml` (1 reference)
+  - `ci_dependencies.yml` (2 references)
+  - `ci_scheduled.yml` (1 reference)
+  - `ci_security.yml` (2 references)
+  - `reusable_scheduled.yml` (1 reference)
+
+## Non-goals
+
+- Changing the sync mechanism or adding automated sync triggers.
+- Implementing a major-version floating tag strategy (e.g., `@v1`).
+- Modifying any third-party action pins (already SHA-pinned).
+
+## Capabilities
+
+### New Capabilities
+
+- `workflow-sha-pinning`: Pin org-infra reusable workflow references to release commit
+  SHAs with version comments, matching the existing third-party action pinning convention.
+
+### Modified Capabilities
+
+(none)
+
+## Impact
+
+- **Workflows**: All 7 consumer workflow files and 1 reusable workflow file in
+  `.github/workflows/` are modified.
+- **Downstream repos**: After the next org sync, downstream repos will receive updated
+  `ci_*` files pinned to the v0.1.0 SHA instead of `@main`. This means downstream repos
+  will use a fixed snapshot of reusable workflows until the next release and sync cycle.
+- **Development workflow**: Future changes to reusable workflows will no longer take
+  effect immediately in downstream repos. A new release + sync cycle will be required to
+  propagate reusable workflow changes.

--- a/openspec/changes/pin-workflows-to-release/specs/workflow-sha-pinning/spec.md
+++ b/openspec/changes/pin-workflows-to-release/specs/workflow-sha-pinning/spec.md
@@ -1,0 +1,52 @@
+## ADDED Requirements
+
+### Requirement: Reusable workflow references use immutable SHA pins
+
+All `uses:` references to org-infra reusable workflows SHALL be pinned to a full
+40-character commit SHA corresponding to a tagged release. This applies to both consumer
+workflows and reusable-to-reusable calls within org-infra.
+
+#### Scenario: Consumer workflow references a reusable workflow
+
+- **WHEN** a consumer workflow (`ci_*`) calls a reusable workflow from org-infra
+- **THEN** the `uses:` value SHALL contain a full 40-character commit SHA (not a branch name, short SHA, or mutable tag)
+
+#### Scenario: Reusable workflow references another reusable workflow
+
+- **WHEN** a reusable workflow calls another reusable workflow from org-infra
+- **THEN** the `uses:` value SHALL contain a full 40-character commit SHA (not a branch name, short SHA, or mutable tag)
+
+### Requirement: SHA pins include version comment
+
+Each SHA-pinned reusable workflow reference SHALL include an inline comment identifying
+the corresponding release version for human readability.
+
+#### Scenario: Version comment format
+
+- **WHEN** a workflow file contains a SHA-pinned reusable workflow reference
+- **THEN** the line SHALL include a trailing comment in the format `# v<major>.<minor>.<patch>`
+
+### Requirement: No mutable references to org-infra reusable workflows
+
+No `uses:` reference to an org-infra reusable workflow SHALL use a mutable ref such as
+a branch name or tag. This convention SHALL be maintained across all releases.
+
+#### Scenario: No mutable references in any workflow file
+
+- **WHEN** a reviewer inspects all workflow files in `.github/workflows/`
+- **THEN** zero `uses:` lines referencing `complytime/org-infra` SHALL contain `@main`, `@master`, or any other branch name
+
+#### Scenario: New release requires SHA update
+
+- **WHEN** a new org-infra release is tagged
+- **THEN** consumer workflows SHALL be updated to reference the new release's commit SHA before the next org sync
+
+### Requirement: SHA pins are updated as part of the release process
+
+Updating reusable workflow SHA pins SHALL be a required step in the org-infra release
+process. The pins SHALL always reference the most recent tagged release.
+
+#### Scenario: Release checklist includes pin update
+
+- **WHEN** a maintainer cuts a new org-infra release
+- **THEN** all reusable workflow SHA pins and version comments SHALL be updated to the new release's commit SHA and version before syncing to downstream repos

--- a/openspec/changes/pin-workflows-to-release/tasks.md
+++ b/openspec/changes/pin-workflows-to-release/tasks.md
@@ -1,0 +1,20 @@
+## 1. Pin Consumer Workflows
+
+- [x] 1.1 Update `.github/workflows/ci_checks.yml`: replace `reusable_ci.yml@main` with `reusable_ci.yml@baf5b2e21e61581b4a3a129795286e8592e6afbb # v0.1.0`
+- [x] 1.2 Update `.github/workflows/ci_compliance.yml`: replace `reusable_compliance.yml@main` with `reusable_compliance.yml@baf5b2e21e61581b4a3a129795286e8592e6afbb # v0.1.0`
+- [x] 1.3 Update `.github/workflows/ci_crapload.yml`: replace `reusable_crapload_analysis.yml@main` with `reusable_crapload_analysis.yml@baf5b2e21e61581b4a3a129795286e8592e6afbb # v0.1.0`
+- [x] 1.4 Update `.github/workflows/ci_dependencies.yml`: replace `reusable_deps_reviewer.yml@main` with `reusable_deps_reviewer.yml@baf5b2e21e61581b4a3a129795286e8592e6afbb # v0.1.0`
+- [x] 1.5 Update `.github/workflows/ci_dependencies.yml`: replace `reusable_dependabot_reviewer.yml@main` with `reusable_dependabot_reviewer.yml@baf5b2e21e61581b4a3a129795286e8592e6afbb # v0.1.0`
+- [x] 1.6 Update `.github/workflows/ci_scheduled.yml`: replace `reusable_scheduled.yml@main` with `reusable_scheduled.yml@baf5b2e21e61581b4a3a129795286e8592e6afbb # v0.1.0`
+- [x] 1.7 Update `.github/workflows/ci_security.yml`: replace `reusable_vuln_scan.yml@main` with `reusable_vuln_scan.yml@baf5b2e21e61581b4a3a129795286e8592e6afbb # v0.1.0`
+- [x] 1.8 Update `.github/workflows/ci_security.yml`: replace `reusable_security.yml@main` with `reusable_security.yml@baf5b2e21e61581b4a3a129795286e8592e6afbb # v0.1.0`
+
+## 2. Pin Reusable-to-Reusable Reference
+
+- [x] 2.1 Update `.github/workflows/reusable_scheduled.yml`: replace `reusable_security.yml@main` with `reusable_security.yml@baf5b2e21e61581b4a3a129795286e8592e6afbb # v0.1.0`
+
+## 3. Validation
+
+- [x] 3.1 Run `yamllint` on all modified workflow files to verify YAML validity
+- [x] 3.2 Verify zero `@main` references remain for `complytime/org-infra` reusable workflows across all `.github/workflows/*.yml` files
+- [x] 3.3 Verify all 9 references use the full SHA `baf5b2e21e61581b4a3a129795286e8592e6afbb` with `# v0.1.0` comment


### PR DESCRIPTION
## Summary

This PR proposes a spec for pinning to a digest in the consumable and reusable workflows. The spec outlines a procedure that can be referenced as reusable workflows need to be updated in a secure fashion. [OSPS-BR.05](https://github.com/ossf/security-baseline/blob/a3193603d0f785a6ef8b24f57d583c85321b0aa6/baseline/OSPS-BR.yaml#L371) outlines standardizing build and release pipelines. The procedure for pinning to a sha for releases supports this baseline requirement.

### Key Changes

- Pins all 9 `@main` reusable workflow references to the v0.1.0 release commit SHA (`baf5b2e21e61581b4a3a129795286e8592e6afbb # v0.1.0`), aligning internal workflow pinning with the existing third-party action SHA-pin convention.
- Includes OpenSpec artifacts (proposal, design, spec, tasks) establishing SHA-pinning as a durable release process requirement for all future releases.
- Covers 7 consumer workflows (`ci_*`) and 1 reusable-to-reusable reference (`reusable_scheduled.yml` → `reusable_security.yml`).

## Files Changed

**Workflows (pinned `@main` → `@baf5b2e...bb # v0.1.0`):**
- `ci_checks.yml`, `ci_compliance.yml`, `ci_crapload.yml`, `ci_dependencies.yml` (2 refs), `ci_scheduled.yml`, `ci_security.yml` (2 refs), `reusable_scheduled.yml`

**Spec artifacts:**
- `openspec/changes/pin-workflows-to-release/` — proposal, design, spec (`workflow-sha-pinning`), tasks

## Related Issues
- Supports Issue #162 

## Validation

- yamllint: all 7 modified files pass clean
- Zero `@main` references remain for `complytime/org-infra` reusable workflows
- All 9 references confirmed using full 40-char SHA with `# v0.1.0` comment