### PR TITLE
fix: handle grouped Dependabot PRs in version extraction

### DIFF
--- a/.github/workflows/reusable_dependabot_reviewer.yml
+++ b/.github/workflows/reusable_dependabot_reviewer.yml
@@ -57,6 +57,7 @@ jobs:
         shell: bash
         env:
           DEPENDABOT_SHA: "${{ github.event.pull_request.head.sha }}"
+          PR_TITLE: "${{ github.event.pull_request.title }}"
         run: |
           REF="${DEPENDABOT_SHA:-HEAD}"
           COMMIT_BODY="$(git log -1 --format=%B "$REF" 2>/dev/null || echo "")"
@@ -93,6 +94,42 @@ jobs:
           [[ "${#versions[@]}" -ge 2 ]] && from_version="${versions[0]}"
           [[ "${#versions[@]}" -ge 2 && -z "$to_version" ]] && to_version="${versions[1]}"
           [[ "${#versions[@]}" -eq 1 && -z "$to_version" ]] && to_version="${versions[0]}"
+
+          # Source 2b: Commit body fallback for versions (grouped PRs omit
+          # version numbers from the subject line)
+          if [[ "${#versions[@]}" -lt 2 ]]; then
+            mapfile -t versions < <(echo "$COMMIT_BODY" \
+              | grep -Eo 'from v?[0-9]+\.[0-9]+\.[0-9]+ to v?[0-9]+\.[0-9]+\.[0-9]+' \
+              | grep -Eo 'v?[0-9]+\.[0-9]+\.[0-9]+' | sed 's/^v//' | head -2)
+            [[ "${#versions[@]}" -ge 2 ]] && from_version="${versions[0]}"
+            [[ "${#versions[@]}" -ge 2 && -z "$to_version" ]] && to_version="${versions[1]}"
+            [[ "${#versions[@]}" -ge 2 ]] && echo "Body fallback: from=$from_version to=$to_version"
+          fi
+
+          # Source 2c: PR title fallback for versions
+          if [[ "${#versions[@]}" -lt 2 && -n "$PR_TITLE" ]]; then
+            mapfile -t versions < <(echo "$PR_TITLE" \
+              | grep -Eo 'v?[0-9]+\.[0-9]+\.[0-9]+' | sed 's/^v//' | head -2)
+            [[ "${#versions[@]}" -ge 2 ]] && from_version="${versions[0]}"
+            [[ "${#versions[@]}" -ge 2 && -z "$to_version" ]] && to_version="${versions[1]}"
+            [[ "${#versions[@]}" -ge 2 ]] && echo "PR title fallback: from=$from_version to=$to_version"
+          fi
+
+          # Derive update_type from versions when metadata is absent
+          if [[ -z "$update_type" && -n "$from_version" && -n "$to_version" ]]; then
+            _from_major=$(echo "$from_version" | cut -d. -f1)
+            _from_minor=$(echo "$from_version" | cut -d. -f2)
+            _to_major=$(echo "$to_version" | cut -d. -f1)
+            _to_minor=$(echo "$to_version" | cut -d. -f2)
+            if [[ "$_from_major" -ne "$_to_major" ]]; then
+              update_type="version-update:semver-major"
+            elif [[ "$_from_minor" -ne "$_to_minor" ]]; then
+              update_type="version-update:semver-minor"
+            else
+              update_type="version-update:semver-patch"
+            fi
+            echo "Derived update_type: $update_type"
+          fi
 
           # Source 3: Diff enrichment (SHA-pinned refs for usage search only)
           DIFF="$(git diff "$REF^..$REF" 2>/dev/null || echo "")"

--- a/openspec/changes/fix-grouped-dependabot-version-detection/.openspec.yaml
+++ b/openspec/changes/fix-grouped-dependabot-version-detection/.openspec.yaml
@@ -1,0 +1,2 @@
+schema: spec-driven
+created: 2026-04-22

