### PR TITLE
feat: self-testing workflows with sync ref transformation

### DIFF
--- a/.github/workflows/ci_checks.yml
+++ b/.github/workflows/ci_checks.yml
@@ -16,7 +16,7 @@ permissions:
 jobs:
   call_reusable_ci:
     name: Standardized CI
-    uses: complytime/org-infra/.github/workflows/reusable_ci.yml@cfd981e757253218aefb37c91969c32827e5c4b1 # v0.2.1
+    uses: ./.github/workflows/reusable_ci.yml
     permissions:
       contents: read
       issues: read

--- a/.github/workflows/ci_compliance.yml
+++ b/.github/workflows/ci_compliance.yml
@@ -24,7 +24,7 @@ jobs:
     name: Compliance Evaluation
     permissions:
       contents: read
-    uses: complytime/org-infra/.github/workflows/reusable_compliance.yml@cfd981e757253218aefb37c91969c32827e5c4b1 # v0.2.1
+    uses: ./.github/workflows/reusable_compliance.yml
     with:
       complytime_config_path: ${{ inputs.complytime_config_path || 'complytime.yaml' }}
       policy_id: ${{ inputs.policy_id || 'ampel-bp' }}

--- a/.github/workflows/ci_crapload.yml
+++ b/.github/workflows/ci_crapload.yml
@@ -19,7 +19,7 @@ permissions:
 jobs:
   crapload:
     name: CRAP Load Analysis
-    uses: complytime/org-infra/.github/workflows/reusable_crapload_analysis.yml@cfd981e757253218aefb37c91969c32827e5c4b1 # v0.2.1
+    uses: ./.github/workflows/reusable_crapload_analysis.yml
     permissions:
       contents: read
 

--- a/.github/workflows/ci_dependencies.yml
+++ b/.github/workflows/ci_dependencies.yml
@@ -25,11 +25,11 @@ env:
 jobs:
   call_deps_reviewer:
     name: General
-    uses: complytime/org-infra/.github/workflows/reusable_deps_reviewer.yml@cfd981e757253218aefb37c91969c32827e5c4b1 # v0.2.1
+    uses: ./.github/workflows/reusable_deps_reviewer.yml
 
   call_dependabot_reviewer:
     name: Dependabot
-    uses: complytime/org-infra/.github/workflows/reusable_dependabot_reviewer.yml@cfd981e757253218aefb37c91969c32827e5c4b1 # v0.2.1
+    uses: ./.github/workflows/reusable_dependabot_reviewer.yml
 
   comment_on_dependabot_prs:
     name: Dependabot Comment

--- a/.github/workflows/ci_scheduled.yml
+++ b/.github/workflows/ci_scheduled.yml
@@ -18,4 +18,4 @@ jobs:
       actions: read           # Required to upload SARIF file to CodeQL. See: https://github.com/github/codeql-action/issues/2117
       security-events: write  # Require writing security events to upload SARIF file to security tab
       id-token: write         # Needed to access GitHub's OIDC token which verifies the authenticity of the result when publishing it.
-    uses: complytime/org-infra/.github/workflows/reusable_scheduled.yml@cfd981e757253218aefb37c91969c32827e5c4b1 # v0.2.1
+    uses: ./.github/workflows/reusable_scheduled.yml

--- a/.github/workflows/ci_security.yml
+++ b/.github/workflows/ci_security.yml
@@ -22,7 +22,7 @@ jobs:
       contents: read
       actions: read
       security-events: write
-    uses: complytime/org-infra/.github/workflows/reusable_vuln_scan.yml@cfd981e757253218aefb37c91969c32827e5c4b1 # v0.2.1
+    uses: ./.github/workflows/reusable_vuln_scan.yml
     with:
       # OSV focuses on known CVEs in dependencies; Trivy adds broader coverage
       enable_trivy_source: true
@@ -33,4 +33,4 @@ jobs:
       contents: read
       id-token: write
       security-events: write
-    uses: complytime/org-infra/.github/workflows/reusable_security.yml@cfd981e757253218aefb37c91969c32827e5c4b1 # v0.2.1
+    uses: ./.github/workflows/reusable_security.yml

--- a/openspec/changes/self-testing-workflows/.openspec.yaml
+++ b/openspec/changes/self-testing-workflows/.openspec.yaml
@@ -1,0 +1,2 @@
+schema: spec-driven
+created: 2026-05-21

