### PR TITLE
fix: quote new-function-threshold expression interpolation

### DIFF
--- a/.github/workflows/reusable_crapload_analysis.yml
+++ b/.github/workflows/reusable_crapload_analysis.yml
@@ -151,7 +151,7 @@ jobs:
         run: |
           BASELINE="${{ inputs.baseline-file }}"
           CURRENT="/tmp/crapload-current.json"
-          NEW_FUNC_THRESHOLD=${{ inputs.new-function-threshold }}
+          NEW_FUNC_THRESHOLD="${{ inputs.new-function-threshold }}"
           EPSILON="${{ inputs.regression-epsilon }}"
           REGRESSIONS=""
           IMPROVEMENTS=""


### PR DESCRIPTION
## Summary

- Quotes `${{ inputs.new-function-threshold }}` shell variable assignment to match the defensive quoting pattern used by `BASELINE` and `EPSILON` on adjacent lines
- Addresses the pre-existing SC-002 (unquoted expression interpolation) finding noted in [PR #224 review](https://github.com/complytime/org-infra/pull/224#discussion_r2625741610) as "outside this PR's scope"

## Details

Line 154 of `reusable_crapload_analysis.yml` assigned `NEW_FUNC_THRESHOLD` without quotes:

```diff
-          NEW_FUNC_THRESHOLD=${{ inputs.new-function-threshold }}
+          NEW_FUNC_THRESHOLD="${{ inputs.new-function-threshold }}"
```

While `workflow_call` inputs are caller-controlled, quoting is a defensive best practice and brings this line in line with the pattern established when the `EPSILON` quoting was fixed in PR #224.