--- a/openspec/changes/fix-grouped-dependabot-version-detection/design.md
+++ b/openspec/changes/fix-grouped-dependabot-version-detection/design.md
@@ -1,0 +1,117 @@
+## Context
+
+The `reusable_dependabot_reviewer.yml` workflow extracts dependency information
+from Dependabot commits using a three-source pipeline:
+
+1. **Commit metadata** -- parses the `updated-dependencies` YAML block for
+   `dependency-name`, `dependency-version`, and `update-type`.
+2. **Commit subject** -- regex extracts semver patterns (`v?N.N.N`) for
+   `from_version` and `to_version`.
+3. **Diff enrichment** -- extracts SHA-pinned action refs for usage search.
+
+The "Classify Risk" step then uses two paths:
+- **Primary**: `update-type` from metadata (e.g., `semver-minor`).
+- **Fallback**: Compares `from_version` vs `to_version` numerically.
+
+**Grouped Dependabot PRs** break both paths because they:
+- Omit `update-type` from the metadata block (only include `dependency-group`).
+- Use a subject like `bump lxml in the pip group across 1 directory` with no
+  version numbers.
+
+The version data is available in the commit body text
+(`Updates \`lxml\` from 6.0.0 to 6.1.0`) and in the PR title, but neither
+source is currently consulted.
+
+## Goals / Non-Goals
+
+**Goals:**
+
+- Populate `from_version` and `to_version` for grouped Dependabot PRs so the
+  semver comparison fallback in "Classify Risk" works correctly.
+- Derive `update_type` from extracted versions when the metadata field is absent.
+- Preserve the existing extraction priority: commit metadata remains the primary
+  source; new fallbacks only activate when existing sources yield incomplete data.
+
+**Non-Goals:**
+
+- Changing the risk classification thresholds or auto-approval criteria.
+- Supporting extraction of multiple dependencies from a single grouped PR
+  (existing first-dependency heuristic is retained).
+- Migrating to a different extraction approach (e.g., GitHub API for PR metadata
+  instead of commit parsing).
+
+## Decisions
+
+### Decision 1: Add commit body version extraction as second fallback
+
+**Choice**: When the commit subject yields fewer than two semver matches, scan
+`COMMIT_BODY` for the pattern `from v?N.N.N to v?N.N.N`.
+
+**Alternatives considered**:
+- **Use PR title only** (via `github.event.pull_request.title`): Simpler, but
+  the PR title is not available in all workflow trigger contexts (e.g., manual
+  re-runs or `workflow_dispatch`). The commit body is always available once the
+  repo is checked out.
+- **Parse the `dependency-group` metadata field** to infer update type: Does not
+  help because grouped metadata still omits per-dependency version ranges.
+
+**Rationale**: The commit body is always accessible after checkout and contains
+machine-generated text from Dependabot with a stable format
+(`Updates \`<name>\` from <old> to <new>`). This makes it a reliable and
+self-contained fallback.
+
+### Decision 2: Add PR title as a third fallback source
+
+**Choice**: If neither the commit subject nor body yield version numbers, fall
+back to `github.event.pull_request.title` which uses the format
+`bump <name> from X.Y.Z to A.B.C in the <group>`.
+
+**Alternatives considered**:
+- **Omit PR title fallback**: Fewer code paths to maintain. Rejected because the
+  PR title contains version info in scenarios where the commit body format may
+  differ (e.g., multi-dependency grouped PRs).
+- **Use GitHub API to fetch PR details**: Over-engineered for this use case; the
+  PR title is already available in the event payload.
+
+**Rationale**: Defense in depth. The PR title is available at no extra cost from
+the event context and covers edge cases where the commit body format varies.
+
+### Decision 3: Derive update_type from versions when metadata is absent
+
+**Choice**: After extracting `from_version` and `to_version`, if `update_type`
+is still empty, compute it by comparing major/minor/patch components and set it
+to `semver-patch`, `semver-minor`, or `semver-major`.
+
+**Alternatives considered**:
+- **Only fix the fallback path in "Classify Risk"**: The fallback already
+  compares versions, so populating `from_version` alone would fix classification.
+  However, this leaves `UPDATE_TYPE` empty in `GITHUB_ENV`, meaning downstream
+  consumers (PR comment, future steps) cannot reference it.
+
+**Rationale**: Computing `update_type` keeps the data model complete for all
+downstream consumers, not just the classification step. The computation is
+trivial and mirrors the existing logic in "Classify Risk."
+
+## Risks / Trade-offs
+
+- **[Risk] Commit body format changes**: Dependabot could change the body text
+  format in future versions. **Mitigation**: The regex is conservative (looks for
+  `from v?N.N.N to v?N.N.N` anywhere in the body) and the fallback chain means
+  other sources would compensate. The existing metadata extraction has the same
+  dependency on Dependabot's format.
+
+- **[Risk] PR title not available in non-PR contexts**: If the workflow is
+  triggered via `workflow_dispatch` or re-run, the PR title may be empty.
+  **Mitigation**: The PR title is the third and final fallback; commit body is
+  tried first. Empty PR title is handled by the existing guard
+  (`[[ -z "$to_version" ]]`).
+
+- **[Trade-off] Slightly more complex extraction logic**: Three version sources
+  instead of one. **Mitigation**: The fallback chain is linear and
+  well-commented. Each source is tried only when previous sources yield
+  incomplete data, keeping the fast path unchanged.
+
+## Open Questions
+
+_None -- the approach is straightforward and all data sources are verified from
+the failing CI job._