--- a/openspec/changes/self-testing-workflows/design.md
+++ b/openspec/changes/self-testing-workflows/design.md
@@ -1,0 +1,164 @@
+## Context
+
+org-infra maintains 12 reusable workflows (`reusable_*.yml`) consumed by 7 consumer
+workflows (`ci_*.yml`). The `pin-workflows-to-release` change (completed) replaced all
+`@main` references with SHA-pinned refs (`@<sha> # v0.2.1`), aligning with the org's
+supply-chain security convention.
+
+This created a self-testing gap: when a reusable workflow is modified on a PR, org-infra's
+own CI still runs the previous release's version of that workflow. Breakage is not detected
+until after a release is cut and SHA refs are bumped — at which point the broken workflow
+has already been tagged and is ready to sync to all downstream repos.
+
+The sync script (`sync-org-repositories.py`) currently copies `ci_*` workflow files as-is
+to downstream repos. It already supports content-level transformations via
+`apply_file_vars()` for per-repo variable substitution (e.g., `enable_trivy_source`).
+
+Five `ci_*` files are synced to downstream repos. Two workflow files with reusable
+workflow refs are not synced (`ci_compliance.yml`, `reusable_scheduled.yml`).
+
+## Goals / Non-Goals
+
+**Goals:**
+
+- Enable org-infra to test its own reusable workflow changes during CI, including on PRs.
+- Ensure downstream repos continue to receive SHA-pinned workflow refs via the sync
+  process.
+- Auto-detect the latest release for sync transformation with no manual configuration.
+- Provide a CLI override when auto-detection fails or a specific version is needed.
+
+**Non-Goals:**
+
+- Adding CI consumers for reusable workflows not currently tested by org-infra.
+- Changing the release process or release-drafter configuration.
+- Modifying how downstream repos consume reusable workflows (they remain SHA-pinned).
+
+## Decisions
+
+### 1. Use local path refs in org-infra (`./.github/workflows/reusable_*.yml`)
+
+Replace SHA-pinned cross-repo refs with local path syntax. GitHub Actions resolves
+local refs to the current commit, meaning PRs that modify a reusable workflow will
+test the modified version immediately.
+
+**Alternatives considered:**
+
+- **`@main` refs**: Would test whatever is on `main`, not the PR's changes. A PR
+  modifying `reusable_ci.yml` would still run the old main-branch version. Rejected
+  because it only catches breakage after merge, not during review.
+- **Keep SHA-pinned refs (status quo)**: Does not catch breakage until after release.
+  Rejected as this is the problem being solved.
+
+### 2. Dedicated `transform_workflow_refs()` function
+
+Add a new function alongside `apply_file_vars()` that replaces local workflow refs
+with SHA-pinned cross-repo refs during sync. Both functions are content-level string
+transforms that compose: vars are applied first, then workflow ref transformation.
+
+**Alternatives considered:**
+
+- **Extend the `vars` mechanism**: Would require adding synthetic variables to
+  `sync-config.yml` for each workflow ref. The vars system uses
+  `<var_name>: <value>` regex matching, which does not fit the `uses:` line format.
+  Rejected as an awkward fit that would complicate the config.
+- **Config-driven replacement map**: Add a mapping in `sync-config.yml` listing each
+  local ref and its replacement. Rejected as redundant — the transformation is
+  deterministic (local ref pattern + release SHA/tag) and does not need per-file config.
+
+### 3. Auto-detect latest release via GitHub API
+
+The sync script queries `GET /repos/{org}/{repo}/releases/latest` to obtain the
+release tag name, then resolves the tag to a commit SHA via
+`GET /repos/{org}/{repo}/git/ref/tags/{tag}`. This endpoint is added to the API
+allowlist.
+
+The org name comes from the existing `--org` CLI argument. The source repo name is a
+module-level constant (`SOURCE_REPO = "org-infra"`) — easy to change, sensible default.
+
+**Alternatives considered:**
+
+- **Git tags on local checkout**: Would require `fetch-depth: 0` and `fetch-tags: true`
+  in the CI checkout step. Rejected because it adds a CI configuration dependency and
+  may not work when the script is run outside of CI.
+- **Manual config in `sync-config.yml`**: Would require updating the config file on
+  every release. Rejected as unnecessary manual toil when the API provides the
+  information.
+- **CLI argument only (no auto-detect)**: Would require passing `--release-ref` on
+  every invocation. Rejected because the common case should be zero-friction.
+
+### 4. Apply transformation only to `ci_*` workflow files
+
+The transformation function checks whether the source path matches
+`.github/workflows/ci_*.yml` before applying. Non-workflow files and reusable workflow
+files pass through unchanged.
+
+**Alternatives considered:**
+
+- **Content-based detection (apply to all files)**: Would transform any file containing
+  the `uses: ./.github/workflows/reusable_*.yml` pattern. Low risk of false positives
+  but violates the explicit scoping requirement. Rejected for clarity and to avoid
+  unintended transformation of documentation or config files that might contain example
+  refs.
+- **All workflow files**: Reusable workflows are not synced to downstream repos, so
+  transforming them would be wasted work. Rejected as unnecessary.
+
+### 5. `--release-ref` CLI argument as override
+
+When provided, `--release-ref <tag>` (e.g., `--release-ref v0.3.0`) skips
+auto-detection and uses the specified tag. The script resolves the tag to a commit SHA
+via the same API path. This serves two purposes: recovery when no release exists yet,
+and explicit version pinning for testing or rollback.
+
+**Alternatives considered:**
+
+- **Separate `--release-sha` argument**: Would allow passing both tag and SHA
+  independently for fully offline use. Rejected as over-engineering — the API call
+  to resolve a tag is trivial, and offline sync is not a supported use case.
+
+### 6. Sync flow integration point
+
+Files that need workflow ref transformation are routed through the content-transform
+path (read → transform → compare → write) regardless of whether they also have `vars`.
+This requires a small refactor to the existing branching logic in `sync_repository()`,
+which currently sends var-less files through the direct-copy `sync_file()` path.
+
+The composition order is: `apply_file_vars()` first (if vars exist), then
+`transform_workflow_refs()`. Both are idempotent regex substitutions.
+
+**Alternatives considered:**
+
+- **Separate pre-processing pass**: Run transformation on all source files before the
+  sync loop. Rejected because it would require modifying source files on disk (or
+  maintaining a parallel transformed copy), adding complexity for no benefit.
+
+## Risks / Trade-offs
+
+- **[Risk] API rate limiting during sync.** The release detection adds 1-2 API calls
+  per sync invocation (not per repo). The sync script already makes multiple API calls
+  per repo (PR check, PR creation). The incremental cost is negligible.
+  -> Mitigation: Release detection runs once at startup, not per-repo.
+
+- **[Risk] Tag-to-SHA resolution for annotated tags.** If a release tag is annotated
+  (not lightweight), the git ref API returns a tag object SHA, not a commit SHA. The
+  tag object must be dereferenced to get the commit SHA.
+  -> Mitigation: Check the `object.type` field in the API response. If `"tag"`,
+  follow up with `GET /repos/{org}/{repo}/git/tags/{sha}` to get the commit SHA.
+
+- **[Risk] GitHub API unavailability.** Release detection and tag-to-SHA resolution
+  both require GitHub API access. If the API is unreachable, the sync script will fail.
+  The `--release-ref` override does not help because it also requires an API call to
+  resolve the tag. This is consistent with the script's existing behavior — it already
+  requires API access for PR creation and repo discovery.
+  -> Mitigation: No additional mitigation needed. The existing sync script's error
+  handling covers HTTP failures. A `--release-sha` option was explicitly rejected
+  (Decision 5) as over-engineering for an unsupported offline use case.
+
+- **[Trade-off] Scorecard for org-infra only.** Local path refs are not flagged by
+  OpenSSF Scorecard (it checks third-party action pinning, not same-repo workflow
+  calls). No Scorecard regression expected.
+
+- **[Trade-off] Supersedes `pin-workflows-to-release` for org-infra.** The prior
+  change established universal SHA-pinning. This change narrows the scope: SHA-pinning
+  remains mandatory for downstream repos (enforced by the sync transformation) but is
+  replaced by local refs within org-infra. The prior change's spec
+  (`workflow-sha-pinning`) is historical documentation of the original decision.

--- a/openspec/changes/self-testing-workflows/proposal.md
+++ b/openspec/changes/self-testing-workflows/proposal.md
@@ -1,0 +1,60 @@
+## Why
+
+org-infra's consumer workflows (`ci_*`) reference their own reusable workflows via
+SHA-pinned refs (e.g., `@cfd981e...  # v0.2.1`). This means changes to reusable
+workflows are not tested by org-infra's own CI until after a release is cut and the
+SHA refs are bumped. Broken reusable workflows can be released and synced to all
+downstream repositories before the breakage is caught.
+
+## What Changes
+
+- Replace all SHA-pinned reusable workflow references in org-infra's `ci_*` and
+  `reusable_scheduled.yml` files with local path syntax
+  (`./.github/workflows/reusable_*.yml`) so org-infra tests the current version of
+  its own reusable workflows, including on PRs.
+- Add a transformation step in the sync script that converts local workflow refs to
+  SHA-pinned cross-repo refs (using the latest release tag and commit SHA) when syncing
+  `ci_*` files to downstream repositories.
+- Add auto-detection of the latest org-infra release in the sync script, with a
+  `--release-ref` override for cases where no release exists or a specific version is
+  desired.
+
+## Non-goals
+
+- Adding `ci_*` consumers for reusable workflows that org-infra does not currently
+  consume (`reusable_publish_ghcr.yml`, `reusable_publish_oras.yml`,
+  `reusable_sign_and_verify.yml`, `reusable_sonarqube.yml`). That is a separate concern.
+- Changing how downstream repositories reference reusable workflows. They continue to
+  receive SHA-pinned refs via the sync process.
+- Modifying the release process itself.
+
+## Capabilities
+
+### New Capabilities
+
+- `workflow-self-testing`: Use local path refs for reusable workflows in org-infra and
+  transform them to SHA-pinned cross-repo refs during sync to downstream repositories.
+
+### Modified Capabilities
+
+(none)
+
+## Impact
+
+- **Workflows**: 7 consumer workflow files and 1 reusable workflow file in
+  `.github/workflows/` are modified (9 total refs changed from SHA-pinned to local).
+- **Sync script**: `scripts/sync-org-repositories.py` gains a new transformation
+  function, release auto-detection, a `--release-ref` CLI argument, and an additional
+  GitHub API endpoint in the allowlist.
+- **Tests**: New unit tests for the transformation function and release detection.
+- **Downstream repos**: No change in behavior. They continue to receive SHA-pinned
+  refs, now produced by the sync script transformation instead of being copied as-is.
+- **Scorecard**: Local path refs are not penalized by OpenSSF Scorecard (it checks
+  third-party action refs, not same-repo workflow calls). No Scorecard regression.
+
+## Supersedes
+
+Narrows the policy established by `pin-workflows-to-release` — SHA pinning remains
+mandatory for downstream repos but is replaced by local refs within org-infra for
+self-testing. The `workflow-sha-pinning` capability's scope is reduced from "all
+org-infra workflow references" to "downstream-facing workflow references only."

