### PR TITLE
fix(ci): update compliance workflow for providers split and Quay direct fetch

### DIFF
--- a/.github/workflows/reusable_compliance.yml
+++ b/.github/workflows/reusable_compliance.yml
@@ -2,9 +2,9 @@
 name: Reusable GitHub Branch Protection Scan
 
 # --------------------------------------------------------------------------
-# This workflow builds complyctl from source and uses it with a local
-# mock-oci-registry to scan GitHub branch protection rules via the
-# ampel-branch-protection policy.
+# This workflow builds complyctl from source and uses it to scan GitHub
+# branch protection rules via the ampel-branch-protection policy.
+# Policy bundles are fetched directly from Quay.io (public OCI artifacts).
 # --------------------------------------------------------------------------
 on:
   workflow_call:
@@ -82,25 +82,6 @@ jobs:
           mkdir -p ~/.complytime/providers
           cp _providers/bin/complyctl-provider-ampel ~/.complytime/providers/complyctl-provider-ampel
 
-      - name: Start mock-oci-registry in background
-        run: |
-          ./bin/mock-oci-registry &
-          echo "MOCK_REGISTRY_PID=$!" >> "$GITHUB_ENV"
-
-          # Wait up to 15 seconds for the registry to be ready
-          for _ in $(seq 1 30); do
-            if curl -sf http://localhost:8765/v2/ >/dev/null 2>&1; then
-              echo "Mock registry is ready."
-              break
-            fi
-            sleep 0.5
-          done
-
-          if ! curl -sf http://localhost:8765/v2/ >/dev/null 2>&1; then
-            echo "ERROR: mock-oci-registry did not start in time."
-            exit 1
-          fi
-
       - name: Validate complytime_config_path input
         env:
           CONFIG_PATH: ${{ inputs.complytime_config_path }}
@@ -119,7 +100,7 @@ jobs:
           mkdir -p .complytime/ampel/granular-policies
           cp _providers/cmd/ampel-provider/convert/testdata/policies/* .complytime/ampel/granular-policies/
 
-      - name: Fetch ampel-branch-protection policy from mock registry
+      - name: Fetch policy bundle from OCI registry
         run: ./bin/complyctl get
 
       - name: Validate policy_id input

--- a/.github/workflows/reusable_compliance.yml
+++ b/.github/workflows/reusable_compliance.yml
@@ -43,6 +43,13 @@ jobs:
           repository: complytime/complyctl
           persist-credentials: false
 
+      - name: Checkout complytime-providers
+        uses: actions/checkout@de0fac2e4500dabe0009e67214ff5f5447ce83dd # v6.0.2
+        with:
+          repository: complytime/complytime-providers
+          path: _providers
+          persist-credentials: false
+
       - name: Checkout calling repository
         uses: actions/checkout@de0fac2e4500dabe0009e67214ff5f5447ce83dd # v6.0.2
         with:
@@ -55,9 +62,14 @@ jobs:
         with:
           go-version-file: './go.mod'
 
-      - name: Build
+      - name: Build complyctl
         run: |
           make build
+
+      - name: Build ampel provider
+        working-directory: _providers
+        run: |
+          make build-ampel-provider
 
       - name: Install snappy
         uses: carabiner-dev/actions/install/snappy@e0e3b8149dafed833431095bc148d50e7eade4e8
@@ -65,10 +77,10 @@ jobs:
       - name: Install ampel
         uses: carabiner-dev/actions/install/ampel@e0e3b8149dafed833431095bc148d50e7eade4e8
 
-      - name: Register ampel-plugin provider with complyctl
+      - name: Register ampel provider with complyctl
         run: |
           mkdir -p ~/.complytime/providers
-          cp bin/ampel-plugin ~/.complytime/providers/complyctl-provider-ampel
+          cp _providers/bin/complyctl-provider-ampel ~/.complytime/providers/complyctl-provider-ampel
 
       - name: Start mock-oci-registry in background
         run: |
@@ -105,7 +117,7 @@ jobs:
       - name: Copy ampel policy files
         run: |
           mkdir -p .complytime/ampel/granular-policies
-          cp cmd/ampel-plugin/convert/testdata/policies/* .complytime/ampel/granular-policies/
+          cp _providers/cmd/ampel-provider/convert/testdata/policies/* .complytime/ampel/granular-policies/
 
       - name: Fetch ampel-branch-protection policy from mock registry
         run: ./bin/complyctl get

--- a/complytime.yaml
+++ b/complytime.yaml
@@ -1,5 +1,5 @@
 policies:
-  - url: http://localhost:8765/policies/ampel-branch-protection
+  - url: quay.io/complytime/policies-ampel-branch-protection:latest
     id: ampel-bp
 
 targets:


### PR DESCRIPTION
## Summary

Fixes `reusable_compliance.yml` which has been **failing daily** in both `org-infra` and `complyctl`, and modernizes it to fetch policies directly from Quay.

### Changes

| Area | Before (broken) | After |
|------|-----------------|-------|
| Provider source | `complyctl` only | `complyctl` + `complytime-providers` |
| Provider binary | `bin/ampel-plugin` | `_providers/bin/complyctl-provider-ampel` |
| Testdata policies | `cmd/ampel-plugin/...` | `_providers/cmd/ampel-provider/...` |
| Policy fetch | Mock OCI registry at `localhost:8765` | Direct from `quay.io` (public OCI artifacts) |
| `complytime.yaml` | `http://localhost:8765/policies/ampel-branch-protection` | `quay.io/complytime/policies-ampel-branch-protection:latest` |

### Why

1. **Providers split**: `ampel-plugin` was migrated from `complyctl` to `complytime-providers`, breaking the build step
2. **Mock registry removal**: Policy bundles are now [publicly available on Quay](https://github.com/complytime/complytime-policies/pull/36), making the mock registry unnecessary

### Failing runs (same error)

- org-infra: https://github.com/complytime/org-infra/actions/workflows/ci_compliance.yml
- complyctl: https://github.com/complytime/complyctl/actions/workflows/ci_compliance.yml

```
cp: cannot stat 'bin/ampel-plugin': No such file or directory
```

### Note

The `ci_compliance.yml` callers in both repos pin to `v0.2.1` of this reusable workflow. After merge, a new tag is needed and both callers must update their pin.

Fixes: #276

## Merge order

This PR is **first in the chain** — no dependencies on other PRs.

| Order | Repo | PR | Purpose | Depends on |
|-------|------|----|---------|------------|
| **1** | **org-infra** | **#277 (this)** | **Fix reusable compliance workflow + Quay direct fetch** | — |
| 2 | complytime-providers | [#22](https://github.com/complytime/complytime-providers/pull/22) | OpenSCAP configuration docs | — |
| 3 | complyctl | [#525](https://github.com/complytime/complyctl/pull/525) | Update policy URLs in QUICK_START + complytime.yaml | #277 merged (for CI) |
| 4 | complytime-policies | [#33](https://github.com/complytime/complytime-policies/pull/33) | Usage docs with provider table + further reading | #22 merged (for doc links) |

## Test plan

- [ ] Verify workflow YAML is valid
- [ ] Tag new release after merge (e.g., `v0.3.0`)
- [ ] Update caller pin in org-infra `ci_compliance.yml` and trigger `workflow_dispatch`
- [ ] Update caller pin in complyctl `ci_compliance.yml` and trigger `workflow_dispatch`
- [ ] Confirm daily scheduled runs pass

Relates to - https://github.com/complytime/complytime-policies/issues/5