--- a/openspec/changes/fix-grouped-dependabot-version-detection/proposal.md
+++ b/openspec/changes/fix-grouped-dependabot-version-detection/proposal.md
@@ -1,0 +1,57 @@
+## Why
+
+The `reusable_dependabot_reviewer.yml` workflow fails to detect version
+information for **grouped Dependabot PRs**, causing all grouped updates to be
+classified as "high risk" regardless of the actual semver change. This happens
+because grouped Dependabot commits (1) omit `update-type` from the
+`updated-dependencies` metadata block, and (2) omit version numbers from the
+commit subject line. The version data exists in the commit body text and PR title
+but the workflow never consults either source, leaving `from_version` and
+`update_type` empty and triggering the default high-risk fallback.
+
+This directly violates FR-015 (fallback chain) and Assumption 12 (graceful
+handling of missing metadata) from spec 006-robust-dependabot-approval, and
+prevents safe grouped patch/minor updates from being auto-approved.
+
+## What Changes
+
+- Add a **commit body fallback** to the version extraction pipeline: when the
+  commit subject yields fewer than two semver matches, scan `COMMIT_BODY` for
+  the pattern `from <version> to <version>` to populate `from_version`.
+- Add a **PR title fallback** as a final extraction source: use
+  `github.event.pull_request.title` when neither the commit subject nor body
+  yield version numbers.
+- Compute `update_type` from extracted `from_version` and `to_version` when the
+  commit metadata lacks `update-type`, so the primary classification path can
+  still function.
+
+## Non-goals
+
+- Changing the auto-approval criteria or risk thresholds (those are correct as
+  designed in 006).
+- Supporting multi-dependency grouped PRs where each dependency has a different
+  update type (the existing "first dependency" heuristic is retained).
+- Refactoring the entire extraction pipeline (this is a targeted fix to the
+  existing fallback chain).
+
+## Capabilities
+
+### New Capabilities
+
+_None._
+
+### Modified Capabilities
+
+- `dependabot-review`: The version extraction fallback chain in the reusable
+  dependabot reviewer workflow is extended to handle grouped Dependabot commit
+  formats that omit `update-type` and version numbers from the subject line.
+
+## Impact
+
+- **Workflow**: `reusable_dependabot_reviewer.yml` -- the "Get Dependency
+  Information" and "Classify Risk Based on Semantic Version" steps are modified.
+- **Downstream**: All org repositories consuming this reusable workflow via
+  `sync-config.yml` will receive the fix automatically on next sync.
+- **Risk**: Low. Changes are additive fallbacks that only activate when existing
+  extraction sources yield incomplete data. The existing primary extraction paths
+  (commit metadata, subject regex) are unchanged.