--- a/openspec/changes/self-testing-workflows/specs/workflow-self-testing/spec.md
+++ b/openspec/changes/self-testing-workflows/specs/workflow-self-testing/spec.md
@@ -1,0 +1,184 @@
+## ADDED Requirements
+
+### Requirement: org-infra workflows use local path refs for reusable workflows
+
+All consumer workflow files (`ci_*.yml`) and reusable-to-reusable references within
+org-infra SHALL use local path syntax (`./.github/workflows/reusable_*.yml`) instead
+of cross-repo SHA-pinned references.
+
+#### Scenario: Consumer workflow references a reusable workflow
+
+- **WHEN** a consumer workflow (`ci_*`) in org-infra calls a reusable workflow
+- **THEN** the `uses:` value SHALL be a local path (`./.github/workflows/reusable_*.yml`)
+- **AND** no cross-repo reference (`complytime/org-infra/...@<ref>`) SHALL appear
+
+#### Scenario: Reusable workflow references another reusable workflow
+
+- **WHEN** a reusable workflow in org-infra calls another reusable workflow from the
+  same repository
+- **THEN** the `uses:` value SHALL be a local path
+
+#### Scenario: PR modifying a reusable workflow tests the modified version
+
+- **WHEN** a pull request modifies a reusable workflow file
+- **AND** a consumer workflow that calls it runs as part of PR CI
+- **THEN** the CI run executes the PR's version of the reusable workflow, not the
+  main branch version
+
+---
+
+### Requirement: Sync script transforms local refs to SHA-pinned refs
+
+The sync script SHALL transform local workflow path references in consumer workflow
+files into SHA-pinned cross-repo references when syncing to downstream repositories.
+
+#### Scenario: Local ref transformed during sync
+
+- **WHEN** the sync script processes a consumer workflow file for a downstream repo
+- **AND** the file contains a local reusable workflow reference
+- **THEN** the reference SHALL be replaced with a cross-repo reference pinned to the
+  latest release commit SHA with an inline version comment
+
+#### Scenario: Transformation format matches existing convention
+
+- **WHEN** a local ref is transformed during sync
+- **THEN** the result SHALL use the format
+  `<org>/<repo>/.github/workflows/<name>@<full-sha> # <tag>`
+- **AND** the SHA SHALL be a full 40-character commit SHA
+- **AND** the tag SHALL match the release version (e.g., `v0.3.0`)
+
+#### Scenario: Non-workflow files are not transformed
+
+- **WHEN** the sync script processes a file that is not a consumer workflow
+- **THEN** no workflow ref transformation SHALL be applied
+
+#### Scenario: Files without local refs pass through unchanged
+
+- **WHEN** the sync script processes a consumer workflow file that contains no local
+  reusable workflow references
+- **THEN** the file content SHALL not be modified by the transformation step
+
+#### Scenario: Transformation composes with variable substitution
+
+- **WHEN** a consumer workflow file has both per-repo variable overrides and local
+  reusable workflow references
+- **THEN** both variable substitution and workflow ref transformation SHALL be applied
+- **AND** the final content SHALL reflect both transformations
+
+---
+
+### Requirement: Sync script auto-detects the latest release
+
+The sync script SHALL automatically determine the latest release tag and its commit
+SHA from the source repository when no explicit override is provided.
+
+#### Scenario: Latest release detected automatically
+
+- **WHEN** the sync script runs without a release override argument
+- **AND** the source repository has at least one published release
+- **THEN** the script SHALL use the latest release tag and commit SHA for workflow
+  ref transformation
+
+#### Scenario: No release found and no override provided
+
+- **WHEN** the sync script runs without a release override argument
+- **AND** the source repository has no published releases
+- **THEN** the script SHALL exit with a non-zero status code
+- **AND** the error message SHALL inform the user that no release was found
+- **AND** the error message SHALL instruct the user to retry with the release
+  override argument
+
+#### Scenario: Annotated tag is resolved to commit SHA
+
+- **WHEN** the latest release tag is an annotated tag (not lightweight)
+- **THEN** the script SHALL dereference the tag object to obtain the underlying
+  commit SHA
+- **AND** the commit SHA (not the tag object SHA) SHALL be used in workflow ref
+  transformation
+
+---
+
+### Requirement: Release override via CLI argument
+
+The sync script SHALL accept an optional CLI argument to override release
+auto-detection with a specific release tag.
+
+#### Scenario: Override with explicit tag
+
+- **WHEN** the sync script is invoked with the release override argument and a tag
+- **THEN** the script SHALL use the specified tag instead of auto-detecting
+- **AND** the script SHALL resolve the tag to its commit SHA
+
+#### Scenario: Override tag does not exist
+
+- **WHEN** the sync script is invoked with a release override tag that does not exist
+- **THEN** the script SHALL exit with a non-zero status code
+- **AND** the error message SHALL indicate the tag was not found
+
+---
+
+## MODIFIED Requirements
+
+> The following requirements amend `workflow-sha-pinning` from the completed
+> `pin-workflows-to-release` change. That spec established universal SHA-pinning
+> for all reusable workflow references. This change narrows its scope: SHA-pinning
+> remains mandatory for downstream repositories (now enforced by the sync script
+> transformation) but is replaced by local path refs within org-infra to enable
+> self-testing of reusable workflow changes before release.
+>
+> The original `workflow-sha-pinning` spec is preserved as-is — it documents the
+> initial decision and remains the authoritative reference for downstream behavior.
+> This section records the scope narrowing for org-infra.
+
+### Requirement: Reusable workflow references use immutable SHA pins
+
+All `uses:` references to org-infra reusable workflows SHALL be pinned to a full
+40-character commit SHA corresponding to a tagged release. This applies to ~~both
+consumer workflows and reusable-to-reusable calls within org-infra~~ **downstream
+repositories only**. Within org-infra, consumer workflows and reusable-to-reusable
+calls SHALL use local path syntax (`./.github/workflows/reusable_*.yml`) as defined
+in the ADDED requirement "org-infra workflows use local path refs for reusable
+workflows" above.
+
+The sync script SHALL ensure downstream repositories receive SHA-pinned references
+by transforming local path refs during the sync process.
+
+#### Scenario: Consumer workflow references a reusable workflow
+
+- **WHEN** a consumer workflow (`ci_*`) in a **downstream repository** calls a
+  reusable workflow from org-infra
+- **THEN** the `uses:` value SHALL contain a full 40-character commit SHA (not a
+  branch name, short SHA, or mutable tag)
+
+#### Scenario: Consumer workflow references a reusable workflow within org-infra
+
+- **WHEN** a consumer workflow (`ci_*`) in **org-infra** calls a reusable workflow
+  from the same repository
+- **THEN** the `uses:` value SHALL be a local path (`./.github/workflows/reusable_*.yml`)
+- **AND** the sync script SHALL transform this to a SHA-pinned cross-repo reference
+  before syncing to downstream repositories
+
+#### Scenario: Reusable workflow references another reusable workflow
+
+- **WHEN** a reusable workflow in **org-infra** calls another reusable workflow from
+  the same repository
+- **THEN** the `uses:` value SHALL be a local path
+- **AND** since reusable workflows are not synced to downstream repositories, no
+  transformation is required
+
+---
+
+### Requirement: SHA pins are updated as part of the release process
+
+Updating reusable workflow SHA pins SHALL ~~be a required step in the org-infra release
+process. The pins SHALL always reference the most recent tagged release~~ **be handled
+automatically by the sync script**. The sync script SHALL resolve the latest release
+tag and commit SHA and apply them during the sync process. Manual SHA pin updates
+within org-infra are no longer required.
+
+#### Scenario: Release checklist includes pin update
+
+- **WHEN** a maintainer cuts a new org-infra release
+- **THEN** the sync script SHALL automatically use the new release's commit SHA and
+  version tag when transforming local refs for downstream repositories
+- **AND** no manual update to org-infra's own workflow files is required

