### PR TITLE
feat(crapload): multi-module package resolution and baseline guidance

### DIFF
--- a/.github/scripts/compare-crapload.sh
+++ b/.github/scripts/compare-crapload.sh
@@ -1,0 +1,308 @@
+#!/usr/bin/env bash
+# Compare CRAP scores against baseline and generate PR comment
+# Usage: compare-crapload.sh <current-json> <baseline-json> <new-func-threshold> <epsilon> <gaze-version> [<gaze-report>]
+#   <current-json>        Path to current CRAP JSON (required)
+#   <baseline-json>       Path to baseline CRAP JSON (required)
+#   <new-func-threshold>  CRAP ceiling for new functions (default: 30)
+#   <epsilon>             Minimum delta to flag regression (default: 0.5)
+#   <gaze-version>        Gaze version string for display (default: latest)
+#   <gaze-report>         Path to full gaze JSON report (default: /tmp/gaze-report.json)
+# Outputs: GitHub Actions outputs written to stdout; comment body written to /tmp/crapload-comment-body.md
+
+set -euo pipefail
+
+CURRENT="${1:?Missing current JSON file}"
+BASELINE="${2:?Missing baseline JSON file}"
+NEW_FUNC_THRESHOLD="${3:-30}"
+EPSILON="${4:-0.5}"
+GAZE_VERSION="${5:-latest}"
+GAZE_REPORT="${6:-/tmp/gaze-report.json}"
+
+# GitHub Actions environment variables (set by runner)
+GITHUB_SERVER_URL="${GITHUB_SERVER_URL:-}"
+GITHUB_REPOSITORY="${GITHUB_REPOSITORY:-}"
+GITHUB_RUN_ID="${GITHUB_RUN_ID:-}"
+
+# Temporary files — cleaned up on exit
+BASELINE_TSV=$(mktemp /tmp/baseline-lookup.XXXXXX.tsv)
+CURRENT_TSV=$(mktemp /tmp/current-scores.XXXXXX.tsv)
+trap 'rm -f "$BASELINE_TSV" "$CURRENT_TSV"' EXIT
+
+REGRESSIONS=""
+IMPROVEMENTS=""
+NEW_FUNCTIONS=""
+REG_COUNT=0
+IMP_COUNT=0
+NEW_COUNT=0
+NEW_VIOLATIONS=0
+
+# Extract summary counts
+CRAPLOAD=$(jq -r '.summary.crapload // 0' "$CURRENT")
+GAZE_CRAPLOAD=$(jq -r '.summary.gaze_crapload // 0' "$CURRENT")
+
+echo "crapload_count=$CRAPLOAD"
+echo "gaze_crapload_count=$GAZE_CRAPLOAD"
+
+if [[ ! -f "$BASELINE" ]]; then
+	# No baseline - show current scores only
+	echo "status=pass"
+	echo "regressions_count=0"
+	echo "improvements_count=0"
+
+	# Generate no-baseline comment
+	AVG_COMPLEXITY=$(jq -r '(.summary.avg_complexity // 0) * 10 | round / 10' "$CURRENT")
+	AVG_LINE_COV=$(jq -r '(.summary.avg_line_coverage // 0) * 10 | round / 10' "$CURRENT")
+	AVG_CRAP=$(jq -r '(.summary.avg_crap // 0) * 10 | round / 10' "$CURRENT")
+	CRAP_THRESH=$(jq -r '.summary.crap_threshold // 15' "$CURRENT")
+	AVG_CONTRACT_COV=$(jq -r '(.summary.avg_contract_coverage // 0) * 10 | round / 10' "$CURRENT")
+	AVG_GAZE_CRAP=$(jq -r '(.summary.avg_gaze_crap // 0) * 10 | round / 10' "$CURRENT")
+	GAZE_CRAP_THRESH=$(jq -r '.summary.gaze_crap_threshold // 15' "$CURRENT")
+	TOTAL_FUNCS=$(jq -r '.summary.total_functions // 0' "$CURRENT")
+
+	cat >/tmp/crapload-comment-body.md <<EOF
+<!-- crapload-analysis-marker -->
+## &#x2705; CRAP Load Analysis: PASS (no baseline)
+
+No baseline file found at \`$BASELINE\`. Showing current scores without regression detection.
+
+### How to Enable Regression Detection
+
+Generate and commit a baseline file to track CRAP score changes over time:
+
+\`\`\`bash
+# 1. Install gaze
+go install github.com/unbound-force/gaze/cmd/gaze@${GAZE_VERSION}
+
+# 2. Auto-detect packages (works for single and multi-module repos)
+PACKAGES=\$(find . -name go.mod -not -path '*/vendor/*' | xargs dirname | sed 's|^\./||;s|^$|.|;s|$|/...|' | paste -sd ' ')
+[ -f go.mod ] && PACKAGES="./..."
+
+# 3. Run tests and generate baseline
+go test -coverprofile=coverage.out \$PACKAGES
+mkdir -p .gaze
+gaze report --format=json --coverprofile=coverage.out \$PACKAGES | jq '.crap' > .gaze/baseline.json
+
+# 4. Commit the baseline
+git add .gaze/baseline.json
+git commit -m "chore: add CRAP baseline for regression detection"
+\`\`\`
+
+**Note**: The workflow auto-detects all modules when \`./...\` doesn't work. To analyze specific modules only, set the \`packages\` input.
+
+**For more information**:
+- [Gaze README](https://github.com/unbound-force/gaze/blob/main/README.md)
+- [CI Integration Guide](https://github.com/unbound-force/gaze/blob/main/docs/guides/ci-integration.md)
+
+### Summary
+
+| Metric | Value |
+|--------|-------|
+| Functions analysed | ${TOTAL_FUNCS} |
+| Avg complexity | ${AVG_COMPLEXITY} |
+| Avg line coverage | ${AVG_LINE_COV}% |
+| Avg CRAP score | ${AVG_CRAP} |
+| CRAPload (>= ${CRAP_THRESH}) | ${CRAPLOAD} |
+| Avg contract coverage | ${AVG_CONTRACT_COV}% |
+| Avg GazeCRAP score | ${AVG_GAZE_CRAP} |
+| GazeCRAPload (>= ${GAZE_CRAP_THRESH}) | ${GAZE_CRAPLOAD} |
+
+[View full analysis logs](${GITHUB_SERVER_URL}/${GITHUB_REPOSITORY}/actions/runs/${GITHUB_RUN_ID})
+EOF
+	exit 0
+fi
+
+# Build lookup from baseline
+jq -r '.scores[] | "\(.file):\(.function)\t\(.crap)\t\(.gaze_crap // 0)"' "$BASELINE" | sort >"$BASELINE_TSV"
+
+# Extract current scores to temp file
+jq -r '.scores[] | "\(.file):\(.function)\t\(.crap)\t\(.gaze_crap // 0)"' "$CURRENT" | sort >"$CURRENT_TSV"
+
+# Process current scores
+while IFS=$'\t' read -r key crap gaze_crap; do
+	baseline_line=$(grep -F "${key}	" "$BASELINE_TSV" || true)
+	# Validate numeric before bc arithmetic — non-numeric values from tampered JSON
+	# could cause bc's system() to execute shell commands (injection risk)
+	if ! [[ "$crap" =~ ^[0-9]+(\.[0-9]+)?$ ]] || ! [[ "$gaze_crap" =~ ^[0-9]+(\.[0-9]+)?$ ]]; then
+		echo "::warning::Skipping non-numeric CRAP values for ${key}: crap=${crap} gaze_crap=${gaze_crap}" >&2
+		continue
+	fi
+	if [[ -z "$baseline_line" ]]; then
+		# New function
+		NEW_COUNT=$((NEW_COUNT + 1))
+		status_icon="+"
+		crap_exceeds_threshold=$(echo "$crap > $NEW_FUNC_THRESHOLD" | bc -l)
+		if ((crap_exceeds_threshold)); then
+			NEW_VIOLATIONS=$((NEW_VIOLATIONS + 1))
+			status_icon="!+"
+		fi
+		NEW_FUNCTIONS="${NEW_FUNCTIONS}| ${status_icon} | \`${key}\` | ${crap} | ${gaze_crap} | new (threshold: ${NEW_FUNC_THRESHOLD}) |"$'\n'
+	else
+		b_crap=$(echo "$baseline_line" | cut -f2)
+		b_gaze=$(echo "$baseline_line" | cut -f3)
+		# Validate baseline numeric values before bc arithmetic
+		if ! [[ "$b_crap" =~ ^[0-9]+(\.[0-9]+)?$ ]] || ! [[ "$b_gaze" =~ ^[0-9]+(\.[0-9]+)?$ ]]; then
+			echo "::warning::Skipping non-numeric baseline CRAP values for ${key}: b_crap=${b_crap} b_gaze=${b_gaze}" >&2
+			continue
+		fi
+		crap_diff=$(echo "$crap - $b_crap" | bc -l)
+		gaze_diff=$(echo "$gaze_crap - $b_gaze" | bc -l)
+		has_regression=false
+		has_improvement=false
+
+		crap_regressed=$(echo "$crap - $b_crap > $EPSILON" | bc -l)
+		crap_improved=$(echo "$b_crap - $crap > $EPSILON" | bc -l)
+		gaze_regressed=$(echo "$gaze_crap - $b_gaze > $EPSILON" | bc -l)
+		gaze_improved=$(echo "$b_gaze - $gaze_crap > $EPSILON" | bc -l)
+		if ((crap_regressed)); then
+			has_regression=true
+		elif ((crap_improved)); then
+			has_improvement=true
+		fi
+		if ((gaze_regressed)); then
+			has_regression=true
+		elif ((gaze_improved)); then
+			has_improvement=true
+		fi
+
+		if [[ "$has_regression" = "true" ]]; then
+			REG_COUNT=$((REG_COUNT + 1))
+			REGRESSIONS="${REGRESSIONS}| \`${key}\` | ${b_crap} | ${crap} | ${crap_diff} | ${b_gaze} | ${gaze_crap} | ${gaze_diff} |"$'\n'
+		elif [[ "$has_improvement" = "true" ]]; then
+			IMP_COUNT=$((IMP_COUNT + 1))
+			IMPROVEMENTS="${IMPROVEMENTS}| \`${key}\` | ${b_crap} | ${crap} | ${crap_diff} | ${b_gaze} | ${gaze_crap} | ${gaze_diff} |"$'\n'
+		fi
+	fi
+done <"$CURRENT_TSV"
+
+# Output counts
+echo "regressions_count=$REG_COUNT"
+echo "improvements_count=$IMP_COUNT"
+
+# Determine pass/fail
+TOTAL_FAILURES=$((REG_COUNT + NEW_VIOLATIONS))
+if [[ "$TOTAL_FAILURES" -gt 0 ]]; then
+	echo "status=fail"
+	echo "::error::CRAP regressions detected: $REG_COUNT regression(s), $NEW_VIOLATIONS new function violation(s)" >&2
+else
+	echo "status=pass"
+fi
+
+# Build PR comment body
+STATUS_BADGE="&#x2705;"
+STATUS_TEXT="PASS"
+if [[ "$TOTAL_FAILURES" -gt 0 ]]; then
+	STATUS_BADGE="&#x274C;"
+	STATUS_TEXT="FAIL"
+fi
+
+AVG_COMPLEXITY=$(jq -r '(.summary.avg_complexity // 0) * 10 | round / 10' "$CURRENT")
+AVG_LINE_COV=$(jq -r '(.summary.avg_line_coverage // 0) * 10 | round / 10' "$CURRENT")
+AVG_CRAP=$(jq -r '(.summary.avg_crap // 0) * 10 | round / 10' "$CURRENT")
+CRAP_THRESH=$(jq -r '.summary.crap_threshold // 15' "$CURRENT")
+AVG_CONTRACT_COV=$(jq -r '(.summary.avg_contract_coverage // 0) * 10 | round / 10' "$CURRENT")
+AVG_GAZE_CRAP=$(jq -r '(.summary.avg_gaze_crap // 0) * 10 | round / 10' "$CURRENT")
+GAZE_CRAP_THRESH=$(jq -r '.summary.gaze_crap_threshold // 15' "$CURRENT")
+TOTAL_FUNCS=$(jq -r '.summary.total_functions // 0' "$CURRENT")
+
+cat >/tmp/crapload-comment-body.md <<EOF
+<!-- crapload-analysis-marker -->
+## ${STATUS_BADGE} CRAP Load Analysis: ${STATUS_TEXT}
+
+### Summary
+
+| Metric | Value |
+|--------|-------|
+| Functions analysed | ${TOTAL_FUNCS} |
+| Avg complexity | ${AVG_COMPLEXITY} |
+| Avg line coverage | ${AVG_LINE_COV}% |
+| Avg CRAP score | ${AVG_CRAP} |
+| CRAPload (>= ${CRAP_THRESH}) | ${CRAPLOAD} |
+| Avg contract coverage | ${AVG_CONTRACT_COV}% |
+| Avg GazeCRAP score | ${AVG_GAZE_CRAP} |
+| GazeCRAPload (>= ${GAZE_CRAP_THRESH}) | ${GAZE_CRAPLOAD} |
+| Regressions | ${REG_COUNT} |
+| Improvements | ${IMP_COUNT} |
+| New functions | ${NEW_COUNT} |
+EOF
+
+# Add quality metrics if available
+QUALITY_COV=$(jq -r '(.quality.summary.average_contract_coverage // empty) * 10 | round / 10' "$GAZE_REPORT" 2>/dev/null || true)
+if [[ -n "$QUALITY_COV" ]]; then
+	QUALITY_OVERSPEC=$(jq -r '(.quality.summary.average_over_specification // 0) * 10 | round / 10' "$GAZE_REPORT" 2>/dev/null || echo "0")
+	cat >>/tmp/crapload-comment-body.md <<EOF
+| Avg contract coverage (quality) | ${QUALITY_COV}% |
+| Avg over-specification | ${QUALITY_OVERSPEC}% |
+EOF
+fi
+
+# Add quadrant distribution if available
+Q1=$(jq -r '.crap.summary.quadrant_counts.Q1_Safe // empty' "$GAZE_REPORT" 2>/dev/null || true)
+if [[ -n "$Q1" ]]; then
+	Q2=$(jq -r '.crap.summary.quadrant_counts.Q2_ComplexButTested // 0' "$GAZE_REPORT" 2>/dev/null || echo "0")
+	Q3=$(jq -r '.crap.summary.quadrant_counts.Q3_SimpleButUnderspecified // 0' "$GAZE_REPORT" 2>/dev/null || echo "0")
+	Q4=$(jq -r '.crap.summary.quadrant_counts.Q4_Dangerous // 0' "$GAZE_REPORT" 2>/dev/null || echo "0")
+	cat >>/tmp/crapload-comment-body.md <<EOF
+
+### Quadrant Distribution
+
+| Quadrant | Count |
+|----------|-------|
+| Q1 Safe | ${Q1} |
+| Q2 Complex but Tested | ${Q2} |
+| Q3 Simple but Underspecified | ${Q3} |
+| Q4 Dangerous | ${Q4} |
+EOF
+fi
+
+# Add regressions table if any
+if [[ -n "$REGRESSIONS" ]]; then
+	cat >>/tmp/crapload-comment-body.md <<EOF
+
+### Regressions
+
+| Function | Baseline CRAP | Current CRAP | Delta | Baseline GazeCRAP | Current GazeCRAP | Delta |
+|----------|---------------|--------------|-------|-------------------|------------------|-------|
+EOF
+	printf '%s' "$REGRESSIONS" >>/tmp/crapload-comment-body.md
+fi
+
+# Add improvements table if any
+if [[ -n "$IMPROVEMENTS" ]]; then
+	cat >>/tmp/crapload-comment-body.md <<EOF
+
+### Improvements
+
+| Function | Baseline CRAP | Current CRAP | Delta | Baseline GazeCRAP | Current GazeCRAP | Delta |
+|----------|---------------|--------------|-------|-------------------|------------------|-------|
+EOF
+	printf '%s' "$IMPROVEMENTS" >>/tmp/crapload-comment-body.md
+fi
+
+# Add new functions table if any
+if [[ -n "$NEW_FUNCTIONS" ]]; then
+	cat >>/tmp/crapload-comment-body.md <<EOF
+
+### New Functions
+
+| Status | Function | CRAP | GazeCRAP | Note |
+|--------|----------|------|----------|------|
+EOF
+	printf '%s' "$NEW_FUNCTIONS" >>/tmp/crapload-comment-body.md
+fi
+
+# Add analysis warnings if any
+FAILED_STEPS=$(jq -r '.errors | to_entries[] | select(.value != null) | "- **\(.key)**: \(.value)"' "$GAZE_REPORT" 2>/dev/null || true)
+if [[ -n "$FAILED_STEPS" ]]; then
+	cat >>/tmp/crapload-comment-body.md <<EOF
+
+### Analysis Warnings
+
+$FAILED_STEPS
+EOF
+fi
+
+# Add footer
+cat >>/tmp/crapload-comment-body.md <<EOF
+
+[View full analysis logs](${GITHUB_SERVER_URL}/${GITHUB_REPOSITORY}/actions/runs/${GITHUB_RUN_ID})
+EOF

--- a/.github/workflows/ci_test_crapload.yml
+++ b/.github/workflows/ci_test_crapload.yml
@@ -1,0 +1,60 @@
+# SPDX-License-Identifier: Apache-2.0
+
+name: Test CRAP Load Workflow
+
+on:
+  pull_request:
+    paths:
+      - '.github/workflows/reusable_crapload_analysis.yml'
+      - 'scripts/resolve-go-packages.sh'
+      - 'tests/test_crapload_package_resolution.py'
+      - '.github/workflows/ci_test_crapload.yml'
+      - '.github/scripts/compare-crapload.sh'
+  push:
+    branches:
+      - main
+    paths:
+      - '.github/workflows/reusable_crapload_analysis.yml'
+      - 'scripts/resolve-go-packages.sh'
+      - 'tests/test_crapload_package_resolution.py'
+      - '.github/workflows/ci_test_crapload.yml'
+      - '.github/scripts/compare-crapload.sh'
+
+permissions:
+  contents: read
+
+jobs:
+  test-package-resolution:
+    name: Test Package Resolution
+    runs-on: ubuntu-latest
+    steps:
+      - name: Checkout code
+        uses: actions/checkout@de0fac2e4500dabe0009e67214ff5f5447ce83dd # v6.0.2
+
+      - name: Set up Python
+        uses: actions/setup-python@a309ff8b426b58ec0e2a45f0f869d46889d02405 # v6.2.0
+        with:
+          python-version: '3.x'
+          cache: 'pip'
+
+      - name: Set up Go
+        uses: actions/setup-go@4a3601121dd01d1626a1e23e37211e3254c1c06c # v6.4.0
+        with:
+          go-version: '1.21'
+
+      - name: Install Python dependencies
+        run: |
+          python -m pip install --upgrade pip
+          pip install -r requirements.txt
+
+      - name: Run package resolution tests
+        run: make test
+
+      - name: Upload test results
+        if: always()
+        uses: actions/upload-artifact@043fb46d1a93c77aae656e7c1c64a875d1fc6a0a # v7.0.1
+        with:
+          name: pytest-test-results
+          path: |
+            .pytest_cache/
+          retention-days: 7

--- a/.github/workflows/reusable_compliance.yml
+++ b/.github/workflows/reusable_compliance.yml
@@ -89,8 +89,18 @@ jobs:
             exit 1
           fi
 
+      - name: Validate complytime_config_path input
+        env:
+          CONFIG_PATH: ${{ inputs.complytime_config_path }}
+        run: |
+          if [[ ! "${CONFIG_PATH}" =~ ^[a-zA-Z0-9_./-]+$ ]] || [[ "${CONFIG_PATH}" == *".."* ]]; then
+            echo "::error::Invalid complytime_config_path"
+            exit 1
+          fi
+          echo "CONFIG_PATH=${CONFIG_PATH}" >> "$GITHUB_ENV"
+
       - name: Copy workspace configuration
-        run: cp "_caller/${{ inputs.complytime_config_path }}" complytime.yaml
+        run: cp "_caller/${CONFIG_PATH}" complytime.yaml
 
       - name: Copy ampel policy files
         run: |
@@ -100,13 +110,25 @@ jobs:
       - name: Fetch ampel-branch-protection policy from mock registry
         run: ./bin/complyctl get
 
+      - name: Validate policy_id input
+        env:
+          POLICY_ID: ${{ inputs.policy_id }}
+        run: |
+          if [[ ! "${POLICY_ID}" =~ ^[a-zA-Z0-9_-]+$ ]]; then
+            echo "::error::Invalid policy_id '${POLICY_ID}': must match ^[a-zA-Z0-9_-]+$"
+            exit 1
+          fi
+          echo "POLICY_ID=${POLICY_ID}" >> "$GITHUB_ENV"
+
       - name: Generate policy graph
-        run: ./bin/complyctl generate --policy-id ${{ inputs.policy_id }}
+        run: |
+          ./bin/complyctl generate --policy-id "${POLICY_ID}"
 
       - name: Scan branch protection rules
         env:
           GITHUB_TOKEN: "${{ secrets.source_token }}"
-        run: ./bin/complyctl scan --policy-id ${{ inputs.policy_id }} --format pretty
+        run: |
+          ./bin/complyctl scan --policy-id "${POLICY_ID}" --format pretty
 
       - name: Publish report to GitHub Step Summary
         run: |

--- a/.github/workflows/reusable_crapload_analysis.yml
+++ b/.github/workflows/reusable_crapload_analysis.yml
@@ -84,8 +84,10 @@ jobs:
       - name: Detect changed packages
         id: detect-changes
         if: github.event_name == 'pull_request'
+        env:
+          BASE_SHA: ${{ github.event.pull_request.base.sha }}
         run: |
-          CHANGED_FILES=$(git diff --name-only "${{ github.event.pull_request.base.sha }}..HEAD" -- '*.go' ':!vendor' ':!*/vendor' || true)
+          CHANGED_FILES=$(git diff --name-only "${BASE_SHA}..HEAD" -- '*.go' ':!vendor' ':!*/vendor' || true)
           if [ -z "$CHANGED_FILES" ]; then
             echo "has_changes=false" >> "$GITHUB_OUTPUT"
             echo "packages=" >> "$GITHUB_OUTPUT"
@@ -105,39 +107,78 @@ jobs:
           printf '%s\n' '<!-- crapload-analysis-marker -->' '## CRAP Load Analysis' '' \
             'No Go code changes detected in this PR. No CRAP impact.' > /tmp/crapload-comment-body.md
 
+      - name: Resolve Go version source
+        if: steps.no-changes.outputs.skip != 'true'
+        id: go-version-source
+        run: |
+          if [[ -f "${{ inputs.go-version-file }}" ]]; then
+            echo "go-version-file=${{ inputs.go-version-file }}" >> "$GITHUB_OUTPUT"
+            echo "go-version=" >> "$GITHUB_OUTPUT"
+          else
+            echo "go-version-file=" >> "$GITHUB_OUTPUT"
+            echo "go-version=stable" >> "$GITHUB_OUTPUT"
+          fi
+
       - name: Set up Go
         if: steps.no-changes.outputs.skip != 'true'
         uses: actions/setup-go@4a3601121dd01d1626a1e23e37211e3254c1c06c # v6.4.0
         with:
-          go-version-file: ${{ inputs.go-version-file }}
+          go-version-file: ${{ steps.go-version-source.outputs.go-version-file }}
+          go-version: ${{ steps.go-version-source.outputs.go-version }}
+
+      - name: Auto-detect packages for multi-module repos
+        if: steps.no-changes.outputs.skip != 'true'
+        id: resolve-packages
+        env:
+          DETECTED_PACKAGES: ${{ steps.detect-changes.outputs.packages }}
+          PACKAGES_INPUT: ${{ inputs.packages }}
+        run: |
+          # In PR mode, detect-changes already scoped to changed files
+          if [ -n "$DETECTED_PACKAGES" ]; then
+            echo "packages=$DETECTED_PACKAGES" >> "$GITHUB_OUTPUT"
+            echo "Using PR-scoped packages: $DETECTED_PACKAGES"
+            exit 0
+          fi
+
+          # Use the resolution script for consistent behavior
+          RESOLVED=$(bash scripts/resolve-go-packages.sh "$PACKAGES_INPUT")
+          echo "packages=$RESOLVED" >> "$GITHUB_OUTPUT"
 
       - name: Install Gaze
         if: steps.no-changes.outputs.skip != 'true'
         id: install-gaze
         env:
           GOTOOLCHAIN: auto
+          GAZE_VERSION: ${{ inputs.gaze-version }}
         run: |
-          echo "Installing gaze@${{ inputs.gaze-version }}..."
-          go install "github.com/unbound-force/gaze/cmd/gaze@${{ inputs.gaze-version }}"
+          echo "Installing gaze@${GAZE_VERSION}..."
+          go install "github.com/unbound-force/gaze/cmd/gaze@${GAZE_VERSION}"
           gaze --version || echo "gaze installed (version flag may not be supported)"
 
       - name: Generate coverage profile
         if: steps.no-changes.outputs.skip != 'true'
+        env:
+          PKGS: ${{ steps.resolve-packages.outputs.packages }}
+          COVERPROFILE: ${{ inputs.coverprofile }}
         run: |
-          PKGS="${{ steps.detect-changes.outputs.packages || inputs.packages }}"
-          echo "Running tests with coverage for: $PKGS"
-          go test -coverprofile="${{ inputs.coverprofile }}" $PKGS || true
+          read -ra pkg_array <<< "$PKGS"
+          echo "Running tests with coverage for: ${pkg_array[*]}"
+          go test -coverprofile="${COVERPROFILE}" "${pkg_array[@]}" || \
+            echo "::warning::Some tests failed; coverage data may be incomplete"
 
       - name: Run Gaze analysis
         if: steps.no-changes.outputs.skip != 'true'
         id: gaze-analysis
+        env:
+          PKGS: ${{ steps.resolve-packages.outputs.packages }}
+          COVERPROFILE: ${{ inputs.coverprofile }}
         run: |
-          PKGS="${{ steps.detect-changes.outputs.packages || inputs.packages }}"
+          read -ra pkg_array <<< "$PKGS"
           REPO_ROOT="$(pwd)/"
           gaze report \
             --format=json \
-            --coverprofile="${{ inputs.coverprofile }}" \
-            $PKGS 2>/tmp/gaze-stderr.txt \
+            --coverprofile="${COVERPROFILE}" \
+            "${pkg_array[@]}" 2>/tmp/gaze-stderr.txt \
             > /tmp/gaze-report.json || true
           echo "Gaze analysis complete."
           cat /tmp/gaze-stderr.txt >&2 || true
@@ -148,246 +189,20 @@ jobs:
       - name: Compare against baseline
         if: steps.no-changes.outputs.skip != 'true'
         id: compare
+        env:
+          BASELINE: ${{ inputs.baseline-file }}
+          NEW_FUNC_THRESHOLD: ${{ inputs.new-function-threshold }}
+          EPSILON: ${{ inputs.regression-epsilon }}
+          GAZE_VERSION: ${{ inputs.gaze-version }}
         run: |
-          BASELINE="${{ inputs.baseline-file }}"
-          CURRENT="/tmp/crapload-current.json"
-          NEW_FUNC_THRESHOLD="${{ inputs.new-function-threshold }}"
-          EPSILON="${{ inputs.regression-epsilon }}"
-          REGRESSIONS=""
-          IMPROVEMENTS=""
-          NEW_FUNCTIONS=""
-          REG_COUNT=0
-          IMP_COUNT=0
-          NEW_COUNT=0
-          NEW_VIOLATIONS=0
-
-          CRAPLOAD=$(jq -r '.summary.crapload // 0' "$CURRENT")
-          GAZE_CRAPLOAD=$(jq -r '.summary.gaze_crapload // 0' "$CURRENT")
-          {
-            echo "crapload_count=$CRAPLOAD"
-            echo "gaze_crapload_count=$GAZE_CRAPLOAD"
-          } >> "$GITHUB_OUTPUT"
-
-          if [ ! -f "$BASELINE" ]; then
-            echo "::warning::Baseline file $BASELINE not found. Skipping per-function comparison."
-            {
-              echo "status=pass"
-              echo "regressions_count=0"
-              echo "improvements_count=0"
-            } >> "$GITHUB_OUTPUT"
-
-            # Generate comment body with current scores (no baseline comparison)
-            AVG_COMPLEXITY=$(jq -r '(.summary.avg_complexity // 0) * 10 | round / 10' "$CURRENT")
-            AVG_LINE_COV=$(jq -r '(.summary.avg_line_coverage // 0) * 10 | round / 10' "$CURRENT")
-            AVG_CRAP=$(jq -r '(.summary.avg_crap // 0) * 10 | round / 10' "$CURRENT")
-            CRAP_THRESH=$(jq -r '.summary.crap_threshold // 15' "$CURRENT")
-            AVG_CONTRACT_COV=$(jq -r '(.summary.avg_contract_coverage // 0) * 10 | round / 10' "$CURRENT")
-            AVG_GAZE_CRAP=$(jq -r '(.summary.avg_gaze_crap // 0) * 10 | round / 10' "$CURRENT")
-            GAZE_CRAP_THRESH=$(jq -r '.summary.gaze_crap_threshold // 15' "$CURRENT")
-            TOTAL_FUNCS=$(jq -r '.summary.total_functions // 0' "$CURRENT")
-
-            {
-              echo "<!-- crapload-analysis-marker -->"
-              echo "## &#x2705; CRAP Load Analysis: PASS (no baseline)"
-              echo ""
-              echo "No baseline file found. Showing current scores without comparison."
-              echo "Commit a baseline to \`$BASELINE\` to enable regression detection."
-              echo ""
-              echo "### Summary"
-              echo ""
-              echo "| Metric | Value |"
-              echo "|--------|-------|"
-              echo "| Functions analysed | ${TOTAL_FUNCS} |"
-              echo "| Avg complexity | ${AVG_COMPLEXITY} |"
-              echo "| Avg line coverage | ${AVG_LINE_COV}% |"
-              echo "| Avg CRAP score | ${AVG_CRAP} |"
-              echo "| CRAPload (>= ${CRAP_THRESH}) | ${CRAPLOAD} |"
-              echo "| Avg contract coverage | ${AVG_CONTRACT_COV}% |"
-              echo "| Avg GazeCRAP score | ${AVG_GAZE_CRAP} |"
-              echo "| GazeCRAPload (>= ${GAZE_CRAP_THRESH}) | ${GAZE_CRAPLOAD} |"
-              echo ""
-              echo "[View full analysis logs](${GITHUB_SERVER_URL}/${GITHUB_REPOSITORY}/actions/runs/${GITHUB_RUN_ID})"
-            } > /tmp/crapload-comment-body.md
-
-            exit 0
-          fi
-
-          # Build lookup from baseline: key = file:function (unique across multi-module repos)
-          jq -r '.scores[] | "\(.file):\(.function)\t\(.crap)\t\(.gaze_crap // 0)"' "$BASELINE" | sort > /tmp/baseline-lookup.tsv
-
-          # Process current scores
-          while IFS=$'\t' read -r key crap gaze_crap; do
-            baseline_line=$(grep -F "${key}	" /tmp/baseline-lookup.tsv || true)
-            if [ -z "$baseline_line" ]; then
-              # New function
-              NEW_COUNT=$((NEW_COUNT + 1))
-              status_icon="+"
-              if [ "$(echo "$crap > $NEW_FUNC_THRESHOLD" | bc -l)" = "1" ]; then
-                NEW_VIOLATIONS=$((NEW_VIOLATIONS + 1))
-                status_icon="!+"
-              fi
-              NEW_FUNCTIONS="${NEW_FUNCTIONS}| ${status_icon} | \`${key}\` | ${crap} | ${gaze_crap} | new (threshold: ${NEW_FUNC_THRESHOLD}) |\n"
-            else
-              b_crap=$(echo "$baseline_line" | cut -f2)
-              b_gaze=$(echo "$baseline_line" | cut -f3)
-              crap_diff=$(echo "$crap - $b_crap" | bc -l)
-              gaze_diff=$(echo "$gaze_crap - $b_gaze" | bc -l)
-              has_regression=false
-              has_improvement=false
-
-              if [ "$(echo "$crap - $b_crap > $EPSILON" | bc -l)" = "1" ]; then
-                has_regression=true
-              elif [ "$(echo "$b_crap - $crap > $EPSILON" | bc -l)" = "1" ]; then
-                has_improvement=true
-              fi
-              if [ "$(echo "$gaze_crap - $b_gaze > $EPSILON" | bc -l)" = "1" ]; then
-                has_regression=true
-              elif [ "$(echo "$b_gaze - $gaze_crap > $EPSILON" | bc -l)" = "1" ]; then
-                has_improvement=true
-              fi
-
-              if [ "$has_regression" = "true" ]; then
-                REG_COUNT=$((REG_COUNT + 1))
-                REGRESSIONS="${REGRESSIONS}| \`${key}\` | ${b_crap} | ${crap} | ${crap_diff} | ${b_gaze} | ${gaze_crap} | ${gaze_diff} |\n"
-              elif [ "$has_improvement" = "true" ]; then
-                IMP_COUNT=$((IMP_COUNT + 1))
-                IMPROVEMENTS="${IMPROVEMENTS}| \`${key}\` | ${b_crap} | ${crap} | ${crap_diff} | ${b_gaze} | ${gaze_crap} | ${gaze_diff} |\n"
-              fi
-            fi
-          done < <(jq -r '.scores[] | "\(.file):\(.function)\t\(.crap)\t\(.gaze_crap // 0)"' "$CURRENT" | sort)
-
-          {
-            echo "regressions_count=$REG_COUNT"
-            echo "improvements_count=$IMP_COUNT"
-          } >> "$GITHUB_OUTPUT"
-
-          TOTAL_FAILURES=$((REG_COUNT + NEW_VIOLATIONS))
-          if [ "$TOTAL_FAILURES" -gt 0 ]; then
-            echo "status=fail" >> "$GITHUB_OUTPUT"
-          else
-            echo "status=pass" >> "$GITHUB_OUTPUT"
-          fi
-
-          if [ "$TOTAL_FAILURES" -gt 0 ]; then
-            echo "::error::CRAP regressions detected: $REG_COUNT regression(s), $NEW_VIOLATIONS new function violation(s)"
-          fi
-
-          # Build PR comment body
-          STATUS_BADGE="&#x2705;"
-          STATUS_TEXT="PASS"
-          if [ "$TOTAL_FAILURES" -gt 0 ]; then
-            STATUS_BADGE="&#x274C;"
-            STATUS_TEXT="FAIL"
-          fi
-
-          AVG_COMPLEXITY=$(jq -r '(.summary.avg_complexity // 0) * 10 | round / 10' "$CURRENT")
-          AVG_LINE_COV=$(jq -r '(.summary.avg_line_coverage // 0) * 10 | round / 10' "$CURRENT")
-          AVG_CRAP=$(jq -r '(.summary.avg_crap // 0) * 10 | round / 10' "$CURRENT")
-          CRAP_THRESH=$(jq -r '.summary.crap_threshold // 15' "$CURRENT")
-          AVG_CONTRACT_COV=$(jq -r '(.summary.avg_contract_coverage // 0) * 10 | round / 10' "$CURRENT")
-          AVG_GAZE_CRAP=$(jq -r '(.summary.avg_gaze_crap // 0) * 10 | round / 10' "$CURRENT")
-          GAZE_CRAP_THRESH=$(jq -r '.summary.gaze_crap_threshold // 15' "$CURRENT")
-          TOTAL_FUNCS=$(jq -r '.summary.total_functions // 0' "$CURRENT")
-
-          {
-            echo "<!-- crapload-analysis-marker -->"
-            echo "## ${STATUS_BADGE} CRAP Load Analysis: ${STATUS_TEXT}"
-            echo ""
-            echo "### Summary"
-            echo ""
-            echo "| Metric | Value |"
-            echo "|--------|-------|"
-            echo "| Functions analysed | ${TOTAL_FUNCS} |"
-            echo "| Avg complexity | ${AVG_COMPLEXITY} |"
-            echo "| Avg line coverage | ${AVG_LINE_COV}% |"
-            echo "| Avg CRAP score | ${AVG_CRAP} |"
-            echo "| CRAPload (>= ${CRAP_THRESH}) | ${CRAPLOAD} |"
-            echo "| Avg contract coverage | ${AVG_CONTRACT_COV}% |"
-            echo "| Avg GazeCRAP score | ${AVG_GAZE_CRAP} |"
-            echo "| GazeCRAPload (>= ${GAZE_CRAP_THRESH}) | ${GAZE_CRAPLOAD} |"
-            echo "| Regressions | ${REG_COUNT} |"
-            echo "| Improvements | ${IMP_COUNT} |"
-            echo "| New functions | ${NEW_COUNT} |"
-          } > /tmp/crapload-comment-body.md
-
-          # Quality metrics from gaze report
-          QUALITY_COV=$(jq -r '(.quality.summary.average_contract_coverage // empty) * 10 | round / 10' /tmp/gaze-report.json 2>/dev/null || true)
-          if [ -n "$QUALITY_COV" ]; then
-            QUALITY_OVERSPEC=$(jq -r '(.quality.summary.average_over_specification // 0) * 10 | round / 10' /tmp/gaze-report.json 2>/dev/null || echo "0")
-            {
-              echo "| Avg contract coverage (quality) | ${QUALITY_COV}% |"
-              echo "| Avg over-specification | ${QUALITY_OVERSPEC}% |"
-            } >> /tmp/crapload-comment-body.md
-          fi
-
-          # Quadrant distribution from gaze report
-          Q1=$(jq -r '.crap.summary.quadrant_counts.Q1_Safe // empty' /tmp/gaze-report.json 2>/dev/null || true)
-          if [ -n "$Q1" ]; then
-            Q2=$(jq -r '.crap.summary.quadrant_counts.Q2_ComplexButTested // 0' /tmp/gaze-report.json)
-            Q3=$(jq -r '.crap.summary.quadrant_counts.Q3_SimpleButUnderspecified // 0' /tmp/gaze-report.json)
-            Q4=$(jq -r '.crap.summary.quadrant_counts.Q4_Dangerous // 0' /tmp/gaze-report.json)
-            {
-              echo ""
-              echo "### Quadrant Distribution"
-              echo ""
-              echo "| Quadrant | Count |"
-              echo "|----------|-------|"
-              echo "| Q1 Safe | ${Q1} |"
-              echo "| Q2 Complex but Tested | ${Q2} |"
-              echo "| Q3 Simple but Underspecified | ${Q3} |"
-              echo "| Q4 Dangerous | ${Q4} |"
-            } >> /tmp/crapload-comment-body.md
-          fi
-
-          if [ -n "$REGRESSIONS" ]; then
-            {
-              echo ""
-              echo "### Regressions"
-              echo ""
-              echo "| Function | Baseline CRAP | Current CRAP | Delta | Baseline GazeCRAP | Current GazeCRAP | Delta |"
-              echo "|----------|---------------|--------------|-------|-------------------|------------------|-------|"
-              printf '%b' "$REGRESSIONS"
-            } >> /tmp/crapload-comment-body.md
-          fi
-
-          if [ -n "$IMPROVEMENTS" ]; then
-            {
-              echo ""
-              echo "### Improvements"
-              echo ""
-              echo "| Function | Baseline CRAP | Current CRAP | Delta | Baseline GazeCRAP | Current GazeCRAP | Delta |"
-              echo "|----------|---------------|--------------|-------|-------------------|------------------|-------|"
-              printf '%b' "$IMPROVEMENTS"
-            } >> /tmp/crapload-comment-body.md
-          fi
-
-          if [ -n "$NEW_FUNCTIONS" ]; then
-            {
-              echo ""
-              echo "### New Functions"
-              echo ""
-              echo "| Status | Function | CRAP | GazeCRAP | Note |"
-              echo "|--------|----------|------|----------|------|"
-              printf '%b' "$NEW_FUNCTIONS"
-            } >> /tmp/crapload-comment-body.md
-          fi
-
-          # Analysis warnings from gaze report
-          FAILED_STEPS=$(jq -r '.errors | to_entries[] | select(.value != null) | "- **\(.key)**: \(.value)"' /tmp/gaze-report.json 2>/dev/null || true)
-          if [ -n "$FAILED_STEPS" ]; then
-            {
-              echo ""
-              echo "### Analysis Warnings"
-              echo ""
-              echo "$FAILED_STEPS"
-            } >> /tmp/crapload-comment-body.md
-          fi
-
-          {
-            echo ""
-            echo "[View full analysis logs](${GITHUB_SERVER_URL}/${GITHUB_REPOSITORY}/actions/runs/${GITHUB_RUN_ID})"
-          } >> /tmp/crapload-comment-body.md
-
+          # Call external script to avoid actionlint hang on large inline bash blocks
+          bash .github/scripts/compare-crapload.sh \
+            "/tmp/crapload-current.json" \
+            "$BASELINE" \
+            "$NEW_FUNC_THRESHOLD" \
+            "$EPSILON" \
+            "$GAZE_VERSION" \
+            "/tmp/gaze-report.json" >> "$GITHUB_OUTPUT"
       - name: Write step summary
         if: github.event_name == 'pull_request'
         run: cat /tmp/crapload-comment-body.md >> "$GITHUB_STEP_SUMMARY"
@@ -411,8 +226,9 @@ jobs:
 
       - name: Enforce threshold
         if: steps.no-changes.outputs.skip != 'true'
+        env:
+          STATUS: ${{ steps.compare.outputs.status }}
         run: |
-          STATUS="${{ steps.compare.outputs.status }}"
           if [ "$STATUS" = "fail" ]; then
             echo "::error::CRAP load check failed. See PR comment for details."
             exit 1

--- a/.github/workflows/sync_org_repositories.yml
+++ b/.github/workflows/sync_org_repositories.yml
@@ -69,25 +69,32 @@ jobs:
         if: github.event.inputs.repos == ''
         env:
           GITHUB_TOKEN: ${{ steps.generate-token.outputs.token }}
+          DRY_RUN: ${{ github.event.inputs.dry_run }}
         run: |
-          python scripts/sync-org-repositories.py \
-            --org ${{ github.repository_owner }} \
-            --config sync-config.yml \
-            ${{ github.event.inputs.dry_run == 'true' && '--dry-run' || '' }}
+          ARGS=(--org "${{ github.repository_owner }}" --config sync-config.yml)
+          if [ "$DRY_RUN" == "true" ]; then
+            ARGS+=(--dry-run)
+          fi
+          python scripts/sync-org-repositories.py "${ARGS[@]}"
 
       - name: Run sync script (specific repos)
         if: github.event.inputs.repos != ''
         env:
           GITHUB_TOKEN: ${{ steps.generate-token.outputs.token }}
+          REPOS: ${{ github.event.inputs.repos }}
+          DRY_RUN: ${{ github.event.inputs.dry_run }}
         run: |
-          python scripts/sync-org-repositories.py \
-            --org ${{ github.repository_owner }} \
-            --config sync-config.yml \
-            --repos ${{ github.event.inputs.repos }} \
-            ${{ github.event.inputs.dry_run == 'true' && '--dry-run' || '' }}
+          ARGS=(--org "${{ github.repository_owner }}" --config sync-config.yml --repos "$REPOS")
+          if [ "$DRY_RUN" == "true" ]; then
+            ARGS+=(--dry-run)
+          fi
+          python scripts/sync-org-repositories.py "${ARGS[@]}"
 
       - name: Summary
         if: always()
+        env:
+          REPOS: ${{ github.event.inputs.repos }}
+          DRY_RUN: ${{ github.event.inputs.dry_run }}
         run: |
           {
             echo "## Sync Organization Repositories Complete"
@@ -95,9 +102,9 @@ jobs:
             echo "- **Trigger:** ${{ github.event_name }}"
 
             if [ "${{ github.event_name }}" == "workflow_dispatch" ]; then
-              echo "- **Dry Run:** ${{ github.event.inputs.dry_run }}"
-              if [ -n "${{ github.event.inputs.repos }}" ]; then
-                echo "- **Repositories:** ${{ github.event.inputs.repos }}"
+              echo "- **Dry Run:** $DRY_RUN"
+              if [ -n "$REPOS" ]; then
+                echo "- **Repositories:** $REPOS"
               else
                 echo "- **Repositories:** All (from peribolos.yml)"
               fi

--- a/.gitignore
+++ b/.gitignore
@@ -55,3 +55,16 @@
 .unbound-force/
 .muti-mind/
 .mx-f/
+
+# Test output artifacts
+.test-output/
+
+# Python virtual environment
+.venv/
+__pycache__/
+*.pyc
+*.pyo
+.pytest_cache/
+
+# MegaLinter reports (generated)
+megalinter-reports/

--- a/Makefile
+++ b/Makefile
@@ -3,6 +3,9 @@
 .DEFAULT_GOAL := help
 
 PYTHON := python3
+VENV := .venv
+VENV_PYTHON := $(VENV)/bin/python3
+VENV_PIP := $(VENV)/bin/pip
 SYNC_SCRIPT := scripts/sync-org-repositories.py
 
 ##@ General
@@ -11,34 +14,69 @@ SYNC_SCRIPT := scripts/sync-org-repositories.py
 help: ## Display this help message
 	@awk 'BEGIN {FS = ":.*##"; printf "\nUsage:\n  make \033[36m<target>\033[0m\n"} /^[a-zA-Z_0-9-]+:.*?##/ { printf "  \033[36m%-20s\033[0m %s\n", $$1, $$2 } /^##@/ { printf "\n\033[1m%s\033[0m\n", substr($$0, 5) }' $(MAKEFILE_LIST)
 
+##@ Setup
+
+.PHONY: venv
+venv: $(VENV)/bin/activate ## Create Python virtual environment and install dependencies
+
+$(VENV)/bin/activate: requirements.txt
+	@if [ -d "$(VENV)" ]; then \
+		echo "Updating Python virtual environment in $(VENV)..."; \
+		$(VENV_PIP) install --upgrade pip; \
+		$(VENV_PIP) install -r requirements.txt; \
+		touch $(VENV)/bin/activate; \
+	else \
+		echo "Creating Python virtual environment in $(VENV)..."; \
+		$(PYTHON) -m venv $(VENV); \
+		echo "Installing dependencies..."; \
+		$(VENV_PIP) install --upgrade pip; \
+		$(VENV_PIP) install -r requirements.txt; \
+	fi
+	@echo ""
+	@echo "✓ Virtual environment ready at $(VENV)"
+	@echo ""
+	@echo "To activate the virtual environment, run:"
+	@echo "  source $(VENV)/bin/activate"
+	@echo ""
+
 ##@ Lint
 
 .PHONY: lint
 lint: lint-yaml lint-python ## Run all linters
 
 .PHONY: lint-yaml
-lint-yaml: ## Lint YAML files
-	yamllint -c .yamllint.yml .
+lint-yaml: $(VENV)/bin/activate ## Lint YAML files
+	@echo "Linting YAML files..."
+	@$(VENV)/bin/yamllint -c .yamllint.yml .
 
 .PHONY: lint-python
-lint-python: ## Lint Python files
-	ruff check scripts/ tests/
+lint-python: $(VENV)/bin/activate ## Lint Python files
+	@echo "Linting Python files..."
+	@$(VENV)/bin/ruff check scripts/ tests/
 
 ##@ Sync
 
 .PHONY: sync-dry-run
-sync-dry-run: ## Run sync script in dry-run mode
-	$(PYTHON) $(SYNC_SCRIPT) --org complytime --dry-run
+sync-dry-run: $(VENV)/bin/activate ## Run sync script in dry-run mode
+	@echo "Running sync script in dry-run mode..."
+	@$(VENV_PYTHON) $(SYNC_SCRIPT) --org complytime --dry-run
 
 ##@ Test
 
 .PHONY: test
-test: ## Run tests
-	$(PYTHON) -m pytest tests/ -v
+test: $(VENV)/bin/activate ## Run all tests
+	@echo "Running all tests..."
+	@$(VENV_PYTHON) -m pytest tests/ -v
 
 ##@ Clean
 
 .PHONY: clean
-clean: ## Remove generated artifacts
+clean: ## Remove generated artifacts (cache, pyc files)
 	find . -type d -name __pycache__ -exec rm -rf {} + 2>/dev/null || true
 	find . -type f -name "*.pyc" -delete 2>/dev/null || true
+	find . -type d -name .pytest_cache -exec rm -rf {} + 2>/dev/null || true
+	rm -rf megalinter-reports
+
+.PHONY: clean-venv
+clean-venv: ## Remove Python virtual environment
+	rm -rf $(VENV)

--- a/README.md
+++ b/README.md
@@ -58,13 +58,54 @@ org-infra/
 │  └── ampel/                               # Policy definitions for branch protection rule compliance checks.
 ├── docs/                                   # More detailed and specific documentation.
 │  ├── LOCAL_TESTING.md                     # Documentation on how to test synchronization locally.
-│  └── SYNC_REPOSITORIES_SETUP.md           # Documentation on how to setup the repository synchronization infrastructure.
+│  └── SYNC_REPOSITORIES_SETUP.md          # Documentation on how to setup the repository synchronization infrastructure.
 ├── scripts/
-│  └── sync-org-repositories.py             # Python script to check and ensure consistence among repositories.
+│  ├── sync-org-repositories.py             # Python script to check and ensure consistence among repositories.
+│  └── resolve-go-packages.sh              # Bash: multi-module Go package auto-discovery
 ├── ...                                     # Multiple technology specific configuration files
 ├── sync-config.yml                         # Configuration file consumed by `sync-org-repositories.py`
 └── README.md                               # This file.
 ```
