### PR TITLE
feat: add Vertex AI WIF integration test workflow

### DIFF
--- a/.github/workflows/ci_council_review_test.yml
+++ b/.github/workflows/ci_council_review_test.yml
@@ -28,6 +28,10 @@ on:
     branches:
       - main
 
+concurrency:
+  group: council-review-test-${{ github.event.pull_request.number }}
+  cancel-in-progress: true
+
 permissions:
   contents: read
   id-token: write

--- a/.github/workflows/ci_council_review_test.yml
+++ b/.github/workflows/ci_council_review_test.yml
@@ -1,0 +1,371 @@
+# Test workflow for AI Council Review provider integration
+#
+# Purpose: Validates that GitHub Actions can authenticate to an AI API
+# and call Claude models. Supports two provider paths:
+#
+#   1. GCP Vertex AI via Workload Identity Federation (WIF)
+#      Secrets: GCP_WORKLOAD_IDENTITY_PROVIDER, GCP_SERVICE_ACCOUNT, GCP_PROJECT_ID
+#
+#   2. Generic API key (Anthropic direct, OpenAI, etc.)
+#      Secrets: AI_API_KEY, AI_API_ENDPOINT
+#
+# The workflow auto-detects which path to use. WIF takes precedence.
+#
+# This is a temporary test workflow. Once validated, the authentication
+# pattern will be integrated into reusable_council_review.yml.
+#
+# Test procedure:
+# 1. Configure secrets (WIF: see docs/VERTEX_AI_WIF_SETUP.md; or set AI_API_KEY)
+# 2. Push this file on a branch and open a PR
+# 3. Verify: auth succeeds, AI call returns a response
+# 4. Verify: fork PRs skip gracefully (no secrets available)
+# 5. Remove this workflow after validation
+
+name: Council Review Test
+
+on:
+  pull_request:
+    branches:
+      - main
+
+permissions:
+  contents: read
+  id-token: write
+  pull-requests: write
+
+jobs:
+  gate-checks:
+    name: Gate Checks
+    runs-on: ubuntu-latest
+    outputs:
+      should_review: ${{ steps.gate.outputs.should_review }}
+      skip_reason: ${{ steps.gate.outputs.skip_reason }}
+      provider: ${{ steps.gate.outputs.provider }}
+    steps:
+      - name: Check gate conditions
+        id: gate
+        env:
+          PR_AUTHOR: ${{ github.event.pull_request.user.login }}
+          PR_DRAFT: ${{ github.event.pull_request.draft }}
+          HAS_WIF: ${{ secrets.GCP_WORKLOAD_IDENTITY_PROVIDER != '' }}
+          HAS_API_KEY: ${{ secrets.AI_API_KEY != '' }}
+        run: |
+          if [[ "${PR_AUTHOR}" == "dependabot[bot]" ]]; then
+            echo "should_review=false" >> "$GITHUB_OUTPUT"
+            echo "skip_reason=Dependabot PR" >> "$GITHUB_OUTPUT"
+            exit 0
+          fi
+
+          if [[ "${PR_DRAFT}" == "true" ]]; then
+            echo "should_review=false" >> "$GITHUB_OUTPUT"
+            echo "skip_reason=Draft PR" >> "$GITHUB_OUTPUT"
+            exit 0
+          fi
+
+          # Detect provider: WIF takes precedence over generic API key
+          if [[ "${HAS_WIF}" == "true" ]]; then
+            echo "provider=vertex-wif" >> "$GITHUB_OUTPUT"
+            echo "should_review=true" >> "$GITHUB_OUTPUT"
+            echo "skip_reason=" >> "$GITHUB_OUTPUT"
+          elif [[ "${HAS_API_KEY}" == "true" ]]; then
+            echo "provider=generic-api" >> "$GITHUB_OUTPUT"
+            echo "should_review=true" >> "$GITHUB_OUTPUT"
+            echo "skip_reason=" >> "$GITHUB_OUTPUT"
+          else
+            echo "should_review=false" >> "$GITHUB_OUTPUT"
+            echo "skip_reason=No AI credentials configured (fork PR or secrets not set)" >> "$GITHUB_OUTPUT"
+          fi
+
+  test-vertex-wif:
+    name: Test Vertex AI (WIF)
+    needs: gate-checks
+    if: needs.gate-checks.outputs.should_review == 'true' && needs.gate-checks.outputs.provider == 'vertex-wif'
+    runs-on: ubuntu-latest
+    permissions:
+      contents: read
+      id-token: write
+      pull-requests: write
+    steps:
+      - name: Authenticate to Google Cloud
+        id: auth
+        uses: google-github-actions/auth@v3
+        with:
+          project_id: ${{ secrets.GCP_PROJECT_ID }}
+          workload_identity_provider: ${{ secrets.GCP_WORKLOAD_IDENTITY_PROVIDER }}
+          service_account: ${{ secrets.GCP_SERVICE_ACCOUNT }}
+          token_format: access_token
+
+      - name: Verify authentication
+        id: verify-auth
+        env:
+          ACCESS_TOKEN: ${{ steps.auth.outputs.access_token }}
+          PROJECT_ID: ${{ steps.auth.outputs.project_id }}
+        run: |
+          echo "Project ID: ${PROJECT_ID}"
+          echo "Access token length: ${#ACCESS_TOKEN}"
+
+          if [[ -z "${ACCESS_TOKEN}" ]]; then
+            echo "::error::Access token is empty"
+            exit 1
+          fi
+          echo "auth_ok=true" >> "$GITHUB_OUTPUT"
+
+      - name: Test Vertex AI Claude call
+        id: vertex-test
+        env:
+          ACCESS_TOKEN: ${{ steps.auth.outputs.access_token }}
+          PROJECT_ID: ${{ secrets.GCP_PROJECT_ID }}
+          REGION: "us-east5"
+          MODEL: "claude-sonnet-4-6"
+        run: |
+          ENDPOINT="https://${REGION}-aiplatform.googleapis.com/v1/projects/${PROJECT_ID}/locations/${REGION}/publishers/anthropic/models/${MODEL}:rawPredict"
+
+          echo "Calling: ${ENDPOINT}"
+          echo "Model: ${MODEL}"
+
+          RESPONSE=$(curl -s -w "\nHTTP_STATUS:%{http_code}" \
+            -X POST "${ENDPOINT}" \
+            -H "Authorization: Bearer ${ACCESS_TOKEN}" \
+            -H "Content-Type: application/json" \
+            -d '{
+              "anthropic_version": "vertex-2023-10-16",
+              "max_tokens": 100,
+              "messages": [
+                {
+                  "role": "user",
+                  "content": "Respond with exactly: VERTEX_AI_WIF_TEST_OK"
+                }
+              ]
+            }')
+
+          HTTP_CODE=$(echo "${RESPONSE}" | grep -o 'HTTP_STATUS:[0-9]*' | cut -d: -f2)
+          BODY=$(echo "${RESPONSE}" | sed 's/HTTP_STATUS:[0-9]*//')
+
+          echo "HTTP Status: ${HTTP_CODE}"
+
+          if [[ "${HTTP_CODE}" -ge 200 && "${HTTP_CODE}" -lt 300 ]]; then
+            echo "Vertex AI call succeeded"
+            echo "test_ok=true" >> "$GITHUB_OUTPUT"
+
+            TEXT=$(echo "${BODY}" | jq -r '.content[0].text // "NO_TEXT"' 2>/dev/null || echo "PARSE_ERROR")
+            echo "Response text: ${TEXT}"
+            echo "response_text=${TEXT}" >> "$GITHUB_OUTPUT"
+
+            INPUT_TOKENS=$(echo "${BODY}" | jq -r '.usage.input_tokens // "?"' 2>/dev/null || echo "?")
+            OUTPUT_TOKENS=$(echo "${BODY}" | jq -r '.usage.output_tokens // "?"' 2>/dev/null || echo "?")
+            echo "Tokens used: input=${INPUT_TOKENS}, output=${OUTPUT_TOKENS}"
+            echo "input_tokens=${INPUT_TOKENS}" >> "$GITHUB_OUTPUT"
+            echo "output_tokens=${OUTPUT_TOKENS}" >> "$GITHUB_OUTPUT"
+          else
+            echo "::error::Vertex AI call failed with HTTP ${HTTP_CODE}"
+            echo "${BODY}" | jq . 2>/dev/null || echo "${BODY}"
+            echo "test_ok=false" >> "$GITHUB_OUTPUT"
+
+            echo "error_body<<EOF" >> "$GITHUB_OUTPUT"
+            echo "${BODY}" | jq -r '.error.message // .error // "Unknown error"' 2>/dev/null || echo "${BODY}" | head -5
+            echo "EOF" >> "$GITHUB_OUTPUT"
+          fi
+
+      - name: Test council review prompt
+        id: council-test
+        if: steps.vertex-test.outputs.test_ok == 'true'
+        env:
+          ACCESS_TOKEN: ${{ steps.auth.outputs.access_token }}
+          PROJECT_ID: ${{ secrets.GCP_PROJECT_ID }}
+          REGION: "us-east5"
+          MODEL: "claude-sonnet-4-6"
+        run: |
+          ENDPOINT="https://${REGION}-aiplatform.googleapis.com/v1/projects/${PROJECT_ID}/locations/${REGION}/publishers/anthropic/models/${MODEL}:rawPredict"
+
+          RESPONSE=$(curl -s -w "\nHTTP_STATUS:%{http_code}" \
+            -X POST "${ENDPOINT}" \
+            -H "Authorization: Bearer ${ACCESS_TOKEN}" \
+            -H "Content-Type: application/json" \
+            -d '{
+              "anthropic_version": "vertex-2023-10-16",
+              "max_tokens": 256,
+              "system": "You are a code reviewer. Review the diff and respond with a JSON object containing: {\"verdict\": \"APPROVE\" or \"REQUEST_CHANGES\", \"findings\": [{\"severity\": \"LOW\", \"description\": \"...\"}]}",
+              "messages": [
+                {
+                  "role": "user",
+                  "content": "<diff>\n--- a/example.py\n+++ b/example.py\n@@ -1,3 +1,3 @@\n-print(\"hello\")\n+print(\"hello world\")\n</diff>\n\nReview this diff."
+                }
+              ]
+            }')
+
+          HTTP_CODE=$(echo "${RESPONSE}" | grep -o 'HTTP_STATUS:[0-9]*' | cut -d: -f2)
+          BODY=$(echo "${RESPONSE}" | sed 's/HTTP_STATUS:[0-9]*//')
+
+          if [[ "${HTTP_CODE}" -ge 200 && "${HTTP_CODE}" -lt 300 ]]; then
+            echo "Council prompt test succeeded"
+            TEXT=$(echo "${BODY}" | jq -r '.content[0].text // "NO_TEXT"' 2>/dev/null)
+            echo "Council response: ${TEXT}"
+            echo "council_ok=true" >> "$GITHUB_OUTPUT"
+
+            INPUT_TOKENS=$(echo "${BODY}" | jq -r '.usage.input_tokens // "?"' 2>/dev/null)
+            OUTPUT_TOKENS=$(echo "${BODY}" | jq -r '.usage.output_tokens // "?"' 2>/dev/null)
+            echo "council_tokens=input=${INPUT_TOKENS}, output=${OUTPUT_TOKENS}" >> "$GITHUB_OUTPUT"
+          else
+            echo "::warning::Council prompt test failed with HTTP ${HTTP_CODE}"
+            echo "council_ok=false" >> "$GITHUB_OUTPUT"
+          fi
+
+      - name: Post test results
+        uses: peter-evans/create-or-update-comment@e8674b075228eee787fea43ef493e45ece1004c9 # v5.0.0
+        with:
+          issue-number: ${{ github.event.pull_request.number }}
+          edit-mode: replace
+          body: |
+            ## AI Provider Integration Test — Vertex AI (WIF)
+
+            | Check | Status | Details |
+            |-------|--------|---------|
+            | WIF Authentication | ${{ steps.auth.outputs.access_token != '' && 'PASS' || 'FAIL' }} | Project: `${{ steps.auth.outputs.project_id }}` |
+            | Vertex AI Call | ${{ steps.vertex-test.outputs.test_ok == 'true' && 'PASS' || 'FAIL' }} | Response: `${{ steps.vertex-test.outputs.response_text || steps.vertex-test.outputs.error_body || 'N/A' }}` |
+            | Token Usage (basic) | ${{ steps.vertex-test.outputs.test_ok == 'true' && 'OK' || 'N/A' }} | input=${{ steps.vertex-test.outputs.input_tokens || '?' }}, output=${{ steps.vertex-test.outputs.output_tokens || '?' }} |
+            | Council Prompt | ${{ steps.council-test.outputs.council_ok == 'true' && 'PASS' || steps.vertex-test.outputs.test_ok != 'true' && 'SKIPPED' || 'FAIL' }} | ${{ steps.council-test.outputs.council_tokens || 'N/A' }} |
+
+            **Provider**: Vertex AI via Workload Identity Federation
+            **Overall: ${{ steps.vertex-test.outputs.test_ok == 'true' && 'READY for integration' || 'NEEDS ATTENTION' }}**
+
+            ---
+            *AI provider integration test. Remove this workflow after validation.*
+
+  test-generic-api:
+    name: Test Generic API
+    needs: gate-checks
+    if: needs.gate-checks.outputs.should_review == 'true' && needs.gate-checks.outputs.provider == 'generic-api'
+    runs-on: ubuntu-latest
+    permissions:
+      contents: read
+      pull-requests: write
+    steps:
+      - name: Test API call
+        id: api-test
+        env:
+          AI_API_KEY: ${{ secrets.AI_API_KEY }}
+          AI_API_ENDPOINT: ${{ secrets.AI_API_ENDPOINT }}
+        run: |
+          ENDPOINT="${AI_API_ENDPOINT:-https://api.anthropic.com/v1/messages}"
+
+          echo "Calling: ${ENDPOINT}"
+
+          RESPONSE=$(curl -s -w "\nHTTP_STATUS:%{http_code}" \
+            -X POST "${ENDPOINT}" \
+            -H "x-api-key: ${AI_API_KEY}" \
+            -H "anthropic-version: 2023-06-01" \
+            -H "Content-Type: application/json" \
+            -d '{
+              "model": "claude-sonnet-4-6-20250514",
+              "max_tokens": 100,
+              "messages": [
+                {
+                  "role": "user",
+                  "content": "Respond with exactly: GENERIC_API_TEST_OK"
+                }
+              ]
+            }')
+
+          HTTP_CODE=$(echo "${RESPONSE}" | grep -o 'HTTP_STATUS:[0-9]*' | cut -d: -f2)
+          BODY=$(echo "${RESPONSE}" | sed 's/HTTP_STATUS:[0-9]*//')
+
+          echo "HTTP Status: ${HTTP_CODE}"
+
+          if [[ "${HTTP_CODE}" -ge 200 && "${HTTP_CODE}" -lt 300 ]]; then
+            echo "API call succeeded"
+            echo "test_ok=true" >> "$GITHUB_OUTPUT"
+
+            TEXT=$(echo "${BODY}" | jq -r '.content[0].text // "NO_TEXT"' 2>/dev/null || echo "PARSE_ERROR")
+            echo "Response text: ${TEXT}"
+            echo "response_text=${TEXT}" >> "$GITHUB_OUTPUT"
+
+            INPUT_TOKENS=$(echo "${BODY}" | jq -r '.usage.input_tokens // "?"' 2>/dev/null || echo "?")
+            OUTPUT_TOKENS=$(echo "${BODY}" | jq -r '.usage.output_tokens // "?"' 2>/dev/null || echo "?")
+            echo "Tokens used: input=${INPUT_TOKENS}, output=${OUTPUT_TOKENS}"
+            echo "input_tokens=${INPUT_TOKENS}" >> "$GITHUB_OUTPUT"
+            echo "output_tokens=${OUTPUT_TOKENS}" >> "$GITHUB_OUTPUT"
+          else
+            echo "::error::API call failed with HTTP ${HTTP_CODE}"
+            echo "${BODY}" | jq . 2>/dev/null || echo "${BODY}"
+            echo "test_ok=false" >> "$GITHUB_OUTPUT"
+
+            echo "error_body<<EOF" >> "$GITHUB_OUTPUT"
+            echo "${BODY}" | jq -r '.error.message // .error // "Unknown error"' 2>/dev/null || echo "${BODY}" | head -5
+            echo "EOF" >> "$GITHUB_OUTPUT"
+          fi
+
+      - name: Test council review prompt
+        id: council-test
+        if: steps.api-test.outputs.test_ok == 'true'
+        env:
+          AI_API_KEY: ${{ secrets.AI_API_KEY }}
+          AI_API_ENDPOINT: ${{ secrets.AI_API_ENDPOINT }}
+        run: |
+          ENDPOINT="${AI_API_ENDPOINT:-https://api.anthropic.com/v1/messages}"
+
+          RESPONSE=$(curl -s -w "\nHTTP_STATUS:%{http_code}" \
+            -X POST "${ENDPOINT}" \
+            -H "x-api-key: ${AI_API_KEY}" \
+            -H "anthropic-version: 2023-06-01" \
+            -H "Content-Type: application/json" \
+            -d '{
+              "model": "claude-sonnet-4-6-20250514",
+              "max_tokens": 256,
+              "system": "You are a code reviewer. Review the diff and respond with a JSON object containing: {\"verdict\": \"APPROVE\" or \"REQUEST_CHANGES\", \"findings\": [{\"severity\": \"LOW\", \"description\": \"...\"}]}",
+              "messages": [
+                {
+                  "role": "user",
+                  "content": "<diff>\n--- a/example.py\n+++ b/example.py\n@@ -1,3 +1,3 @@\n-print(\"hello\")\n+print(\"hello world\")\n</diff>\n\nReview this diff."
+                }
+              ]
+            }')
+
+          HTTP_CODE=$(echo "${RESPONSE}" | grep -o 'HTTP_STATUS:[0-9]*' | cut -d: -f2)
+          BODY=$(echo "${RESPONSE}" | sed 's/HTTP_STATUS:[0-9]*//')
+
+          if [[ "${HTTP_CODE}" -ge 200 && "${HTTP_CODE}" -lt 300 ]]; then
+            echo "Council prompt test succeeded"
+            TEXT=$(echo "${BODY}" | jq -r '.content[0].text // "NO_TEXT"' 2>/dev/null)
+            echo "Council response: ${TEXT}"
+            echo "council_ok=true" >> "$GITHUB_OUTPUT"
+
+            INPUT_TOKENS=$(echo "${BODY}" | jq -r '.usage.input_tokens // "?"' 2>/dev/null)
+            OUTPUT_TOKENS=$(echo "${BODY}" | jq -r '.usage.output_tokens // "?"' 2>/dev/null)
+            echo "council_tokens=input=${INPUT_TOKENS}, output=${OUTPUT_TOKENS}" >> "$GITHUB_OUTPUT"
+          else
+            echo "::warning::Council prompt test failed with HTTP ${HTTP_CODE}"
+            echo "council_ok=false" >> "$GITHUB_OUTPUT"
+          fi
+
+      - name: Post test results
+        uses: peter-evans/create-or-update-comment@e8674b075228eee787fea43ef493e45ece1004c9 # v5.0.0
+        with:
+          issue-number: ${{ github.event.pull_request.number }}
+          edit-mode: replace
+          body: |
+            ## AI Provider Integration Test — Generic API Key
+
+            | Check | Status | Details |
+            |-------|--------|---------|
+            | API Authentication | ${{ steps.api-test.outputs.test_ok == 'true' && 'PASS' || 'FAIL' }} | Endpoint: `${{ secrets.AI_API_ENDPOINT || 'https://api.anthropic.com/v1/messages' }}` |
+            | API Call | ${{ steps.api-test.outputs.test_ok == 'true' && 'PASS' || 'FAIL' }} | Response: `${{ steps.api-test.outputs.response_text || steps.api-test.outputs.error_body || 'N/A' }}` |
+            | Token Usage (basic) | ${{ steps.api-test.outputs.test_ok == 'true' && 'OK' || 'N/A' }} | input=${{ steps.api-test.outputs.input_tokens || '?' }}, output=${{ steps.api-test.outputs.output_tokens || '?' }} |
+            | Council Prompt | ${{ steps.council-test.outputs.council_ok == 'true' && 'PASS' || steps.api-test.outputs.test_ok != 'true' && 'SKIPPED' || 'FAIL' }} | ${{ steps.council-test.outputs.council_tokens || 'N/A' }} |
+
+            **Provider**: Generic API Key
+            **Overall: ${{ steps.api-test.outputs.test_ok == 'true' && 'READY for integration' || 'NEEDS ATTENTION' }}**
+
+            ---
+            *AI provider integration test. Remove this workflow after validation.*
+
+  post-skip:
+    name: Log Skip
+    needs: gate-checks
+    if: needs.gate-checks.outputs.should_review == 'false'
+    runs-on: ubuntu-latest
+    steps:
+      - name: Log skip reason
+        env:
+          SKIP_REASON: ${{ needs.gate-checks.outputs.skip_reason }}
+        run: |
+          echo "Council review test skipped: ${SKIP_REASON}"