--- a/openspec/changes/self-testing-workflows/tasks.md
+++ b/openspec/changes/self-testing-workflows/tasks.md
@@ -1,0 +1,43 @@
+## 1. Convert Workflow Refs to Local Paths
+
+- [x] 1.1 Update `.github/workflows/ci_checks.yml`: replace `complytime/org-infra/.github/workflows/reusable_ci.yml@cfd981e757253218aefb37c91969c32827e5c4b1 # v0.2.1` with `./.github/workflows/reusable_ci.yml`
+- [x] 1.2 Update `.github/workflows/ci_compliance.yml`: replace `complytime/org-infra/.github/workflows/reusable_compliance.yml@cfd981e757253218aefb37c91969c32827e5c4b1 # v0.2.1` with `./.github/workflows/reusable_compliance.yml`
+- [x] 1.3 Update `.github/workflows/ci_crapload.yml`: replace `complytime/org-infra/.github/workflows/reusable_crapload_analysis.yml@cfd981e757253218aefb37c91969c32827e5c4b1 # v0.2.1` with `./.github/workflows/reusable_crapload_analysis.yml`
+- [x] 1.4 Update `.github/workflows/ci_dependencies.yml`: replace both reusable workflow refs (`reusable_deps_reviewer.yml` and `reusable_dependabot_reviewer.yml`) with local paths
+- [x] 1.5 Update `.github/workflows/ci_scheduled.yml`: replace `complytime/org-infra/.github/workflows/reusable_scheduled.yml@cfd981e757253218aefb37c91969c32827e5c4b1 # v0.2.1` with `./.github/workflows/reusable_scheduled.yml`
+- [x] 1.6 Update `.github/workflows/ci_security.yml`: replace both reusable workflow refs (`reusable_vuln_scan.yml` and `reusable_security.yml`) with local paths
+- [x] 1.7 Update `.github/workflows/reusable_scheduled.yml`: replace the reusable-to-reusable ref to `reusable_security.yml` with a local path
+
+## 2. Sync Script — Release Detection
+
+- [x] 2.1 Add `SOURCE_REPO` module-level constant to `scripts/sync-org-repositories.py`
+- [x] 2.2 Add the releases API endpoint (`GET /repos/{owner}/{repo}/releases/latest`) and git ref endpoint (`GET /repos/{owner}/{repo}/git/ref/tags/*`) to the API allowlist in `scripts/sync-org-repositories.py`
+- [x] 2.3 Implement `get_latest_release(org, repo_name)` function in `scripts/sync-org-repositories.py` that fetches the latest release tag and resolves it to a commit SHA, handling both lightweight and annotated tags
+- [x] 2.4 Add `--release-ref` optional CLI argument to the argument parser in `scripts/sync-org-repositories.py`
+- [x] 2.5 Integrate release detection at script startup: auto-detect if `--release-ref` is not provided, fail with clear message and `--release-ref` usage hint if no release is found
+
+## 3. Sync Script — Workflow Ref Transformation
+
+- [x] 3.1 Implement `transform_workflow_refs(content, org, source_repo, sha, tag)` function in `scripts/sync-org-repositories.py` that replaces local path refs with SHA-pinned cross-repo refs
+- [x] 3.2 Update the sync loop in `sync_repository()` in `scripts/sync-org-repositories.py` to apply `transform_workflow_refs()` for source files matching `.github/workflows/ci_*.yml`, ensuring it composes with the existing `apply_file_vars()` path
+
+## 4. Tests
+
+- [x] 4.1 Add unit tests for `transform_workflow_refs()` in `tests/`: single ref, multiple refs, no refs (passthrough), mixed content
+- [x] 4.2 Add unit tests for `get_latest_release()` in `tests/`: successful detection, no release found, annotated tag dereferencing, `--release-ref` override
+- [x] 4.3 Add integration test for composition: a workflow file with both per-repo vars and local workflow refs produces correct output after both transforms
+
+New functions (`transform_workflow_refs`, `get_latest_release`) SHALL have 100% branch
+coverage via unit tests.
+
+## 5. Validation
+
+- [x] 5.1 Run `yamllint` on all modified workflow files to verify YAML validity
+- [x] 5.2 Verify zero cross-repo `@sha` or `@main` refs remain for `complytime/org-infra` reusable workflows in `.github/workflows/*.yml`
+- [x] 5.3 Run `make test` to verify all existing and new tests pass
+- [x] 5.4 Run `make lint` to verify all linting passes
+- [ ] 5.5 Run `make sync-dry-run` and verify that dry-run output shows transformed refs for downstream repos (requires GITHUB_TOKEN — deferred to CI)
+- [x] 5.6 Update sync script `--help` text to document the `--release-ref` argument usage and purpose
+
+<!-- spec-review: passed -->
+<!-- code-review: passed -->

--- a/openspec/changes/self-testing-workflows/tasks.md
+++ b/openspec/changes/self-testing-workflows/tasks.md
@@ -6,7 +6,7 @@
 - [x] 1.4 Update `.github/workflows/ci_dependencies.yml`: replace both reusable workflow refs (`reusable_deps_reviewer.yml` and `reusable_dependabot_reviewer.yml`) with local paths
 - [x] 1.5 Update `.github/workflows/ci_scheduled.yml`: replace `complytime/org-infra/.github/workflows/reusable_scheduled.yml@cfd981e757253218aefb37c91969c32827e5c4b1 # v0.2.1` with `./.github/workflows/reusable_scheduled.yml`
 - [x] 1.6 Update `.github/workflows/ci_security.yml`: replace both reusable workflow refs (`reusable_vuln_scan.yml` and `reusable_security.yml`) with local paths
-- [x] 1.7 Update `.github/workflows/reusable_scheduled.yml`: replace the reusable-to-reusable ref to `reusable_security.yml` with a local path
+- [ ] ~~1.7 Update `.github/workflows/reusable_scheduled.yml`: replace the reusable-to-reusable ref to `reusable_security.yml` with a local path~~ — Reverted: reusable-to-reusable refs must stay SHA-pinned because reusable workflows run in the downstream repo context where local paths would not resolve
 
 ## 2. Sync Script — Release Detection
 

--- a/scripts/sync-org-repositories.py
+++ b/scripts/sync-org-repositories.py
@@ -403,7 +403,13 @@ def get_latest_release(
             f"{GITHUB_API}/repos/{org}/{repo_name}"
             f"/git/tags/{obj['sha']}"
         )