+
+---
+
+## 🧪 Testing
+
+### Quick Start
+
+```bash
+# Set up Python virtual environment (automatic dependency installation)
+make venv
+
+# Activate the virtual environment (optional for interactive use)
+source .venv/bin/activate
+
+# Run all tests (unit and integration)
+make test
+
+# Run linters
+make lint             # Lint YAML and Python (auto-creates venv if needed)
+```
+
+The `make venv` target automatically creates a `.venv` directory and installs all Python dependencies from `requirements.txt` (including pytest, ruff, yamllint). All make targets that need Python (`make test`, `make lint`, `make sync-dry-run`) automatically use the virtual environment - you don't need to activate it manually for make commands.
+
+### Test Suites
+
+All tests use pytest and are located in the `tests/` directory:
+
+1. **Python Unit Tests** - Test the sync script logic
+2. **Integration Tests** - Test CRAP load package resolution and workflow input validation
+
+Run all tests with:
+```bash
+make test
+# or directly with pytest
+pytest tests/ -v
+```
+
+See [`docs/LOCAL_TESTING.md`](docs/LOCAL_TESTING.md) for detailed setup and troubleshooting.
+
+---
 
 ## Style Guides
 

--- a/requirements.txt
+++ b/requirements.txt
@@ -1,14 +1,18 @@
 # Python dependencies for org-infra scripts
 
 # Git operations