--- a/openspec/changes/fix-grouped-dependabot-version-detection/specs/dependabot-review/spec.md
+++ b/openspec/changes/fix-grouped-dependabot-version-detection/specs/dependabot-review/spec.md
@@ -1,0 +1,101 @@
+## ADDED Requirements
+
+### Requirement: Commit body version extraction fallback
+
+The version extraction pipeline SHALL scan the full commit body for version
+numbers when the commit subject yields fewer than two semver matches. The system
+SHALL extract versions from patterns matching `from <version> to <version>` in
+the commit body text.
+
+#### Scenario: Grouped Dependabot PR with versions in commit body only
+
+- **WHEN** a grouped Dependabot commit has a subject without version numbers
+  (e.g., `bump lxml in the pip group across 1 directory`) and the commit body
+  contains `Updates lxml from 6.0.0 to 6.1.0`
+- **THEN** the extraction step SHALL populate `from_version` as `6.0.0` and
+  `to_version` as `6.1.0`
+
+#### Scenario: Non-grouped Dependabot PR with versions in subject
+
+- **WHEN** a non-grouped Dependabot commit has version numbers in the subject
+  (e.g., `bump lxml from 6.0.0 to 6.1.0`)
+- **THEN** the commit body fallback SHALL NOT be used and the versions SHALL be
+  extracted from the subject as before
+
+#### Scenario: No versions in subject or body
+
+- **WHEN** neither the commit subject nor the commit body contain recognizable
+  semver version numbers
+- **THEN** the extraction step SHALL proceed to the next fallback source without
+  error
+
+### Requirement: PR title version extraction fallback
+
+The version extraction pipeline SHALL use the pull request title as a final
+fallback source for version numbers when neither the commit subject nor the
+commit body yield at least two semver matches.
+
+#### Scenario: Versions available only in PR title
+
+- **WHEN** the commit subject and body do not contain semver version numbers and
+  the PR title contains `from 6.0.0 to 6.1.0`
+- **THEN** the extraction step SHALL populate `from_version` as `6.0.0` and
+  `to_version` as `6.1.0` from the PR title
+
+#### Scenario: PR title unavailable
+
+- **WHEN** the PR title is empty or not available in the event context
+- **THEN** the extraction step SHALL continue without error and leave version
+  fields unpopulated if no prior source provided them
+
+### Requirement: Derived update type from extracted versions
+
+The extraction step SHALL compute `update_type` from `from_version` and
+`to_version` when the commit metadata does not include an `update-type` field.
+The computation SHALL compare major, minor, and patch components to classify the
+update as `semver-patch`, `semver-minor`, or `semver-major`.
+
+#### Scenario: Grouped PR with no update-type metadata
+
+- **WHEN** a Dependabot commit metadata block omits the `update-type` field and
+  `from_version` is `6.0.0` and `to_version` is `6.1.0`
+- **THEN** the extraction step SHALL derive `update_type` as
+  `version-update:semver-minor`
+
+#### Scenario: Non-grouped PR with update-type in metadata
+
+- **WHEN** a Dependabot commit metadata block includes
+  `update-type: version-update:semver-patch`
+- **THEN** the extraction step SHALL use the metadata value and SHALL NOT
+  override it with a derived value
+
+#### Scenario: No versions available for derivation
+
+- **WHEN** both `from_version` and `to_version` are empty or unknown
+- **THEN** the extraction step SHALL leave `update_type` empty and downstream
+  classification SHALL default to high risk
+
+### Requirement: Risk classification with derived data
+
+The risk classification step SHALL produce correct risk levels for grouped
+Dependabot PRs by using either the metadata `update-type` or the derived
+`update_type` from the extraction step, falling back to semver comparison of
+`from_version` and `to_version`.
+
+#### Scenario: Minor update correctly classified from derived data
+
+- **WHEN** a grouped Dependabot PR updates a dependency from `6.0.0` to `6.1.0`
+  and the commit metadata omits `update-type`
+- **THEN** the risk classification SHALL be `medium` (not `high`)
+
+#### Scenario: Patch update correctly classified from derived data
+
+- **WHEN** a grouped Dependabot PR updates a dependency from `6.0.0` to `6.0.1`
+  and the commit metadata omits `update-type`
+- **THEN** the risk classification SHALL be `low`
+
+#### Scenario: Major update correctly classified from derived data
+
+- **WHEN** a grouped Dependabot PR updates a dependency from `5.2.0` to `6.0.0`
+  and the commit metadata omits `update-type`
+- **THEN** the risk classification SHALL be `high`