--- a/docs/REUSABLE_WORKFLOW_WIF_PATCH.md
+++ b/docs/REUSABLE_WORKFLOW_WIF_PATCH.md
@@ -1,0 +1,212 @@
+# WIF Integration Patch for reusable_council_review.yml
+
+This document specifies the changes needed to add Vertex AI WIF support
+to `reusable_council_review.yml` from PR #218. The changes implement the
+two-tier provider interface: GCP Vertex AI (WIF) takes precedence when
+configured, with generic API key as fallback.
+
+## Change 1: Add WIF secrets to workflow_call
+
+Add three optional secrets for the GCP-native path alongside the
+existing `AI_API_KEY` and `AI_API_ENDPOINT`:
+
+```yaml
+    secrets:
+      AI_API_KEY:
+        description: "API key for the AI provider (generic path)"
+        required: false
+      AI_API_ENDPOINT:
+        description: "Base URL for the AI API (generic path)"
+        required: false
+      GCP_WORKLOAD_IDENTITY_PROVIDER:
+        description: "WIF provider resource name (Vertex AI path)"
+        required: false
+      GCP_SERVICE_ACCOUNT:
+        description: "GCP service account email (Vertex AI path)"
+        required: false
+      GCP_PROJECT_ID:
+        description: "GCP project ID (Vertex AI path)"
+        required: false
+```
+
+## Change 2: Add Vertex AI inputs
+
+Add region and model inputs for the Vertex AI path:
+
+```yaml
+    inputs:
+      # ... existing inputs ...
+      vertex_ai_region:
+        description: "GCP region for Vertex AI (default: us-east5)"
+        required: false
+        type: string
+        default: "us-east5"
+      vertex_ai_model:
+        description: "Claude model name on Vertex AI"
+        required: false
+        type: string
+        default: "claude-sonnet-4-6"
+```
+
+## Change 3: Update gate check for two-tier detection
+
+Replace the single `HAS_API_KEY` check with two-tier detection and
+output the detected provider:
+
+```yaml
+      - name: Check gate conditions
+        id: gate
+        env:
+          PR_AUTHOR: ${{ github.event.pull_request.user.login }}
+          PR_DRAFT: ${{ github.event.pull_request.draft }}
+          HAS_WIF: ${{ secrets.GCP_WORKLOAD_IDENTITY_PROVIDER != '' }}
+          HAS_API_KEY: ${{ secrets.AI_API_KEY != '' }}
+        run: |
+          # Gate 1-2: dependabot, draft (unchanged)
+          # ...
+
+          # Gate 3: Detect provider or skip
+          if [[ "${HAS_WIF}" == "true" ]]; then
+            echo "provider=vertex-wif" >> "$GITHUB_OUTPUT"
+            echo "should_review=true" >> "$GITHUB_OUTPUT"
+          elif [[ "${HAS_API_KEY}" == "true" ]]; then
+            echo "provider=generic-api" >> "$GITHUB_OUTPUT"
+            echo "should_review=true" >> "$GITHUB_OUTPUT"
+          else
+            echo "should_review=false" >> "$GITHUB_OUTPUT"
+            echo "skip_reason=No AI credentials configured" >> "$GITHUB_OUTPUT"
+            exit 0
+          fi
+          echo "skip_reason=" >> "$GITHUB_OUTPUT"
+```
+
+Add `provider` to the gate-checks outputs:
+
+```yaml
+    outputs:
+      should_review: ${{ steps.gate.outputs.should_review }}
+      review_mode: ${{ steps.detect-mode.outputs.review_mode }}
+      skip_reason: ${{ steps.gate.outputs.skip_reason }}
+      provider: ${{ steps.gate.outputs.provider }}
+```
+
+## Change 4: Add WIF auth step to council-review job
+
+Add an authentication step before the review step. This step only runs
+on the WIF path. It requires `id-token: write` permission.
+
+```yaml
+  council-review:
+    name: Council Review
+    needs: gate-checks
+    if: needs.gate-checks.outputs.should_review == 'true'
+    runs-on: ubuntu-latest
+    permissions:
+      contents: read
+      id-token: write
+      pull-requests: write
+    steps:
+      # ... existing steps (checkout, check-agents, context, diff) ...
+
+      - name: Authenticate to Google Cloud (WIF path)
+        id: gcp-auth
+        if: needs.gate-checks.outputs.provider == 'vertex-wif'
+        uses: google-github-actions/auth@v3
+        with:
+          project_id: ${{ secrets.GCP_PROJECT_ID }}
+          workload_identity_provider: ${{ secrets.GCP_WORKLOAD_IDENTITY_PROVIDER }}
+          service_account: ${{ secrets.GCP_SERVICE_ACCOUNT }}
+          token_format: access_token
+
+      - name: Run council review
+        # ... update env to include WIF token and provider ...
+        env:
+          AI_PROVIDER: ${{ needs.gate-checks.outputs.provider }}
+          AI_API_KEY: ${{ secrets.AI_API_KEY }}
+          AI_API_ENDPOINT: ${{ secrets.AI_API_ENDPOINT }}
+          GCP_ACCESS_TOKEN: ${{ steps.gcp-auth.outputs.access_token || '' }}
+          GCP_PROJECT_ID: ${{ secrets.GCP_PROJECT_ID }}
+          VERTEX_REGION: ${{ inputs.vertex_ai_region }}
+          VERTEX_MODEL: ${{ inputs.vertex_ai_model }}
+          # ... existing env vars ...
+```
+
+## Change 5: Two-tier API call logic in the review step
+
+Replace the placeholder review step with actual API calls that detect
+the provider and use the correct endpoint/auth:
+
+```bash
+call_ai_api() {
+  local system_prompt="$1"
+  local user_prompt="$2"
+
+  if [[ "${AI_PROVIDER}" == "vertex-wif" ]]; then
+    ENDPOINT="https://${VERTEX_REGION}-aiplatform.googleapis.com/v1/projects/${GCP_PROJECT_ID}/locations/${VERTEX_REGION}/publishers/anthropic/models/${VERTEX_MODEL}:rawPredict"
+
+    curl -s -X POST "${ENDPOINT}" \
+      -H "Authorization: Bearer ${GCP_ACCESS_TOKEN}" \
+      -H "Content-Type: application/json" \
+      -d "$(jq -n \
+        --arg system "${system_prompt}" \
+        --arg user "${user_prompt}" \
+        '{
+          anthropic_version: "vertex-2023-10-16",
+          max_tokens: 4096,
+          system: $system,
+          messages: [{role: "user", content: $user}]
+        }')"
+  else
+    ENDPOINT="${AI_API_ENDPOINT:-https://api.anthropic.com/v1/messages}"
+    MODEL="${AI_MODEL:-claude-sonnet-4-6-20250514}"
+
+    curl -s -X POST "${ENDPOINT}" \
+      -H "x-api-key: ${AI_API_KEY}" \
+      -H "anthropic-version: 2023-06-01" \
+      -H "Content-Type: application/json" \
+      -d "$(jq -n \
+        --arg model "${MODEL}" \
+        --arg system "${system_prompt}" \
+        --arg user "${user_prompt}" \
+        '{
+          model: $model,
+          max_tokens: 4096,
+          system: $system,
+          messages: [{role: "user", content: $user}]
+        }')"
+  fi
+}
+```
+
+## Change 6: Update consumer workflow (ci_council_review.yml)
+
+Pass the WIF secrets from the consumer to the reusable workflow:
+
+```yaml
+jobs:
+  council:
+    name: AI Council Review
+    uses: complytime/org-infra/.github/workflows/reusable_council_review.yml@main
+    permissions:
+      contents: read
+      id-token: write
+      pull-requests: write
+    secrets:
+      AI_API_KEY: ${{ secrets.AI_API_KEY }}
+      AI_API_ENDPOINT: ${{ secrets.AI_API_ENDPOINT }}
+      GCP_WORKLOAD_IDENTITY_PROVIDER: ${{ secrets.GCP_WORKLOAD_IDENTITY_PROVIDER }}
+      GCP_SERVICE_ACCOUNT: ${{ secrets.GCP_SERVICE_ACCOUNT }}
+      GCP_PROJECT_ID: ${{ secrets.GCP_PROJECT_ID }}
+```
+
+Note the addition of `id-token: write` permission (required for WIF).
+
+## Change 7: Add concurrency control
+
+Add to the consumer workflow:
+
+```yaml
+concurrency:
+  group: council-review-${{ github.event.pull_request.number }}
+  cancel-in-progress: true
+```