-GitPython>=3.1.50
+GitPython==3.1.50
 
 # YAML parsing
-PyYAML>=6.0.3
+PyYAML==6.0.3
 
 # HTTP requests
-requests>=2.34.2
+requests==2.34.2
 
 # Testing
-pytest>=9.0.3
+pytest==9.0.3
+
+# Linting
+ruff==0.8.4
+yamllint==1.35.1
 

--- a/scripts/resolve-go-packages.sh
+++ b/scripts/resolve-go-packages.sh
@@ -1,0 +1,63 @@
+#!/usr/bin/env bash
+# Resolve Go packages for analysis, with auto-discovery for multi-module repos
+#
+# Requirements:
+#   - bash 4.0+
+#   - go (any version with module support)
+#   - Standard POSIX utilities (find, sed, xargs)
+#
+# Usage: resolve-go-packages.sh [INPUT_PACKAGES]
+#   INPUT_PACKAGES: Package pattern from workflow input (default: ./...)
+#
+# Outputs:
+#   stdout: Space-separated package patterns (consumed by callers)
+#   stderr: Diagnostic messages and GitHub Actions annotations (::notice::, ::error::)
+# Exits: 0 on success, 1 if no packages found
+#
+# Exit on error, undefined variables, and pipe failures
+set -euo pipefail
+
+INPUT_PKGS="${1:-./...}"
+
+# If using default ./..., check if it actually works
+if [[ "$INPUT_PKGS" = "./..." ]]; then
+	# Test if ./... resolves to any packages
+	if ! go list ./... >/dev/null 2>&1; then
+		echo "::notice::Default './...' pattern did not resolve packages. Auto-discovering Go modules..." >&2
+		echo "Searching for go.mod files..." >&2
+
+		# Find all go.mod files and construct package patterns.
+		# Count lines before paste collapses them — wc -w is inaccurate for paths with spaces.
+		# Note: find does not follow symlinks by default for -type predicates
+		DISCOVERED=$(find . -name go.mod -type f -not -path '*/vendor/*' -not -path '*/.*/*' -print0 |
+			xargs -0 -I{} dirname {} |
+			sed 's|^\./||' |
+			sed 's|^$|.|' |
+			sed 's|$|/...|' |
+			sort)
+
+		if [[ -z "$DISCOVERED" ]]; then
+			echo "::error::No Go modules found in repository. Cannot analyze." >&2
+			# shellcheck disable=SC2312 # pwd is a shell builtin used for diagnostic output only
+			echo "Searched in: $(pwd)" >&2
+			exit 1
+		fi
+
+		# Count newline-separated entries before collapsing to a single line
+		MODULE_COUNT=$(echo "$DISCOVERED" | grep -c .)
+		echo "Found $MODULE_COUNT module(s)" >&2
+
+		DISCOVERED=$(echo "$DISCOVERED" | paste -sd ' ')
+		echo "$DISCOVERED"
+		echo "Auto-discovered packages: $DISCOVERED" >&2
+		echo "::notice::Analyzing all discovered modules. To analyze specific modules, set the 'packages' workflow input." >&2
+	else
+		# ./... works, use it
+		echo "$INPUT_PKGS"
+		echo "Using default packages: $INPUT_PKGS" >&2
+	fi
+else
+	# Use explicitly configured packages as-is
+	echo "$INPUT_PKGS"
+	echo "Using configured packages: $INPUT_PKGS" >&2
+fi

