### PR TITLE
fix(ci): update complytime.yaml to per-bundle Quay URL

### DIFF
--- a/complytime.yaml
+++ b/complytime.yaml
@@ -1,5 +1,5 @@
 policies:
-  - url: http://localhost:8765/policies/ampel-branch-protection
+  - url: quay.io/complytime/policies-ampel-branch-protection:latest
     id: ampel-bp
 
 targets:


### PR DESCRIPTION
## Summary

- Updates `complytime.yaml` to use the published per-bundle Quay URL now that [complytime-policies#36](https://github.com/complytime/complytime-policies/pull/36) has merged and bundles are publicly accessible
- Replaces `http://localhost:8765/policies/ampel-branch-protection` with `quay.io/complytime/policies-ampel-branch-protection:latest`

### Note on mock registry

The `reusable_compliance.yml` workflow still starts a mock-oci-registry. With this URL change, `complyctl get` pulls directly from Quay, making the mock registry a harmless no-op. A follow-up can remove the mock registry step once both this PR and #277 are validated.

### Dependency

This PR should merge **after** [#277](https://github.com/complytime/org-infra/pull/277) (reusable workflow fix for providers split), since the compliance workflow is currently broken without that fix.

Refs: complytime/complytime-policies#36

## Test plan

- [ ] Merge #277 first (reusable workflow fix)
- [ ] Trigger `ci_compliance.yml` via `workflow_dispatch` to confirm end-to-end flow

Made with [Cursor](https://cursor.com)