-        _, tag_data = github_api_request(tag_url)
+        tag_status, tag_data = github_api_request(tag_url)
+        if tag_status != 200:
+            print(
+                f"Error: Could not dereference tag object "
+                f"for {org}/{repo_name}."
+            )
+            sys.exit(1)
         commit_sha = tag_data.get("object", {}).get("sha", "")
     else:
         # Lightweight tag — SHA points directly to the commit
@@ -981,7 +987,16 @@ def main() -> None:
                 f"/{SOURCE_REPO}"
                 f"/git/tags/{data['object']['sha']}"
             )
-            _, tag_data = github_api_request(tag_endpoint)
+            tag_status, tag_data = github_api_request(
+                tag_endpoint,
+            )
+            if tag_status != 200:
+                print(
+                    f"Error: Could not dereference "
+                    f"tag object for "
+                    f"{args.org}/{SOURCE_REPO}."
+                )
+                sys.exit(1)
             release_sha = tag_data.get(
                 "object", {},
             ).get("sha")

--- a/scripts/sync-org-repositories.py
+++ b/scripts/sync-org-repositories.py
@@ -72,6 +72,7 @@ GITHUB_TOKEN = os.getenv("GITHUB_TOKEN", os.getenv("GITHUB_PAT"))
 DEFAULT_CONFIG_FILE = "sync-config.yml"
 SYNC_BRANCH_PREFIX = "sync-repo-standards-"
 SYNC_PR_TITLE = "chore: sync repository standards"
+SOURCE_REPO = "org-infra"
 
 
 def parse_args() -> argparse.Namespace:
@@ -99,6 +100,15 @@ def parse_args() -> argparse.Namespace:
         nargs="*",
         help="Specific repositories to sync (default: all from peribolos.yml)",
     )
+    parser.add_argument(
+        "--release-ref",
+        default=None,
+        help=(
+            "Release tag to use for workflow ref "
+            "transformation (e.g., v0.3.0). Auto-detects "
+            "latest release if not provided."
+        ),
+    )
     return parser.parse_args()
 
 
@@ -123,6 +133,12 @@ def validate_github_api_request(endpoint: str, method: str) -> bool:
         (r"^" + re.escape(GITHUB_API) + r"/repos/[^/]+/[^/]+/pulls$", "GET"),
         (r"^" + re.escape(GITHUB_API) + r"/repos/[^/]+/[^/]+/pulls$", "POST"),
         (r"^" + re.escape(GITHUB_API) + r"/repos/[^/]+/[^/]+/contents/.+$", "GET"),