--- a/specs/001-crapload-workflow/quickstart.md
+++ b/specs/001-crapload-workflow/quickstart.md
@@ -31,7 +31,57 @@ jobs:
 
 ### 2. (Optional) Commit a baseline file
 
-To enable regression detection, commit a baseline at `.gaze/baseline.json`. This file contains per-function CRAP scores from a known-good state. Without it, the workflow still runs but skips per-function comparison.
+To enable regression detection, generate and commit a baseline at `.gaze/baseline.json`. This file contains per-function CRAP scores from a known-good state. Without it, the workflow still runs but skips per-function comparison.
+
+**Generate a baseline:**
+
+```bash
+# 1. Install gaze
+go install github.com/unbound-force/gaze/cmd/gaze@latest
+
+# 2. Determine packages to analyze
+# For single-module repos (go.mod at root):
+PACKAGES="./..."
+
+# For multi-module repos (no root go.mod), auto-discover:
+PACKAGES=$(find . -name go.mod -type f -not -path '*/vendor/*' \
+  | xargs dirname | sed 's|^\./||' | sed 's|^$|.|' | sed 's|$|/...|' | paste -sd ' ')
+
+# 3. Run tests with coverage
+go test -coverprofile=coverage.out $PACKAGES
+
+# 4. Generate baseline
+mkdir -p .gaze
+gaze report --format=json --coverprofile=coverage.out $PACKAGES | jq '.crap' > .gaze/baseline.json
+
+# 5. Commit the baseline
+git add .gaze/baseline.json
+git commit -m "chore: add CRAP baseline for regression detection"
+```
+
+**For multi-module projects:**
+
+The workflow automatically discovers all Go modules when the default `./...` pattern doesn't resolve packages (e.g., no code at root, or root go.mod contains only tools). No additional configuration is required.
+
+To analyze only specific modules (e.g., exclude experimental packages), specify packages explicitly:
+
+```bash
+# Run tests for specific packages only
+go test -coverprofile=coverage.out ./cmd/... ./pkg/...
+
+# Generate baseline with the same packages
+gaze report --format=json --coverprofile=coverage.out ./cmd/... ./pkg/... | jq '.crap' > .gaze/baseline.json
+```
+
+And configure the `packages` input in your workflow:
+
+```yaml
+jobs:
+  crapload:
+    uses: complytime/org-infra/.github/workflows/reusable_crapload_analysis.yml@main
+    with:
+      packages: './cmd/... ./pkg/...'  # Analyze only these modules
+```
 
 ### 3. Open a pull request
 

