### PR TITLE
fix: add mode: subagent to 5 agent files showing as primary modes

### DIFF
--- a/.opencode/agents/background-worker.md
+++ b/.opencode/agents/background-worker.md
@@ -1,7 +1,8 @@
 ---
-name: background-worker
 description: Runs background tasks without MCP tool access.
+mode: subagent
 ---
+<!-- scaffolded by uf vdev -->
 
 # Background Worker
 

--- a/.opencode/agents/coordinator.md
+++ b/.opencode/agents/coordinator.md
@@ -1,7 +1,8 @@
 ---
-name: coordinator
 description: Orchestrates forge coordination and supervises worker agents.
+mode: subagent
 ---
+<!-- scaffolded by uf vdev -->
 
 # Forge Coordinator
 

--- a/.opencode/agents/gaze-reporter.md
+++ b/.opencode/agents/gaze-reporter.md
@@ -5,6 +5,7 @@ description: >
   metrics, side effect classifications, and overall project health.
   Supports three modes: crap (CRAP scores only), quality (test
   quality metrics only), and full (comprehensive health assessment).
+mode: subagent
 tools:
   read: true
   bash: true

--- a/.opencode/agents/gaze-test-generator.md
+++ b/.opencode/agents/gaze-test-generator.md
@@ -5,6 +5,7 @@ description: >
   complete, compilable Go test functions, improve documentation for
   classifier visibility, and restructure assertions for mapper
   accuracy. Works on any Go project gaze can analyze.
+mode: subagent
 tools:
   read: true
   bash: true

--- a/.opencode/agents/worker.md
+++ b/.opencode/agents/worker.md
@@ -1,7 +1,8 @@
 ---
-name: worker
 description: Executes a single subtask with file reservations and progress reporting.
+mode: subagent
 ---
+<!-- scaffolded by uf vdev -->
 
 # Forge Worker
 


### PR DESCRIPTION
## Summary

- Adds `mode: subagent` to 5 agent files (`coordinator.md`, `worker.md`, `background-worker.md`, `gaze-reporter.md`, `gaze-test-generator.md`) that were missing it, causing them to appear as primary modes in the OpenCode Tab cycle
- Removes redundant `name:` fields from forge agents (OpenCode derives agent name from filename)
- Adds `<!-- scaffolded by uf vdev -->` comments to forge agents for consistency with other uf-scaffolded agents

## Root Cause

OpenCode defaults agents without an explicit `mode:` to `all`, which registers them as both primary agents (Tab-cyclable) and subagents. The upstream `uf init` and `gaze init` CLIs scaffold these files without the `mode: subagent` field.

## Impact

After this fix, the Tab key cycles only through the built-in **Build** and **Plan** modes. All 17 custom agents are subagents only, invocable via `@` mention or the Task tool.