+        # Release detection
+        (r"^" + re.escape(GITHUB_API) + r"/repos/[^/]+/[^/]+/releases/latest$", "GET"),
+        # Tag-to-SHA resolution
+        (r"^" + re.escape(GITHUB_API) + r"/repos/[^/]+/[^/]+/git/ref/tags/.+$", "GET"),
+        # Annotated tag dereferencing
+        (r"^" + re.escape(GITHUB_API) + r"/repos/[^/]+/[^/]+/git/tags/[a-f0-9]+$", "GET"),
     ]
     return any(
         re.match(pattern, endpoint) and method == allowed_method
@@ -332,6 +348,115 @@ def apply_file_vars(content: str, resolved_vars: Dict[str, str]) -> str:
     return content
 
 
+def get_latest_release(
+    org: str, repo_name: str,
+) -> Tuple[str, str]:
+    """Fetch the latest release tag and resolve it to a commit SHA.
+
+    Queries the GitHub API for the latest published release, then
+    resolves the tag to a full commit SHA.  Handles both lightweight
+    tags (object.type == "commit") and annotated tags (object.type ==
+    "tag") by dereferencing the tag object when needed.
+
+    Args:
+        org: GitHub organization name.
+        repo_name: Repository name within the organization.
+
+    Returns:
+        Tuple of (tag_name, commit_sha).
+
+    Raises:
+        SystemExit: If no release is found or the tag cannot be
+            resolved.
+    """
+    release_url = (
+        f"{GITHUB_API}/repos/{org}/{repo_name}"
+        f"/releases/latest"
+    )
+    status, data = github_api_request(release_url)
+    if status != 200:
+        print(
+            f"No release found for {org}/{repo_name}. "
+            f"Use --release-ref <tag> to specify a "
+            f"release tag."
+        )
+        sys.exit(1)
+
+    tag_name = data["tag_name"]
+
+    ref_url = (
+        f"{GITHUB_API}/repos/{org}/{repo_name}"
+        f"/git/ref/tags/{tag_name}"
+    )
+    ref_status, ref_data = github_api_request(ref_url)
+    if ref_status != 200:
+        print(
+            f"Error: Could not resolve tag '{tag_name}' "
+            f"for {org}/{repo_name}."
+        )
+        sys.exit(1)
+
+    obj = ref_data.get("object", {})
+    if obj.get("type") == "tag":
+        # Annotated tag — dereference to get the commit SHA
+        tag_url = (
+            f"{GITHUB_API}/repos/{org}/{repo_name}"
+            f"/git/tags/{obj['sha']}"
+        )
+        _, tag_data = github_api_request(tag_url)
+        commit_sha = tag_data.get("object", {}).get("sha", "")
+    else:
+        # Lightweight tag — SHA points directly to the commit
+        commit_sha = obj.get("sha", "")
+
+    return tag_name, commit_sha
+
+
+def transform_workflow_refs(
+    content: str,
+    org: str,
+    source_repo: str,
+    sha: str,
+    tag: str,
+) -> str:
+    """Replace local workflow path refs with SHA-pinned cross-repo refs.
+
+    Finds ``uses: ./.github/workflows/reusable_<name>.yml`` patterns
+    and replaces them with
+    ``uses: <org>/<source_repo>/.github/workflows/reusable_<name>.yml@<sha>  # <tag>``.
+
+    Only matches lines where the value starts with
+    ``./.github/workflows/reusable_`` to avoid transforming
+    non-reusable workflow references.
+
+    Args:
+        content: Workflow file content as a string.
+        org: GitHub organization name (e.g., ``complytime``).
+        source_repo: Source repository name (e.g., ``org-infra``).
+        sha: Full 40-character commit SHA to pin to.
+        tag: Release tag for the inline version comment.
+
+    Returns:
+        Content with local refs replaced by SHA-pinned cross-repo
+        refs.
+
+    Raises:
+        ValueError: If ``sha`` is not a valid 40-character hex string.
+    """
+    if not re.fullmatch(r"[0-9a-f]{40}", sha):
+        raise ValueError(f"Invalid SHA format: {sha!r}")
+
+    pattern = (
+        r"(uses:\s*)"
+        r"\./\.github/workflows/(reusable_\S+\.yml)"
+    )
+    replacement = (
+        rf"\g<1>{org}/{source_repo}/"
+        rf".github/workflows/\g<2>@{sha} # {tag}"
+    )
+    return re.sub(pattern, replacement, content)
+
+
 def setup_git_credentials(repo_path: str, org: str, repo_name: str) -> None:
     """Configure git credentials for authenticated pushes to the target repo.
 
@@ -526,6 +651,8 @@ def sync_repository(
     repo_name: str,
     config: dict,
     dry_run: bool = False,
+    release_tag: Optional[str] = None,
+    release_sha: Optional[str] = None,
 ) -> bool:
     """Sync a single repository with standard files using direct push.
 
@@ -534,6 +661,8 @@ def sync_repository(
         repo_name: Repository name
         config: Sync configuration
         dry_run: If True, only show what would be done
+        release_tag: Release tag for workflow ref transformation
+        release_sha: Commit SHA for workflow ref pinning
     """
     print(f"\n{'=' * 60}")
     print(f"Processing: {org}/{repo_name}")
@@ -611,19 +740,57 @@ def sync_repository(
                         print(f"{source_rel_path} excluded for this repo")
                         continue
 
-                resolved_vars = resolve_file_vars(file_config, repo_name)
+                resolved_vars = resolve_file_vars(
+                    file_config, repo_name,
+                )
 
-                if resolved_vars:
-                    # Var-aware path: read, substitute, compare resolved
-                    # content against destination.
-                    source_content = source_path.read_text()
-                    resolved_content = apply_file_vars(
-                        source_content, resolved_vars,
+                is_ci_workflow = (
+                    source_rel_path.startswith(
+                        ".github/workflows/ci_",
                     )
+                    and source_rel_path.endswith(".yml")
+                )
+                needs_content_transform = bool(
+                    resolved_vars,
+                ) or (
+                    is_ci_workflow
+                    and release_tag
+                    and release_sha
+                )
 
-                    if dry_run:
-                        for vn, vv in resolved_vars.items():
-                            print(f"[DRY RUN] var {vn}={vv}")
+                if needs_content_transform:
+                    # Content-transform path: read source,
+                    # apply vars and/or workflow ref
+                    # transformation, then compare.
+                    source_content = source_path.read_text()
+
+                    if resolved_vars:
+                        source_content = apply_file_vars(
+                            source_content, resolved_vars,
+                        )
+                        if dry_run:
+                            for vn, vv in resolved_vars.items():
+                                print(
+                                    f"[DRY RUN] var {vn}={vv}",
+                                )
+
+                    if is_ci_workflow and release_sha:
+                        source_content = (
+                            transform_workflow_refs(
+                                source_content,
+                                org,
+                                SOURCE_REPO,
+                                release_sha,
+                                release_tag or "",
+                            )
+                        )
+                        if dry_run:
+                            print(
+                                "[DRY RUN] workflow refs "
+                                "transformed"
+                            )
+
+                    resolved_content = source_content
 
                     existing_content = ""
                     if os.path.exists(dest_path):
@@ -632,29 +799,52 @@ def sync_repository(
 
                     if resolved_content != existing_content:
                         if dry_run:
-                            action = "add" if not existing_content else "update"
-                            print(f"[DRY RUN] Would {action}: {dest_rel_path}")
+                            action = (
+                                "add"
+                                if not existing_content
+                                else "update"
+                            )
+                            print(
+                                f"[DRY RUN] Would {action}: "
+                                f"{dest_rel_path}"
+                            )
                         else:
                             os.makedirs(
-                                os.path.dirname(dest_path), exist_ok=True,
+                                os.path.dirname(dest_path),
+                                exist_ok=True,
                             )
                             with open(dest_path, "w") as f:
                                 f.write(resolved_content)
-                            print(f"{dest_rel_path} updated (vars applied)")
+                            print(
+                                f"{dest_rel_path} updated "
+                                f"(content transformed)"
+                            )
                         files_changed.append(dest_rel_path)
                     else:
                         print(f"{dest_rel_path} is up to date")
                 elif dry_run:
                     if not os.path.exists(dest_path):
-                        print(f"[DRY RUN] Would add: {dest_rel_path}")
+                        print(
+                            f"[DRY RUN] Would add: "
+                            f"{dest_rel_path}"
+                        )
                         files_changed.append(dest_rel_path)
-                    elif not compare_files(str(source_path), dest_path):
-                        print(f"[DRY RUN] Would update: {dest_rel_path}")
+                    elif not compare_files(
+                        str(source_path), dest_path,
+                    ):
+                        print(
+                            f"[DRY RUN] Would update: "
+                            f"{dest_rel_path}"
+                        )
                         files_changed.append(dest_rel_path)
                     else:
                         print(f"{dest_rel_path} is up to date")
                 else:
-                    if sync_file(str(source_path), dest_path, dest_rel_path):
+                    if sync_file(
+                        str(source_path),
+                        dest_path,
+                        dest_rel_path,
+                    ):
                         files_changed.append(dest_rel_path)
 
             # Step 4: Generate and sync dependabot.yml
@@ -765,6 +955,52 @@ def main() -> None:
 
     config = load_sync_config(args.config)
 
+    # Detect or resolve release for workflow ref transformation
+    release_tag: Optional[str] = None
+    release_sha: Optional[str] = None
+
+    if args.release_ref:
+        # User provided an explicit tag — resolve it to SHA
+        print(f"Using release override: {args.release_ref}")
+        release_tag = args.release_ref
+        ref_endpoint = (
+            f"{GITHUB_API}/repos/{args.org}/{SOURCE_REPO}"
+            f"/git/ref/tags/{release_tag}"
+        )
+        status, data = github_api_request(ref_endpoint)
+        if status != 200:
+            print(
+                f"Error: Tag '{release_tag}' not found "
+                f"for {args.org}/{SOURCE_REPO}."
+            )
+            sys.exit(1)
+        # Handle annotated vs lightweight tags
+        if data.get("object", {}).get("type") == "tag":
+            tag_endpoint = (
+                f"{GITHUB_API}/repos/{args.org}"
+                f"/{SOURCE_REPO}"
+                f"/git/tags/{data['object']['sha']}"
+            )
+            _, tag_data = github_api_request(tag_endpoint)
+            release_sha = tag_data.get(
+                "object", {},
+            ).get("sha")
+        else:
+            release_sha = data.get(
+                "object", {},
+            ).get("sha")
+    else:
+        # Auto-detect latest release
+        release_tag, release_sha = get_latest_release(
+            args.org, SOURCE_REPO,
+        )
+
+    if release_tag and release_sha:
+        print(
+            f"Release ref: {release_tag} "
+            f"({release_sha[:12]})"
+        )
+
     # Fetch and parse peribolos.yml
     peribolos_data = fetch_peribolos_file(args.org)
     repositories = extract_repositories(peribolos_data, args.org)
@@ -793,7 +1029,11 @@ def main() -> None:
     success_count = 0
     for repo_name in repositories:
         try:
-            if sync_repository(args.org, repo_name, config, args.dry_run):
+            if sync_repository(
+                args.org, repo_name, config, args.dry_run,
+                release_tag=release_tag,
+                release_sha=release_sha,
+            ):
                 success_count += 1
         except Exception as e:
             print(f"Failed to process {repo_name}: {e}")

--- a/sync-config.yml
+++ b/sync-config.yml
@@ -10,6 +10,8 @@ exclude_repos:
   - website                     # Managed independently
   - nunya                       # Internal tooling (Jira migration)
   - roadmap                     # Internal tooling (roadmap scripts)
+  - complyscribe                # Archived
+  - gemara-content-service      # Archived
 
 # Files and workflows to synchronize
 # Each entry specifies:
@@ -20,15 +22,23 @@ files_to_sync:
   # GitHub Workflows
   - source: .github/workflows/ci_checks.yml
     destination: .github/workflows/ci_checks.yml
+    exclude_repos:
+      - community
 
   - source: .github/workflows/ci_dependencies.yml
     destination: .github/workflows/ci_dependencies.yml
+    exclude_repos:
+      - community
 
   - source: .github/workflows/ci_scheduled.yml
     destination: .github/workflows/ci_scheduled.yml
+    exclude_repos:
+      - community
 
   - source: .github/workflows/ci_security.yml
     destination: .github/workflows/ci_security.yml
+    exclude_repos:
+      - community
     vars:
       enable_trivy_source:
         default: "false"
@@ -37,13 +47,11 @@ files_to_sync:
           complytime: "true"
           complytime-providers: "true"
           complytime-collector-components: "true"
-          gemara-content-service: "true"
-          complyscribe: "true"
 
   - source: .github/workflows/ci_crapload.yml
     destination: .github/workflows/ci_crapload.yml
     exclude_repos:
-      - complyscribe
+      - .github
       - complytime-demos
       - complytime-policies
       - community
@@ -56,8 +64,6 @@ files_to_sync:
 
   - source: .yamllint.yml
     destination: .yamllint.yml
-    exclude_repos:
-      - complyscribe
 
   - source: commitlint.config.js
     destination: commitlint.config.js
@@ -65,9 +71,9 @@ files_to_sync:
   - source: .golangci.yml
     destination: .golangci.yml
     exclude_repos:
-      - complyscribe
       - complytime-demos
       - complytime-policies
+      - community
 
   - source: ruff.toml
     destination: ruff.toml
@@ -77,32 +83,31 @@ files_to_sync:
       - complytime
       - complytime-collector-components
       - complytime-providers
-      - gemara-content-service
+      - community
 
   # AI Tooling
   - source: .specify/memory/constitution.md
     destination: .specify/memory/constitution.md
     exclude_repos:
       - .github
-      - complyscribe
 
   - source: docs/AI_TOOLING.md
     destination: docs/AI_TOOLING.md
     exclude_repos:
       - .github
-      - complyscribe
+      - community
 
   - source: .agents/skills/.gitkeep
     destination: .agents/skills/.gitkeep
     exclude_repos:
       - .github
-      - complyscribe
+      - community
 
   - source: .opencode/commands/review-pr.md
     destination: .opencode/commands/review-pr.md
     exclude_repos:
       - .github
-      - complyscribe
+      - community
 
   # GitHub Templates
   - source: .github/pull_request_template.md
@@ -181,37 +186,6 @@ dependabot:
 
     complytime-providers:
       - package-ecosystem: "gomod"
-        directory: "/"
-        schedule:
-          interval: "weekly"
-        open-pull-requests-limit: 10
-        commit-message:
-          prefix: "chore"
-          include: "scope"
-
-    gemara-content-service:
-      - package-ecosystem: "gomod"
-        directory: "/"
-        schedule:
-          interval: "weekly"
-        open-pull-requests-limit: 10
-        commit-message:
-          prefix: "chore"
-          include: "scope"
-
-    complyscribe:
-      - package-ecosystem: "github-actions"
-        directories:
-          - "/"
-          - "/.github/actions/e2e-testing"
-          - "/.github/actions/publish-image"
-          - "/.github/actions/setup-poetry"
-        schedule:
-          interval: "daily"
-        commit-message:
-          prefix: "ci"
-          include: "scope"
-      - package-ecosystem: "pip"
         directory: "/"
         schedule:
           interval: "weekly"

--- a/tests/test_sync_org_repositories.py
+++ b/tests/test_sync_org_repositories.py
@@ -7,6 +7,7 @@ import sys
 from pathlib import Path
 from unittest.mock import patch
 
+import pytest
 import yaml
 
 # Add scripts to path for import
@@ -14,7 +15,12 @@ sys.path.insert(0, str(Path(__file__).parent.parent / "scripts"))
 
 sync_module = importlib.import_module("sync-org-repositories")
 
+import pytest
+
 GITHUB_API = sync_module.GITHUB_API
+
+# Valid 40-character hex SHA for use in transform_workflow_refs tests.
+TEST_SHA = "a" * 40
 
 
 class TestValidateGithubApiRequest:
@@ -85,6 +91,33 @@ class TestValidateGithubApiRequest:
     def test_disallowed_get_app(self):
         result = sync_module.validate_github_api_request(f"{GITHUB_API}/app", "GET")
         assert not result
+
+    def test_allowed_get_releases_latest(self):
+        assert (
+            sync_module.validate_github_api_request(
+                f"{GITHUB_API}/repos/org/repo/releases/latest",
+                "GET",
+            )
+            is True
+        )
+
+    def test_allowed_get_git_ref_tags(self):
+        assert (
+            sync_module.validate_github_api_request(
+                f"{GITHUB_API}/repos/org/repo/git/ref/tags/v1.0.0",
+                "GET",
+            )
+            is True
+        )
+
+    def test_allowed_get_git_tags_sha(self):
+        assert (
+            sync_module.validate_github_api_request(
+                f"{GITHUB_API}/repos/org/repo/git/tags/abc123def456",
+                "GET",
+            )
+            is True
+        )
 
 
 class TestValidateBranchName:
@@ -649,3 +682,235 @@ class TestVarAwareFileComparison:
             source.read_text(), resolved_vars,
         )
         assert resolved_content == source.read_text()
+
+
+class TestTransformWorkflowRefs:
+    """Tests for transform_workflow_refs."""
+
+    def test_single_ref_transformed(self):
+        content = (
+            "    uses: ./.github/workflows/reusable_ci.yml\n"
+        )
+        result = sync_module.transform_workflow_refs(
+            content, "complytime", "org-infra",
+            TEST_SHA, "v1.0.0",
+        )
+        expected = (
+            "    uses: complytime/org-infra/"
+            ".github/workflows/"
+            f"reusable_ci.yml@{TEST_SHA} # v1.0.0\n"
+        )
+        assert result == expected
+
+    def test_multiple_refs_transformed(self):
+        content = (
+            "    uses: ./.github/workflows/reusable_ci.yml\n"
+            "    runs-on: ubuntu-latest\n"
+            "    uses: ./.github/workflows/reusable_lint.yml\n"
+        )
+        result = sync_module.transform_workflow_refs(
+            content, "complytime", "org-infra",
+            TEST_SHA, "v2.0.0",
+        )
+        assert f"reusable_ci.yml@{TEST_SHA} # v2.0.0" in result
+        assert f"reusable_lint.yml@{TEST_SHA} # v2.0.0" in result
+        assert "./.github/workflows/" not in result
+
+    def test_no_refs_passthrough(self):
+        content = (
+            "name: CI\n"
+            "on: push\n"
+            "jobs:\n"
+            "  build:\n"
+            "    runs-on: ubuntu-latest\n"
+        )
+        result = sync_module.transform_workflow_refs(
+            content, "complytime", "org-infra",
+            TEST_SHA, "v1",
+        )
+        assert result == content
+
+    def test_non_reusable_ref_not_transformed(self):
+        content = (
+            "    uses: ./.github/workflows/ci_checks.yml\n"
+        )
+        result = sync_module.transform_workflow_refs(
+            content, "complytime", "org-infra",
+            TEST_SHA, "v1",
+        )
+        assert result == content
+
+    def test_third_party_action_not_transformed(self):
+        content = (
+            "    uses: actions/checkout@abc123def456\n"
+        )
+        result = sync_module.transform_workflow_refs(
+            content, "complytime", "org-infra",
+            TEST_SHA, "v1",
+        )
+        assert result == content
+
+    def test_mixed_content(self):
+        content = (
+            "name: CI Pipeline\n"
+            "jobs:\n"
+            "  lint:\n"
+            "    uses: ./.github/workflows/reusable_lint.yml\n"
+            "  build:\n"
+            "    runs-on: ubuntu-latest\n"
+            "    steps:\n"
+            "      - uses: actions/checkout@v4\n"
+            "  deploy:\n"
+            "    uses: ./.github/workflows/ci_deploy.yml\n"
+        )
+        result = sync_module.transform_workflow_refs(
+            content, "org", "repo", TEST_SHA, "v3.0.0",
+        )
+        # Reusable ref transformed
+        assert (
+            "uses: org/repo/.github/workflows/"
+            f"reusable_lint.yml@{TEST_SHA} # v3.0.0" in result
+        )
+        # Third-party action untouched
+        assert "uses: actions/checkout@v4" in result
+        # Non-reusable local ref untouched
+        assert (
+            "uses: ./.github/workflows/ci_deploy.yml" in result
+        )
+
+    def test_preserves_indentation(self):
+        content = (
+            "  uses: ./.github/workflows/reusable_a.yml\n"
+            "    uses: ./.github/workflows/reusable_b.yml\n"
+            "      uses: ./.github/workflows/reusable_c.yml\n"
+        )
+        result = sync_module.transform_workflow_refs(
+            content, "org", "repo", TEST_SHA, "v1",
+        )
+        lines = result.splitlines()
+        assert lines[0].startswith("  uses:")
+        assert lines[1].startswith("    uses:")
+        assert lines[2].startswith("      uses:")
+
+    def test_invalid_sha_raises_value_error(self):
+        with pytest.raises(ValueError, match="Invalid SHA format"):
+            sync_module.transform_workflow_refs(
+                "uses: ./.github/workflows/reusable_ci.yml",
+                "org", "repo", "not-a-valid-sha", "v1",
+            )
+
+    def test_short_sha_raises_value_error(self):
+        with pytest.raises(ValueError, match="Invalid SHA format"):
+            sync_module.transform_workflow_refs(
+                "uses: ./.github/workflows/reusable_ci.yml",
+                "org", "repo", "abc123", "v1",
+            )
+
+
+class TestGetLatestRelease:
+    """Tests for get_latest_release."""
+
+    @patch.object(sync_module, "github_api_request")
+    def test_lightweight_tag_returns_commit_sha(self, mock_api):
+        mock_api.side_effect = [
+            (200, {"tag_name": "v1.0.0"}),
+            (200, {"object": {"type": "commit", "sha": "abc123"}}),
+        ]
+        tag, sha = sync_module.get_latest_release("org", "repo")
+        assert tag == "v1.0.0"
+        assert sha == "abc123"
+
+    @patch.object(sync_module, "github_api_request")
+    def test_annotated_tag_dereferences_to_commit(self, mock_api):
+        mock_api.side_effect = [
+            (200, {"tag_name": "v1.0.0"}),
+            (
+                200,
+                {"object": {"type": "tag", "sha": "tag_obj_sha"}},
+            ),
+            (200, {"object": {"sha": "real_commit_sha"}}),
+        ]
+        tag, sha = sync_module.get_latest_release("org", "repo")
+        assert tag == "v1.0.0"
+        assert sha == "real_commit_sha"
+
+    @patch.object(sync_module, "github_api_request")
+    def test_no_release_exits(self, mock_api):
+        mock_api.return_value = (404, {"message": "Not Found"})
+        with pytest.raises(SystemExit) as exc_info:
+            sync_module.get_latest_release("org", "repo")
+        assert exc_info.value.code == 1
+
+    @patch.object(sync_module, "github_api_request")
+    def test_tag_resolution_fails_exits(self, mock_api):
+        mock_api.side_effect = [
+            (200, {"tag_name": "v1.0.0"}),
+            (404, {"message": "Not Found"}),
+        ]
+        with pytest.raises(SystemExit) as exc_info:
+            sync_module.get_latest_release("org", "repo")
+        assert exc_info.value.code == 1
+
+
+class TestWorkflowRefTransformComposition:
+    """Tests for composition of apply_file_vars and transform_workflow_refs."""
+
+    def test_vars_and_refs_compose(self):
+        content = (
+            "jobs:\n"
+            "  scan:\n"
+            "    uses: ./.github/workflows/"
+            "reusable_vuln_scan.yml\n"
+            "    with:\n"
+            "      enable_trivy_source: false\n"
+        )
+        # Apply vars first (change false to true)
+        with_vars = sync_module.apply_file_vars(
+            content, {"enable_trivy_source": "true"},
+        )
+        # Then transform workflow refs
+        result = sync_module.transform_workflow_refs(
+            with_vars, "org", "repo", TEST_SHA, "v1.0.0",
+        )
+        assert "enable_trivy_source: true" in result
+        assert (
+            "uses: org/repo/.github/workflows/"
+            f"reusable_vuln_scan.yml@{TEST_SHA} # v1.0.0"
+            in result
+        )
+        assert "./.github/workflows/" not in result
+
+    def test_vars_only_no_refs(self):
+        content = (
+            "jobs:\n"
+            "  scan:\n"
+            "    uses: actions/checkout@v4\n"
+            "    with:\n"
+            "      enable_trivy_source: false\n"
+        )
+        with_vars = sync_module.apply_file_vars(
+            content, {"enable_trivy_source": "true"},
+        )
+        result = sync_module.transform_workflow_refs(
+            with_vars, "org", "repo", TEST_SHA, "v1",
+        )
+        assert "enable_trivy_source: true" in result
+        assert "uses: actions/checkout@v4" in result
+
+    def test_refs_only_no_vars(self):
+        content = (
+            "jobs:\n"
+            "  lint:\n"
+            "    uses: ./.github/workflows/reusable_lint.yml\n"
+            "    with:\n"
+            "      some_input: value\n"
+        )
+        with_vars = sync_module.apply_file_vars(content, {})
+        result = sync_module.transform_workflow_refs(
+            with_vars, "org", "repo", TEST_SHA, "v1",
+        )
+        assert (
+            "uses: org/repo/.github/workflows/"
+            f"reusable_lint.yml@{TEST_SHA} # v1" in result
+        )
+        assert "some_input: value" in result

--- a/tests/test_sync_org_repositories.py
+++ b/tests/test_sync_org_repositories.py
@@ -15,8 +15,6 @@ sys.path.insert(0, str(Path(__file__).parent.parent / "scripts"))
 
 sync_module = importlib.import_module("sync-org-repositories")
 
-import pytest
-
 GITHUB_API = sync_module.GITHUB_API
 
 # Valid 40-character hex SHA for use in transform_workflow_refs tests.


### PR DESCRIPTION
## Summary

Enable org-infra to test its own reusable workflow changes during CI by using local path refs instead of SHA-pinned cross-repo refs.
The sync script transforms local refs back to SHA-pinned refs when syncing to downstream repos.

This eliminates the self-testing gap where broken reusable workflows could be released and synced to all org repos before the breakage was caught. With this change, reusable workflow modifications are validated on PRs - catching issues at the earliest possible stage instead of after a release.
It also removes one manual step from the release process (bumping SHA refs) and reduces the Dependabot PRs created across org repos to bump workflow SHAs after each release.

Additionally, sync-config.yml is cleaned up to exclude archived repositories (complyscribe, gemara-content-service) globally and scope the community repo to only receive files relevant to a markdown-only repository.

## Related Issues

- Supersedes the within-org-infra scope of the `pin-workflows-to-release` change

## Review Hints

- Review commits individually — they are split by concern: specs, implementation, sync-config cleanup.

- The key design decision is using local path refs (`./.github/workflows/...`) instead of `@main`. Local refs resolve to the current commit, so PRs that modify a reusable workflow test the modified version immediately. See  `openspec/changes/self-testing-workflows/design.md` Decision 1 for the full rationale.

- The sync script transformation logic is in `transform_workflow_refs()` and  `get_latest_release()`. Both follow the same content-transform pattern as the existing `apply_file_vars()`.

- Run `make test` to verify all 100 tests pass. Run `make lint` for yamllint + ruff.