--- a/docs/VERTEX_AI_WIF_SETUP.md
+++ b/docs/VERTEX_AI_WIF_SETUP.md
@@ -205,7 +205,37 @@ org-infra and open a PR. See the workflow file for the test procedure.
   receive OIDC tokens. If it does, the WIF attribute condition
   (`repository_owner_id == '181758273'`) blocks non-ComplyTime repos.
 
-## Cost Estimate
+## Cost Controls
+
+### Workflow-Level Gates (implemented)
+
+These gates prevent unnecessary API calls and are enforced in the
+workflow itself:
+
+- **Fork PRs**: Skipped (no OIDC token or secrets available)
+- **Draft PRs**: Skipped
+- **Dependabot PRs**: Skipped
+- **Concurrency**: Only one review runs per PR at a time; rapid pushes
+  cancel the previous run (`cancel-in-progress: true`)
+- **Diff size limit**: 1000 lines per persona (truncated with notice)
+
+### GCP-Level Controls (requires Billing Admin)
+
+These controls limit spending at the GCP project level:
+
+1. **Budget Alert**: Create a monthly budget (e.g., $50) scoped to the
+   `aiplatform.googleapis.com` service. Set thresholds at 50%, 80%, 100%.
+
+2. **Automated Kill-Switch** (optional): Deploy a Cloud Function
+   triggered by a Pub/Sub budget notification that revokes
+   `roles/aiplatform.user` from the `ci-council-review` service account
+   when spending reaches the budget limit. Note: there is a delay of
+   minutes to hours between actual spend and notification.
+
+3. **Quota Reduction**: Request a lower `rawPredict` request quota for
+   the project (default is 30K/min; reduce to 10-30/min for CI usage).
+
+### Cost Estimate
 
 Per council review run (5 personas, ~1000-line diff):
 - Input: ~5K-25K tokens across 5 calls