--- a/tests/test_crapload_package_resolution.py
+++ b/tests/test_crapload_package_resolution.py
@@ -1,0 +1,475 @@
+# SPDX-License-Identifier: Apache-2.0
+
+"""Integration tests for CRAP load workflow package resolution."""
+
+import json
+import os
+import subprocess
+import tempfile
+from pathlib import Path
+
+
+class TestCrapLoadPackageResolution:
+    """Tests for scripts/resolve-go-packages.sh."""
+
+    @staticmethod
+    def _run_script(fixture_dir, args=""):
+        """Run resolve-go-packages.sh in fixture directory."""
+        project_root = Path(__file__).parent.parent
+        script_path = project_root / "scripts" / "resolve-go-packages.sh"
+
+        cmd = f"bash {script_path} {args}"
+        result = subprocess.run(
+            cmd,
+            shell=True,
+            cwd=fixture_dir,
+            capture_output=True,
+            text=True,
+        )
+        return result
+
+    def test_single_module_repo(self):
+        """Single module repo (go.mod at root with packages)."""
+        with tempfile.TemporaryDirectory() as fixture:
+            # Setup single-module fixture
+            subprocess.run(["go", "mod", "init", "example.com/single"], cwd=fixture, check=True)
+            cmd_app = Path(fixture) / "cmd" / "app"
+            cmd_app.mkdir(parents=True)
+            (cmd_app / "main.go").write_text("package main\nfunc main() {}\n")
+
+            # Run the script
+            result = self._run_script(fixture)
+
+            # Verify
+            assert result.returncode == 0
+            assert result.stdout.strip() == "./..."
+
+    def test_multi_module_repo(self):
+        """Multi-module repo (no root go.mod)."""
+        with tempfile.TemporaryDirectory() as fixture:
+            # Setup multi-module fixture
+            cmd_app = Path(fixture) / "cmd" / "app"
+            cmd_app.mkdir(parents=True)
+            subprocess.run(["go", "mod", "init", "example.com/app"], cwd=cmd_app, check=True)
+            (cmd_app / "main.go").write_text("package main\nfunc main() {}\n")
+
+            pkg_lib = Path(fixture) / "pkg" / "lib"
+            pkg_lib.mkdir(parents=True)
+            subprocess.run(["go", "mod", "init", "example.com/lib"], cwd=pkg_lib, check=True)
+            (pkg_lib / "lib.go").write_text('package lib\nfunc Hello() string { return "hello" }\n')
+
+            # Run the script
+            result = self._run_script(fixture)
+
+            # Verify
+            assert result.returncode == 0
+            tokens = result.stdout.split()
+            assert "cmd/app/..." in tokens
+            assert "pkg/lib/..." in tokens
+
+    def test_go_workspace(self):
+        """Go workspace (go.work with multiple modules)."""
+        with tempfile.TemporaryDirectory() as fixture:
+            # Create workspace
+            subprocess.run(["go", "work", "init"], cwd=fixture, check=True)
+
+            # Create tools module
+            tools = Path(fixture) / "tools"
+            tools.mkdir()
+            subprocess.run(["go", "mod", "init", "example.com/tools"], cwd=tools, check=True)
+            (tools / "tools.go").write_text("package tools\n")
+            subprocess.run(["go", "work", "use", "."], cwd=tools, check=True)
+
+            # Create app module
+            app = Path(fixture) / "app"
+            app.mkdir()
+            subprocess.run(["go", "mod", "init", "example.com/app"], cwd=app, check=True)
+            (app / "main.go").write_text("package main\nfunc main() {}\n")
+            subprocess.run(["go", "work", "use", "."], cwd=app, check=True)
+
+            # Run the script
+            result = self._run_script(fixture)
+
+            # Verify
+            assert result.returncode == 0
+            tokens = result.stdout.split()
+            assert "app/..." in tokens
+            assert "tools/..." in tokens
+
+    def test_explicit_package_override(self):
+        """Explicit package override."""
+        with tempfile.TemporaryDirectory() as fixture:
+            # Setup multi-module fixture
+            cmd_app = Path(fixture) / "cmd" / "app"
+            cmd_app.mkdir(parents=True)
+            subprocess.run(["go", "mod", "init", "example.com/app"], cwd=cmd_app, check=True)
+            (cmd_app / "main.go").write_text("package main\nfunc main() {}\n")
+
+            cmd_exp = Path(fixture) / "cmd" / "experimental"
+            cmd_exp.mkdir(parents=True)
+            subprocess.run(["go", "mod", "init", "example.com/experimental"], cwd=cmd_exp, check=True)
+            (cmd_exp / "main.go").write_text("package main\nfunc main() {}\n")
+
+            pkg_lib = Path(fixture) / "pkg" / "lib"
+            pkg_lib.mkdir(parents=True)
+            subprocess.run(["go", "mod", "init", "example.com/lib"], cwd=pkg_lib, check=True)
+            (pkg_lib / "lib.go").write_text('package lib\nfunc Hello() string { return "hello" }\n')
+
+            # Run with explicit packages
+            result = self._run_script(fixture, args="./cmd/app/... ./pkg/lib/...")
+
+            # Verify
+            assert result.returncode == 0
+            # Script outputs each package on its own line
+            assert "./cmd/app/..." in result.stdout
+            assert "experimental" not in result.stdout and "experimental" not in result.stderr
+
+    def test_empty_repo(self):
+        """Empty repo (should fail gracefully)."""
+        with tempfile.TemporaryDirectory() as fixture:
+            # Run script in empty directory
+            result = self._run_script(fixture)
+
+            # Verify
+            assert result.returncode == 1
+            assert "No Go modules found" in result.stderr
+
+    def test_single_module_with_vendor(self):
+        """Single module with vendor (vendor auto-excluded)."""
+        with tempfile.TemporaryDirectory() as fixture:
+            # Setup single module
+            subprocess.run(["go", "mod", "init", "example.com/test"], cwd=fixture, check=True)
+            cmd_app = Path(fixture) / "cmd" / "app"
+            cmd_app.mkdir(parents=True)
+            (cmd_app / "main.go").write_text("package main\nfunc main() {}\n")
+
+            # Add vendor directory
+            vendor = Path(fixture) / "vendor" / "github.com" / "some" / "dep"
+            vendor.mkdir(parents=True)
+            (vendor / "go.mod").write_text("module github.com/some/dep\n")
+
+            # Run the script
+            result = self._run_script(fixture)
+
+            # Verify
+            assert result.returncode == 0
+            assert result.stdout.strip() == "./..."
+            assert "Using default packages" in result.stderr
+
+    def test_malformed_go_mod(self):
+        """Malformed go.mod (discovers module despite invalid syntax)."""
+        with tempfile.TemporaryDirectory() as fixture:
+            # Create invalid go.mod
+            (Path(fixture) / "go.mod").write_text("this is not valid go.mod syntax\n")
+
+            # Run the script
+            result = self._run_script(fixture)
+
+            # Verify - script discovers the go.mod file (validation happens in 'go list' later)
+            assert result.returncode == 0
+            assert "Found 1 module" in result.stderr
+            assert result.stdout.strip() == "./..."
+
+    def test_empty_module(self):
+        """Empty module (no packages under ./...)."""
+        with tempfile.TemporaryDirectory() as fixture:
+            # Create valid go.mod but no Go files
+            subprocess.run(["go", "mod", "init", "example.com/empty"], cwd=fixture, check=True)
+
+            # Run the script
+            result = self._run_script(fixture)
+
+            # Verify
+            assert result.returncode == 0
+            assert result.stdout.strip() == "./..."
+
+
+class TestWorkflowInputValidation:
+    """Tests for GitHub Actions workflow input validation patterns."""
+
+    # Mirrors: reusable_compliance.yml "Validate policy_id input" step (lines ~103-111)
+    @staticmethod
+    def _validate_policy_id(policy_id):
+        """Validate policy_id using workflow regex."""
+        import re
+        if not re.match(r"^[a-zA-Z0-9_-]+$", policy_id):
+            return False
+        return True
+
+    # Mirrors: reusable_compliance.yml "Validate complytime_config_path input" step (added by this PR)
+    @staticmethod
+    def _validate_path(path):
+        """Validate complytime_config_path using workflow rules."""
+        import re
+        if not re.match(r"^[a-zA-Z0-9_./-]+$", path):
+            return False
+        if ".." in path:
+            return False
+        return True
+
+    def test_policy_id_valid_values(self):
+        """Test valid policy_id patterns."""
+        assert self._validate_policy_id("ampel-bp") is True
+        assert self._validate_policy_id("policy_123") is True
+        assert self._validate_policy_id("test-policy-v2") is True
+        assert self._validate_policy_id("UPPERCASE") is True
+        assert self._validate_policy_id("a1b2c3") is True
+
+    def test_policy_id_invalid_values(self):
+        """Test invalid policy_id patterns are rejected."""
+        assert self._validate_policy_id("../evil") is False
+        assert self._validate_policy_id(";rm -rf /") is False
+        assert self._validate_policy_id("") is False
+        assert self._validate_policy_id("policy.with.dots") is False
+        assert self._validate_policy_id("policy with spaces") is False
+
+    def test_complytime_config_path_valid_values(self):
+        """Test valid complytime_config_path patterns."""
+        assert self._validate_path("complytime.yaml") is True
+        assert self._validate_path(".github/complytime.yaml") is True
+        assert self._validate_path("config/complytime.yaml") is True
+        assert self._validate_path("my_config.yaml") is True
+
+    def test_complytime_config_path_traversal_rejection(self):
+        """Test path traversal attacks are blocked."""
+        assert self._validate_path("../../etc/passwd") is False
+        assert self._validate_path("../evil") is False
+        assert self._validate_path("subdir/../../../etc/passwd") is False
+
+    def test_complytime_config_path_shell_metacharacters(self):
+        """Test shell metacharacters are blocked."""
+        assert self._validate_path("file; rm -rf /") is False
+        assert self._validate_path("file$var.yaml") is False
+        assert self._validate_path("file*.yaml") is False
+        assert self._validate_path("file|cat") is False
+        assert self._validate_path("file&background") is False
+
+    def test_complytime_config_path_canonical_check(self):
+        """Test realpath canonicalization and root escape detection."""
+        with tempfile.TemporaryDirectory() as fixture:
+            caller_dir = Path(fixture) / "_caller"
+            caller_dir.mkdir()
+            config_dir = caller_dir / "config"
+            config_dir.mkdir()
+
+            # Create test files
+            (caller_dir / "complytime.yaml").touch()
+            (config_dir / "complytime.yaml").touch()
+
+            # Valid paths within caller
+            original_dir = os.getcwd()
+            try:
+                os.chdir(fixture)
+                real = os.path.realpath(os.path.join("_caller", "complytime.yaml"))
+                caller_root = os.path.realpath("_caller")
+                assert real.startswith(caller_root + "/")
+
+                real = os.path.realpath(os.path.join("_caller", "config/complytime.yaml"))
+                assert real.startswith(caller_root + "/")
+            finally:
+                os.chdir(original_dir)
+
+
+class TestCompareCrapload:
+    """Tests for .github/scripts/compare-crapload.sh."""
+
+    _MINIMAL_SUMMARY = {
+        "crapload": 0,
+        "gaze_crapload": 0,
+        "avg_complexity": 1.0,
+        "avg_line_coverage": 80.0,
+        "avg_crap": 5.0,
+        "crap_threshold": 15,
+        "avg_contract_coverage": 70.0,
+        "avg_gaze_crap": 5.0,
+        "gaze_crap_threshold": 15,
+        "total_functions": 1,
+    }
+
+    @staticmethod
+    def _run_script(
+        current_json_path,
+        baseline_json_path,
+        threshold=30,
+        epsilon=0.5,
+        gaze_version="latest",
+        gaze_report="/dev/null",
+    ):
+        """Run compare-crapload.sh from repo root and return CompletedProcess."""
+        project_root = Path(__file__).parent.parent
+        script_path = project_root / ".github" / "scripts" / "compare-crapload.sh"
+        result = subprocess.run(
+            [
+                "bash",
+                str(script_path),
+                str(current_json_path),
+                str(baseline_json_path),
+                str(threshold),
+                str(epsilon),
+                str(gaze_version),
+                str(gaze_report),
+            ],
+            capture_output=True,
+            text=True,
+            cwd=str(project_root),
+        )
+        return result
+
+    def test_no_baseline(self):
+        """No baseline file → status=pass with 'no baseline' comment."""
+        current_data = {
+            "summary": dict(self._MINIMAL_SUMMARY),
+            "scores": [{"file": "pkg/foo.go", "function": "Bar", "crap": 5.0, "gaze_crap": 5.0}],
+        }
+        tmp_current = None
+        try:
+            with tempfile.NamedTemporaryFile(
+                mode="w", suffix=".json", delete=False,
+            ) as f:
+                json.dump(current_data, f)
+                tmp_current = f.name
+
+            nonexistent_baseline = tmp_current + ".nonexistent"
+            result = self._run_script(tmp_current, nonexistent_baseline)
+
+            assert result.returncode == 0
+            assert "status=pass" in result.stdout
+
+            comment_path = Path("/tmp/crapload-comment-body.md")
+            assert comment_path.exists()
+            comment_body = comment_path.read_text()
+            assert "<!-- crapload-analysis-marker -->" in comment_body
+            assert "no baseline" in comment_body.lower()
+        finally:
+            if tmp_current and os.path.exists(tmp_current):
+                os.unlink(tmp_current)
+
+    def test_regression_detected(self):
+        """Regression (current CRAP > baseline + epsilon) → status=fail, regressions_count=1."""
+        current_data = {
+            "summary": dict(self._MINIMAL_SUMMARY),
+            "scores": [{"file": "pkg/foo.go", "function": "Bar", "crap": 20.0, "gaze_crap": 20.0}],
+        }
+        baseline_data = {
+            "summary": dict(self._MINIMAL_SUMMARY),
+            "scores": [{"file": "pkg/foo.go", "function": "Bar", "crap": 5.0, "gaze_crap": 5.0}],
+        }
+        tmp_current = tmp_baseline = None
+        try:
+            with tempfile.NamedTemporaryFile(
+                mode="w", suffix=".json", delete=False,
+            ) as f:
+                json.dump(current_data, f)
+                tmp_current = f.name
+            with tempfile.NamedTemporaryFile(
+                mode="w", suffix=".json", delete=False,
+            ) as f:
+                json.dump(baseline_data, f)
+                tmp_baseline = f.name
+
+            result = self._run_script(tmp_current, tmp_baseline, epsilon=0.5)
+
+            assert result.returncode == 0
+            assert "status=fail" in result.stdout
+            assert "regressions_count=1" in result.stdout
+        finally:
+            for path in (tmp_current, tmp_baseline):
+                if path and os.path.exists(path):
+                    os.unlink(path)
+
+    def test_improvement_detected(self):
+        """Improvement (current CRAP < baseline - epsilon) → status=pass, improvements_count=1."""
+        current_data = {
+            "summary": dict(self._MINIMAL_SUMMARY),
+            "scores": [{"file": "pkg/foo.go", "function": "Bar", "crap": 5.0, "gaze_crap": 5.0}],
+        }
+        baseline_data = {
+            "summary": dict(self._MINIMAL_SUMMARY),
+            "scores": [{"file": "pkg/foo.go", "function": "Bar", "crap": 20.0, "gaze_crap": 20.0}],
+        }
+        tmp_current = tmp_baseline = None
+        try:
+            with tempfile.NamedTemporaryFile(
+                mode="w", suffix=".json", delete=False,
+            ) as f:
+                json.dump(current_data, f)
+                tmp_current = f.name
+            with tempfile.NamedTemporaryFile(
+                mode="w", suffix=".json", delete=False,
+            ) as f:
+                json.dump(baseline_data, f)
+                tmp_baseline = f.name
+
+            result = self._run_script(tmp_current, tmp_baseline, epsilon=0.5)
+
+            assert result.returncode == 0
+            assert "status=pass" in result.stdout
+            assert "improvements_count=1" in result.stdout
+        finally:
+            for path in (tmp_current, tmp_baseline):
+                if path and os.path.exists(path):
+                    os.unlink(path)
+
+    def test_new_function_above_threshold(self):
+        """New function with CRAP > threshold → status=fail."""
+        current_data = {
+            "summary": dict(self._MINIMAL_SUMMARY),
+            "scores": [{"file": "pkg/foo.go", "function": "NewFunc", "crap": 50.0, "gaze_crap": 50.0}],
+        }
+        baseline_data = {
+            "summary": dict(self._MINIMAL_SUMMARY),
+            "scores": [{"file": "pkg/foo.go", "function": "OtherFunc", "crap": 5.0, "gaze_crap": 5.0}],
+        }
+        tmp_current = tmp_baseline = None
+        try:
+            with tempfile.NamedTemporaryFile(
+                mode="w", suffix=".json", delete=False,
+            ) as f:
+                json.dump(current_data, f)
+                tmp_current = f.name
+            with tempfile.NamedTemporaryFile(
+                mode="w", suffix=".json", delete=False,
+            ) as f:
+                json.dump(baseline_data, f)
+                tmp_baseline = f.name
+
+            result = self._run_script(tmp_current, tmp_baseline, threshold=30)
+
+            assert result.returncode == 0
+            assert "status=fail" in result.stdout
+        finally:
+            for path in (tmp_current, tmp_baseline):
+                if path and os.path.exists(path):
+                    os.unlink(path)
+
+    def test_new_function_below_threshold(self):
+        """New function with CRAP <= threshold → status=pass."""
+        current_data = {
+            "summary": dict(self._MINIMAL_SUMMARY),
+            "scores": [{"file": "pkg/foo.go", "function": "NewFunc", "crap": 10.0, "gaze_crap": 10.0}],
+        }
+        baseline_data = {
+            "summary": dict(self._MINIMAL_SUMMARY),
+            "scores": [],
+        }
+        tmp_current = tmp_baseline = None
+        try:
+            with tempfile.NamedTemporaryFile(
+                mode="w", suffix=".json", delete=False,
+            ) as f:
+                json.dump(current_data, f)
+                tmp_current = f.name
+            with tempfile.NamedTemporaryFile(
+                mode="w", suffix=".json", delete=False,
+            ) as f:
+                json.dump(baseline_data, f)
+                tmp_baseline = f.name
+
+            result = self._run_script(tmp_current, tmp_baseline, threshold=30)
+
+            assert result.returncode == 0
+            assert "status=pass" in result.stdout
+        finally:
+            for path in (tmp_current, tmp_baseline):
+                if path and os.path.exists(path):
+                    os.unlink(path)


