### PR TITLE
fix: quote new-function-threshold expression interpolation

### DIFF
--- a/.github/workflows/reusable_crapload_analysis.yml
+++ b/.github/workflows/reusable_crapload_analysis.yml
@@ -151,7 +151,7 @@ jobs:
         run: |
           BASELINE="${{ inputs.baseline-file }}"
           CURRENT="/tmp/crapload-current.json"
-          NEW_FUNC_THRESHOLD=${{ inputs.new-function-threshold }}
+          NEW_FUNC_THRESHOLD="${{ inputs.new-function-threshold }}"
           EPSILON="${{ inputs.regression-epsilon }}"
           REGRESSIONS=""
           IMPROVEMENTS=""

--- a/openspec/changes/quote-crapload-interpolation/.openspec.yaml
+++ b/openspec/changes/quote-crapload-interpolation/.openspec.yaml
@@ -1,0 +1,2 @@
+schema: spec-driven
+created: 2026-05-06

--- a/openspec/changes/quote-crapload-interpolation/design.md
+++ b/openspec/changes/quote-crapload-interpolation/design.md
@@ -1,0 +1,41 @@
+## Context
+
+`reusable_crapload_analysis.yml` runs CRAP score regression detection across org repos. In the `compare` step, shell variables are assigned from `workflow_call` inputs. Two of the three input-derived variables (`BASELINE`, `EPSILON`) use defensive quoting. The third (`NEW_FUNC_THRESHOLD`) does not.
+
+This inconsistency was flagged as a pre-existing finding during the PR #224 review (convention pack SC-002 — external input validation) but was outside that PR's scope. No follow-up was created.
+
+## Goals / Non-Goals
+
+**Goals:**
+
+- Quote `NEW_FUNC_THRESHOLD=${{ inputs.new-function-threshold }}` to match the established pattern
+- Eliminate the last unquoted input interpolation in the workflow
+
+**Non-Goals:**
+
+- Auditing other reusable workflows for similar patterns
+- Changing input types, defaults, or workflow behavior
+- Refactoring the shell script structure
+
+## Decisions
+
+### Decision 1: Add double quotes around the interpolation
+
+**Change:**
+```diff
+-          NEW_FUNC_THRESHOLD=${{ inputs.new-function-threshold }}
++          NEW_FUNC_THRESHOLD="${{ inputs.new-function-threshold }}"
+```
+
+**Alternative A considered:** Leave as-is since the input is `type: number` and caller-controlled.
+
+**Rejected because:** Inconsistency with adjacent lines (`BASELINE` and `EPSILON` are quoted). Defensive quoting is a convention in this repo and costs nothing. The PR #224 reviewer specifically flagged this for follow-up.
+
+**Alternative B considered:** Refactor to use `env:` block indirection to pass inputs to the shell (as established in the `release-workflow` spec, per GitHub Security Lab guidance).
+
+**Rejected because:** The inputs are `workflow_call` caller-controlled (not from untrusted sources like PR titles), and the quoting fix achieves consistency with adjacent lines at minimal cost. A broader refactor to `env:` blocks could be a separate change.
+
+## Risks / Trade-offs
+
+- **Risk:** None. Quoting a numeric shell variable assignment is a behavioral no-op.
+- **Trade-off:** None. The change is one character pair (`"..."`) on a single line.

--- a/openspec/changes/quote-crapload-interpolation/proposal.md
+++ b/openspec/changes/quote-crapload-interpolation/proposal.md
@@ -1,0 +1,49 @@
+## Why
+
+`reusable_crapload_analysis.yml` has an unquoted `${{ inputs.new-function-threshold }}` shell variable assignment. This was identified as a pre-existing finding during the PR #224 review (convention pack SC-002 — external input validation), outside that PR's scope. No follow-up was created to address it.
+
+The adjacent `BASELINE` and `EPSILON` assignments already use defensive quoting — this is the last remaining unquoted input interpolation in the workflow. While `workflow_call` inputs are caller-controlled and not directly exploitable, unquoted interpolation is inconsistent with the established pattern and violates the project's defensive security conventions.
+
+## What Changes
+
+- Quote the `NEW_FUNC_THRESHOLD` shell variable assignment in `reusable_crapload_analysis.yml` to match the quoting pattern used by `BASELINE` and `EPSILON`
+
+## Capabilities
+
+### New Capabilities
+
+_None — this is a single-line defensive fix, not a new capability._
+
+### Modified Capabilities
+
+_None — no spec-level behavior changes._
+
+### Removed Capabilities
+
+_None._
+
+## Impact
+
+- **File**: `.github/workflows/reusable_crapload_analysis.yml` (line 154)
+- **Downstream**: This reusable workflow is referenced cross-repository by consumer workflows (e.g., `ci_crapload.yml`) in all org repos. The fix propagates automatically on their next workflow run. Adding quotes around a numeric value does not change shell behavior, so no downstream breakage is expected
+- **References**: PR #224 review comment by @hbraswelrh — [link](https://github.com/complytime/org-infra/pull/224#discussion_r2625741610)
+
+## Constitution Alignment
+
+Assessed against the Unbound Force org constitution.
+
+### I. Autonomous Collaboration
+
+**Assessment**: N/A — No change to artifact-based communication or self-describing outputs.
+
+### II. Composability First
+
+**Assessment**: N/A — No new dependencies or coupling introduced.
+
+### III. Observable Quality
+
+**Assessment**: PASS — Eliminates an inconsistency in defensive quoting, improving code hygiene.
+
+### IV. Testability
+
+**Assessment**: N/A — Behavioral no-op; workflow outputs remain identical.