--- a/docs/VERTEX_AI_WIF_SETUP.md
+++ b/docs/VERTEX_AI_WIF_SETUP.md
@@ -1,0 +1,246 @@
+# Vertex AI Workload Identity Federation Setup
+
+This runbook configures keyless authentication from GitHub Actions to Google
+Cloud Vertex AI using Workload Identity Federation (WIF). It enables the
+CI council review workflow to call Claude models on Vertex AI without
+long-lived credentials.
+
+## Prerequisites
+
+- `gcloud` CLI authenticated with Owner or IAM Admin on the target project
+- The target GCP project with Vertex AI API enabled
+- GitHub organization admin access (for org-level secrets)
+
+## Project Details
+
+| Resource | Value |
+|----------|-------|
+| GCP Project ID | `itpc-gcp-prodsec-eng-claude` |
+| GCP Project Number | `909559566812` |
+| GitHub Org | `complytime` |
+| GitHub Org ID | `181758273` |
+| Vertex AI Region | `us-east5` (Claude availability) |
+
+## Step 1: Enable Required APIs
+
+WIF requires IAM, STS, and IAM Credentials APIs in addition to Vertex AI
+(already enabled).
+
+```bash
+gcloud services enable \
+  iam.googleapis.com \
+  cloudresourcemanager.googleapis.com \
+  iamcredentials.googleapis.com \
+  sts.googleapis.com \
+  --project=itpc-gcp-prodsec-eng-claude
+```
+
+## Step 2: Create Workload Identity Pool
+
+The pool is a logical grouping for external identities. One pool can serve
+all ComplyTime repositories.
+
+```bash
+gcloud iam workload-identity-pools create "github-actions" \
+  --project="itpc-gcp-prodsec-eng-claude" \
+  --location="global" \
+  --display-name="GitHub Actions Pool" \
+  --description="WIF pool for ComplyTime GitHub Actions workflows"
+```
+
+Verify creation:
+
+```bash
+gcloud iam workload-identity-pools describe "github-actions" \
+  --project="itpc-gcp-prodsec-eng-claude" \
+  --location="global" \
+  --format="value(name)"
+```
+
+Expected output:
+```
+projects/909559566812/locations/global/workloadIdentityPools/github-actions
+```
+
+## Step 3: Create OIDC Provider
+
+The provider establishes trust with GitHub's OIDC issuer. The attribute
+condition restricts access to the ComplyTime org using the **numeric org ID**
+(immutable, not vulnerable to name-squatting).
+
+```bash
+gcloud iam workload-identity-pools providers create-oidc "complytime" \
+  --project="itpc-gcp-prodsec-eng-claude" \
+  --location="global" \
+  --workload-identity-pool="github-actions" \
+  --display-name="ComplyTime GitHub" \
+  --attribute-mapping="\
+google.subject=assertion.sub,\
+attribute.actor=assertion.actor,\
+attribute.repository=assertion.repository,\
+attribute.repository_owner_id=assertion.repository_owner_id,\
+attribute.repository_id=assertion.repository_id,\
+attribute.ref=assertion.ref" \
+  --attribute-condition="assertion.repository_owner_id == '181758273'" \
+  --issuer-uri="https://token.actions.githubusercontent.com"
+```
+
+### Attribute Mapping Rationale
+
+| Mapped Attribute | Source Claim | Purpose |
+|-----------------|-------------|---------|
+| `google.subject` | `assertion.sub` | Required. Unique identity per workflow run |
+| `attribute.repository_owner_id` | `assertion.repository_owner_id` | Gate condition: only ComplyTime org |
+| `attribute.repository_id` | `assertion.repository_id` | Optional: per-repo restrictions |
+| `attribute.repository` | `assertion.repository` | Audit logging (human-readable) |
+| `attribute.actor` | `assertion.actor` | Audit logging |
+| `attribute.ref` | `assertion.ref` | Optional: branch restrictions |
+
+### Security Notes
+
+- The condition uses `repository_owner_id` (numeric `181758273`), not the
+  string name `complytime`. Numeric IDs are immutable and cannot be reused
+  if the org is deleted, preventing name-squatting attacks.
+- All repositories under the `complytime` GitHub org can authenticate.
+  To restrict to specific repos, add:
+  `&& assertion.repository_id == '1084101898'` (org-infra only).
+- Fork PRs **cannot** obtain OIDC tokens from GitHub Actions, so they
+  cannot authenticate through WIF. This is enforced by GitHub, not GCP.
+
+## Step 4: Create Service Account
+
+A dedicated service account for council review with minimal permissions.
+
+```bash
+gcloud iam service-accounts create "ci-council-review" \
+  --project="itpc-gcp-prodsec-eng-claude" \
+  --display-name="CI Council Review" \
+  --description="Service account for AI council review in GitHub Actions CI"
+```
+
+## Step 5: Grant Vertex AI Permissions
+
+Grant the service account permission to call Vertex AI prediction endpoints.
+`roles/aiplatform.user` is the minimum role needed for `rawPredict` calls
+to Claude models.
+
+```bash
+gcloud projects add-iam-policy-binding "itpc-gcp-prodsec-eng-claude" \
+  --role="roles/aiplatform.user" \
+  --member="serviceAccount:ci-council-review@itpc-gcp-prodsec-eng-claude.iam.gserviceaccount.com" \
+  --condition=None
+```
+
+## Step 6: Allow WIF to Impersonate the Service Account
+
+Grant the GitHub Actions federated identity permission to impersonate the
+service account. This binding is scoped to the ComplyTime org.
+
+```bash
+gcloud iam service-accounts add-iam-policy-binding \
+  "ci-council-review@itpc-gcp-prodsec-eng-claude.iam.gserviceaccount.com" \
+  --project="itpc-gcp-prodsec-eng-claude" \
+  --role="roles/iam.workloadIdentityUser" \
+  --member="principalSet://iam.googleapis.com/projects/909559566812/locations/global/workloadIdentityPools/github-actions/attribute.repository_owner_id/181758273"
+```
+
+This allows **any** repo in the `complytime` org to authenticate. To
+restrict to a single repo (e.g., org-infra only during testing):
+
+```bash
+# Alternative: restrict to org-infra only
+gcloud iam service-accounts add-iam-policy-binding \
+  "ci-council-review@itpc-gcp-prodsec-eng-claude.iam.gserviceaccount.com" \
+  --project="itpc-gcp-prodsec-eng-claude" \
+  --role="roles/iam.workloadIdentityUser" \
+  --member="principalSet://iam.googleapis.com/projects/909559566812/locations/global/workloadIdentityPools/github-actions/attribute.repository_id/1084101898"
+```
+
+## Step 7: Configure GitHub Organization Secrets
+
+Set these as **organization secrets** in the ComplyTime GitHub org, scoped
+to repositories that need council review.
+
+| Secret Name | Value | Notes |
+|-------------|-------|-------|
+| `GCP_WORKLOAD_IDENTITY_PROVIDER` | `projects/909559566812/locations/global/workloadIdentityPools/github-actions/providers/complytime` | Full provider resource name |
+| `GCP_SERVICE_ACCOUNT` | `ci-council-review@itpc-gcp-prodsec-eng-claude.iam.gserviceaccount.com` | Service account email |
+| `GCP_PROJECT_ID` | `itpc-gcp-prodsec-eng-claude` | Project ID |
+
+These are the GCP-native path secrets. The workflow also accepts the
+generic `AI_API_KEY` and `AI_API_ENDPOINT` secrets as a fallback for
+non-GCP providers (Anthropic direct, OpenAI, etc.). WIF takes
+precedence when both are set.
+
+## Step 8: Test with the Validation Workflow
+
+Push a branch with `.github/workflows/ci_council_review_test.yml` to
+org-infra and open a PR. See the workflow file for the test procedure.
+
+## Verification Checklist
+
+- [ ] APIs enabled (`iam`, `sts`, `iamcredentials`, `aiplatform`)
+- [ ] WIF pool created and visible in IAM console
+- [ ] OIDC provider created with correct attribute condition
+- [ ] Service account created with `roles/aiplatform.user`
+- [ ] WIF-to-SA binding in place
+- [ ] GitHub org secrets configured
+- [ ] Test workflow succeeds on an org-member PR
+- [ ] Test workflow skips on a fork PR (no OIDC token available)
+
+## Troubleshooting
+
+### "Unable to exchange token" error
+- Wait 5 minutes after creating WIF resources (propagation delay)
+- Verify the `id-token: write` permission is in the workflow
+- Check the attribute condition matches the org ID exactly
+
+### "Permission denied" on Vertex AI
+- Verify `roles/aiplatform.user` is granted to the service account
+- Check the region in the API URL matches where Claude is available
+- Ensure the service account can access the specific model
+
+### Fork PR attempts to authenticate
+- This should not happen. `pull_request` events from forks do not
+  receive OIDC tokens. If it does, the WIF attribute condition
+  (`repository_owner_id == '181758273'`) blocks non-ComplyTime repos.
+
+## Cost Estimate
+
+Per council review run (5 personas, ~1000-line diff):
+- Input: ~5K-25K tokens across 5 calls
+- Output: ~2K-10K tokens across 5 calls
+- At Claude Sonnet 4.6 Vertex rates (`claude-sonnet-4-6`): ~$0.05-0.20 per review
+- Gate checks prevent unnecessary runs (drafts, dependabot, forks,
+  binary-only changes)
+
+## Architecture
+
+```
+GitHub Actions (pull_request)
+  |
+  | 1. Request OIDC token (id-token: write)
+  v
+GitHub OIDC Provider (token.actions.githubusercontent.com)
+  |
+  | 2. JWT with org_id, repo_id, actor claims
+  v
+google-github-actions/auth@v3
+  |
+  | 3. Exchange OIDC token for GCP access token via STS
+  v
+GCP Workload Identity Federation
+  |
+  | 4. Validate attribute condition (org_id == 181758273)
+  | 5. Impersonate ci-council-review service account
+  v
+GCP Service Account (ci-council-review@...)
+  |
+  | 6. Short-lived OAuth 2.0 access token (~1 hour)
+  v
+Vertex AI rawPredict (Claude models)
+  |
+  | 7. Council review responses
+  v
+GitHub PR Comment (peter-evans/create-or-update-comment)
+```