--- a/openspec/changes/fix-grouped-dependabot-version-detection/tasks.md
+++ b/openspec/changes/fix-grouped-dependabot-version-detection/tasks.md
@@ -1,0 +1,35 @@
+## 1. Commit Body Version Extraction Fallback
+
+- [x] 1.1 In `.github/workflows/reusable_dependabot_reviewer.yml`, in the "Get
+  Dependency Information" step, add a commit body fallback block after the
+  existing subject-line version extraction (line 95). When `versions` array has
+  fewer than 2 entries, scan `COMMIT_BODY` for the pattern
+  `from v?N.N.N to v?N.N.N` and re-populate the `versions` array.
+
+## 2. PR Title Version Extraction Fallback
+
+- [x] 2.1 In `.github/workflows/reusable_dependabot_reviewer.yml`, in the "Get
+  Dependency Information" step, add a PR title fallback block after the commit
+  body fallback. Pass `github.event.pull_request.title` as an environment
+  variable (`PR_TITLE`). When `versions` array still has fewer than 2 entries
+  after the body fallback, scan `PR_TITLE` with the same semver regex.
+
+## 3. Derived Update Type
+
+- [x] 3.1 In `.github/workflows/reusable_dependabot_reviewer.yml`, in the "Get
+  Dependency Information" step, after all version extraction is complete, add
+  logic to derive `update_type` from `from_version` and `to_version` when
+  `update_type` is empty. Compare major/minor/patch components and set
+  `update_type` to `version-update:semver-patch`, `version-update:semver-minor`,
+  or `version-update:semver-major`.
+
+## 4. Validation
+
+- [x] 4.1 Run `make lint` to verify the modified workflow passes yamllint and
+  all other linters with zero issues.
+- [x] 4.2 Manually verify the extraction logic by tracing through the grouped
+  Dependabot commit from PR complytime/complyscribe#836 (subject:
+  `bump lxml in the pip group across 1 directory`, body: `Updates lxml from
+  6.0.0 to 6.1.0`) and confirming the expected outputs: `from_version=6.0.0`,
+  `to_version=6.1.0`, `update_type=version-update:semver-minor`,
+  `risk_level=medium`.


### PR DESCRIPTION
## Summary

Grouped Dependabot commits (those using dependency groups like `pip group`) omit
`update-type` from the commit metadata and version numbers from the commit
subject line. This causes the `reusable_dependabot_reviewer.yml` workflow to
default all grouped updates to "high risk" regardless of the actual semver
change, preventing safe patch/minor updates from being auto-approved.

This PR extends the version extraction fallback chain in the "Get Dependency
Information" step with three additions:

- **Commit body fallback**: When the subject line yields fewer than two semver
  matches, scan `COMMIT_BODY` for `from X.Y.Z to A.B.C` patterns (Dependabot
  always includes this in the body text for grouped PRs).
- **PR title fallback**: As a final source, scan the PR title via the
  `github.event.pull_request.title` event payload.
- **Derived update_type**: When commit metadata lacks `update-type`, compute it
  from the extracted `from_version` and `to_version` by comparing major/minor/patch
  components.

All changes are additive fallbacks that only activate when existing extraction
sources yield incomplete data. The existing primary paths (commit metadata,
subject regex) are unchanged.

## Related Issues

- Observed on complytime/complyscribe#836 (`lxml` 6.0.0 -> 6.1.0 classified as
  high risk instead of medium).
- Addresses a gap in FR-015 (fallback chain) from spec 006-robust-dependabot-approval.

## Review Hints

- The core change is in `.github/workflows/reusable_dependabot_reviewer.yml`
  lines 98-132 (three new blocks in the "Get Dependency Information" step).
  The rest of the workflow is untouched.

- To trace the fix against the real failure, compare the [CI job logs](https://github.com/complytime/complyscribe/actions/runs/24750809393/job/72413279483)
  (which show `No version info available. Defaulting to high risk.`) with the
  new fallback chain that would produce `from_version=6.0.0`, `to_version=6.1.0`,
  `update_type=version-update:semver-minor`, `risk_level=medium`.

- The `openspec/changes/fix-grouped-dependabot-version-detection/` directory
  contains the full proposal, design, specs, and tasks artifacts for this change.