--- a/openspec/changes/quote-crapload-interpolation/specs/shell-interpolation-safety/spec.md
+++ b/openspec/changes/quote-crapload-interpolation/specs/shell-interpolation-safety/spec.md
@@ -1,0 +1,19 @@
+## ADDED Requirements
+
+### Requirement: Input interpolations in shell assignments are quoted
+
+All `${{ inputs.* }}` expressions assigned to shell variables in `reusable_crapload_analysis.yml` `run:` blocks SHALL be wrapped in double quotes to prevent word splitting and globbing.
+
+> **Note**: This requirement addresses the known violation in `reusable_crapload_analysis.yml`. The same quoting convention SHOULD be followed across all reusable workflows. For new workflows, the preferred pattern is `env:` block indirection (per the `release-workflow` spec) rather than inline `${{ }}` interpolation.
+
+#### Scenario: Numeric input assigned to shell variable
+
+- **GIVEN** a reusable workflow with a `run:` block that assigns `workflow_call` inputs to shell variables
+- **WHEN** a `workflow_call` input of type `number` is assigned to a shell variable
+- **THEN** the assignment SHALL use double quotes around the interpolation (e.g., `VAR="${{ inputs.name }}"`)
+
+#### Scenario: Consistency across adjacent assignments
+
+- **GIVEN** a `run:` block containing multiple input-derived variable assignments
+- **WHEN** multiple input-derived variables are assigned in the same `run:` block
+- **THEN** all assignments SHALL follow the same quoting pattern

--- a/openspec/changes/quote-crapload-interpolation/tasks.md
+++ b/openspec/changes/quote-crapload-interpolation/tasks.md
@@ -1,0 +1,10 @@
+## 1. Fix Unquoted Interpolation
+
+- [x] 1.1 Add double quotes around `${{ inputs.new-function-threshold }}` on line 154 of `.github/workflows/reusable_crapload_analysis.yml`
+
+## 2. Validation
+
+> **Test strategy**: YAML workflow files have no unit test framework. Coverage for this change relies on `yamllint` (syntax validation), `grep`-based verification (quoting consistency), and code review. Regression protection depends on review conventions.
+
+- [x] 2.1 Run `yamllint` on `.github/workflows/reusable_crapload_analysis.yml` to confirm valid YAML
+- [x] 2.2 Verify all 3 `${{ inputs.* }}` shell variable assignments (`BASELINE`, `NEW_FUNC_THRESHOLD`, `EPSILON`) in `.github/workflows/reusable_crapload_analysis.yml` use double-quoted interpolation


### PR DESCRIPTION
## Summary

- Quotes `${{ inputs.new-function-threshold }}` shell variable assignment to match the defensive quoting pattern used by `BASELINE` and `EPSILON` on adjacent lines
- Addresses the pre-existing convention pack SC-002 (external input validation) finding noted in [PR #224 review](https://github.com/complytime/org-infra/pull/224#discussion_r2625741610) as "outside this PR's scope"
- Includes full OpenSpec change artifacts (`openspec/changes/quote-crapload-interpolation/`)

## Details

Line 154 of `reusable_crapload_analysis.yml` assigned `NEW_FUNC_THRESHOLD` without quotes:

```diff
-          NEW_FUNC_THRESHOLD=${{ inputs.new-function-threshold }}
+          NEW_FUNC_THRESHOLD="${{ inputs.new-function-threshold }}"
```

While `workflow_call` inputs are caller-controlled, quoting is a defensive best practice and brings this line in line with the pattern established when the `EPSILON` quoting was fixed in PR #224.

## OpenSpec Artifacts

The change went through the full spec-driven OpenSpec workflow and review council:

- **Proposal**: Motivation, impact, constitution alignment
- **Design**: Decision with two alternatives considered (leave as-is, `env:` block refactor) and rejection rationale
- **Spec**: `shell-interpolation-safety` — requirement with GIVEN/WHEN/THEN scenarios
- **Tasks**: 3/3 complete (fix, yamllint, consistency verification)
- **Review council**: 9/9 Divisor agents approved (all MEDIUM and LOW findings auto-fixed)