### PR DESCRIPTION
## Summary

- Add temporary test workflow (`ci_council_review_test.yml`) to validate AI provider integration for the council review CI
- Add WIF setup runbook (`docs/VERTEX_AI_WIF_SETUP.md`) with project-specific gcloud commands
- Supports two-tier provider interface: GCP Vertex AI (WIF) and generic API key path

## What this PR validates

This is a **draft PR from a fork** -- it will exercise the fork-safety path:
- The workflow should **skip** because fork PRs don't get OIDC tokens or access to secrets
- Gate checks should detect missing `GCP_WORKLOAD_IDENTITY_PROVIDER` and skip gracefully
- The `post-skip` job should log the reason

Once the GCP WIF infrastructure is provisioned (needs project admin), a PR from within the org repo will validate the full WIF auth + Vertex AI rawPredict chain.

## Artifacts

| File | Purpose |
|------|---------|
| `.github/workflows/ci_council_review_test.yml` | Two-tier test workflow: WIF path + generic API key path |
| `docs/VERTEX_AI_WIF_SETUP.md` | Step-by-step WIF setup runbook for `itpc-gcp-prodsec-eng-claude` |

## GCP Setup Status

| Step | Status |
|------|--------|
| APIs enabled (iam, sts, iamcredentials) | BLOCKED (needs `serviceUsageAdmin`) |
| WIF pool + OIDC provider | BLOCKED (needs `iam.workloadIdentityPoolAdmin`) |
| Service account created | DONE (`ci-council-review@...`) |
| `roles/aiplatform.user` granted | DONE |
| Claude model available | CONFIRMED (us-east5, claude-sonnet-4-6) |
| GitHub repo secrets set | DONE (GCP_PROJECT_ID, GCP_SERVICE_ACCOUNT, GCP_WORKLOAD_IDENTITY_PROVIDER) |

## Test plan

- [ ] Fork PR: workflow skips with "No AI credentials configured" message
- [ ] Org-member PR (after WIF setup): WIF auth succeeds, rawPredict returns response
- [ ] Draft PR: workflow skips with "Draft PR" message
- [ ] Remove test workflow after full validation

Made with [Cursor](https://cursor.com)