### PR TITLE
feat: add regression-epsilon input to reusable_crapload_analysis.yml

### DIFF
--- a/.github/workflows/reusable_crapload_analysis.yml
+++ b/.github/workflows/reusable_crapload_analysis.yml
@@ -42,8 +42,8 @@ on:
           Differences within this tolerance are treated as noise
           from platform, toolchain, or test-ordering variance.
         required: false
-        type: string
-        default: '0.5'
+        type: number
+        default: 0.5
     outputs:
       status:
         description: 'pass or fail'
@@ -152,7 +152,7 @@ jobs:
           BASELINE="${{ inputs.baseline-file }}"
           CURRENT="/tmp/crapload-current.json"
           NEW_FUNC_THRESHOLD=${{ inputs.new-function-threshold }}
-          EPSILON=${{ inputs.regression-epsilon }}
+          EPSILON="${{ inputs.regression-epsilon }}"
           REGRESSIONS=""
           IMPROVEMENTS=""
           NEW_FUNCTIONS=""

--- a/.github/workflows/reusable_crapload_analysis.yml
+++ b/.github/workflows/reusable_crapload_analysis.yml
@@ -36,6 +36,14 @@ on:
         description: 'CRAP score ceiling for new functions with no baseline entry'
         type: number
         default: 30
+      regression-epsilon:
+        description: >-
+          Minimum CRAP/GazeCRAP score delta to flag a regression.
+          Differences within this tolerance are treated as noise
+          from platform, toolchain, or test-ordering variance.
+        required: false
+        type: string
+        default: '0.5'
     outputs:
       status:
         description: 'pass or fail'
@@ -144,6 +152,7 @@ jobs:
           BASELINE="${{ inputs.baseline-file }}"
           CURRENT="/tmp/crapload-current.json"
           NEW_FUNC_THRESHOLD=${{ inputs.new-function-threshold }}
+          EPSILON=${{ inputs.regression-epsilon }}
           REGRESSIONS=""
           IMPROVEMENTS=""
           NEW_FUNCTIONS=""
@@ -192,14 +201,14 @@ jobs:
               has_regression=false
               has_improvement=false
 
-              if [ "$(echo "$crap > $b_crap" | bc -l)" = "1" ]; then
+              if [ "$(echo "$crap - $b_crap > $EPSILON" | bc -l)" = "1" ]; then
                 has_regression=true
-              elif [ "$(echo "$crap < $b_crap" | bc -l)" = "1" ]; then
+              elif [ "$(echo "$b_crap - $crap > $EPSILON" | bc -l)" = "1" ]; then
                 has_improvement=true
               fi
-              if [ "$(echo "$gaze_crap > $b_gaze" | bc -l)" = "1" ]; then
+              if [ "$(echo "$gaze_crap - $b_gaze > $EPSILON" | bc -l)" = "1" ]; then
                 has_regression=true
-              elif [ "$(echo "$gaze_crap < $b_gaze" | bc -l)" = "1" ]; then
+              elif [ "$(echo "$b_gaze - $gaze_crap > $EPSILON" | bc -l)" = "1" ]; then
                 has_improvement=true
               fi
 

--- a/specs/001-crapload-workflow/data-model.md
+++ b/specs/001-crapload-workflow/data-model.md
@@ -14,6 +14,7 @@ This feature does not introduce a traditional data model. The relevant data stru
 | packages | string | no | `./...` | Go packages to analyze |
 | coverprofile | string | no | `coverage.out` | Path to coverage profile |
 | new-function-threshold | number | no | `30` | CRAP score ceiling for new functions |
+| regression-epsilon | string | no | `0.5` | Minimum score delta to flag a regression |
 | post-comment | boolean | no | `true` | Whether to post/update PR comment |
 
 ## Workflow Outputs

--- a/specs/001-crapload-workflow/data-model.md
+++ b/specs/001-crapload-workflow/data-model.md
@@ -14,7 +14,7 @@ This feature does not introduce a traditional data model. The relevant data stru
 | packages | string | no | `./...` | Go packages to analyze |
 | coverprofile | string | no | `coverage.out` | Path to coverage profile |
 | new-function-threshold | number | no | `30` | CRAP score ceiling for new functions |
-| regression-epsilon | string | no | `0.5` | Minimum score delta to flag a regression |
+| regression-epsilon | number | no | `0.5` | Minimum score delta to flag a regression |
 | post-comment | boolean | no | `true` | Whether to post/update PR comment |
 
 ## Workflow Outputs

--- a/specs/001-crapload-workflow/spec.md
+++ b/specs/001-crapload-workflow/spec.md
@@ -70,7 +70,7 @@ The org-infra sync mechanism distributes a consumer workflow template to Go repo
 - **FR-004**: The workflow MUST generate a coverage profile, run CRAP analysis, and compare results against a committed baseline file when available.
 - **FR-005**: The workflow MUST post or update a single PR comment (idempotent) with a summary table including metrics such as average complexity, coverage, CRAP scores, regressions, improvements, and new functions.
 - **FR-006**: The workflow MUST fail the check when regressions or new-function threshold violations are detected.
-- **FR-007**: The workflow MUST support configurable inputs for Go version detection, analysis tool version, baseline file path, target packages, coverage profile path, new-function threshold, and PR comment toggle.
+- **FR-007**: The workflow MUST support configurable inputs for Go version detection, analysis tool version, baseline file path, target packages, coverage profile path, new-function threshold, regression epsilon tolerance, and PR comment toggle.
 - **FR-008**: The consumer workflow template MUST be added to the org-infra sync configuration to distribute it to Go repositories, excluding non-Go repositories.
 - **FR-009**: The workflow MUST upload analysis artifacts for retention.
 - **FR-010**: The workflow MUST follow the Principle of Least Privilege, requesting only the minimum permissions required for reading source code and writing PR comments.


### PR DESCRIPTION
## Summary

- Add configurable `regression-epsilon` input (default `0.5`) to `reusable_crapload_analysis.yml` that sets the minimum CRAP/GazeCRAP score delta required to flag a regression
- Replace exact float comparison (`$crap > $b_crap`) with epsilon-tolerant comparison (`$crap - $b_crap > $EPSILON`) for both CRAP and GazeCRAP scores, applied symmetrically to regressions and improvements
- Update spec documentation (`spec.md`, `data-model.md`) to reflect the new input

## Motivation

Exact float comparison causes false regressions when:
1. The baseline is generated on a different platform (e.g., macOS ARM) than CI (Ubuntu x86_64)
2. Go toolchain patch updates change coverage instrumentation
3. Non-deterministic test ordering causes minor coverage fluctuations

A default epsilon of `0.5` absorbs this noise without masking real regressions. Setting epsilon to `0` recovers the previous exact-comparison behavior.

Closes #223