### PR DESCRIPTION
- Extract package resolution into scripts/resolve-go-packages.sh for multi-module Go repos
- Replace terse "no baseline" warning with step-by-step setup instructions in workflow output and PR comments
- Add Venom integration tests and CI workflow for package resolution across 6 repo patterns
- Introduce Python venv management in Makefile; add ruff and yamllint to requirements.txt

Details:

Workflow (reusable_crapload_analysis.yml):
- Add resolve-packages step that falls back to module auto-discovery when ./... fails
- Route coverage and gaze analysis through resolved packages instead of raw input
- Expand missing-baseline output with copy-pasteable gaze setup commands in both the log warning and the PR comment body

Package resolution script (scripts/resolve-go-packages.sh):
- Try ./... first; on failure, find all go.mod files and build per-module patterns
- Skip vendor and hidden directories during discovery
- Exit non-zero with a clear error when no modules exist

Tests and CI:
- Add tests/crapload-package-resolution.venom.yml covering single-module, multi-module, go.work, explicit override, empty repo, and vendor exclusion scenarios
- Add ci_test_crapload.yml workflow triggered by changes to the script, tests, or workflow
- Wire make test-crapload into the existing make test target

Build tooling (Makefile):
- Add venv target that creates .venv and installs from requirements.txt
- Repoint lint, test-python, and sync-dry-run targets through the venv
- Add clean-venv target; extend clean to remove venom logs and pytest cache

Documentation:
- Add Testing section to README.md with quick-start commands
- Expand docs/LOCAL_TESTING.md with CRAP load workflow testing guide
- Add docs/testing-approach.md describing test infrastructure and scenarios
- Update specs/001-crapload-workflow/quickstart.md with baseline generation steps

Fixes: #251
Fixes: #252