### PR TITLE
refactor(ci): extract trivy image scan into separate reusable workflow

### DIFF
--- a/.github/workflows/ci_test_trivy_image_scan.yml
+++ b/.github/workflows/ci_test_trivy_image_scan.yml
@@ -1,0 +1,182 @@
+# CI Test: Reusable Trivy Image Scan
+# ====================================
+# Self-validation tests for reusable_trivy_image_scan.yml.
+# Builds a minimal temp image, then scans it with and without digest to verify:
+# - Positive: scan passes on a clean image, vuln attestation attached when digest provided
+# - Negative: no attestation produced when digest is omitted
+
+name: Test Trivy Image Scan
+
+on:
+  pull_request:
+    branches:
+      - main
+    paths:
+      - ".github/workflows/reusable_trivy_image_scan.yml"
+      - ".github/workflows/ci_test_trivy_image_scan.yml"
+      - ".github/ci-tests/ghcr-publish/Containerfile"
+
+permissions:
+  contents: read
+
+jobs:
+  check-changes:
+    name: Check Changed Files
+    runs-on: ubuntu-latest
+    permissions:
+      contents: read
+      pull-requests: read
+    outputs:
+      files_changed: ${{ steps.filter.outputs.any_changed }}
+    steps:
+      - uses: tj-actions/changed-files@9426d40962ed5378910ee2e21d5f8c6fcbf2dd96 # v47.0.5
+        id: filter
+        with:
+          files: |
+            .github/workflows/reusable_trivy_image_scan.yml
+            .github/workflows/ci_test_trivy_image_scan.yml
+            .github/ci-tests/ghcr-publish/**
+
+  build-test-image:
+    name: Build Test Image
+    needs: check-changes
+    if: >-
+      needs.check-changes.outputs.files_changed == 'true' &&
+      github.event.pull_request.head.repo.full_name == github.repository &&
+      github.actor != 'dependabot[bot]'
+    uses: ./.github/workflows/reusable_publish_ghcr.yml
+    permissions:
+      contents: read
+      packages: write
+      actions: read
+      id-token: write
+      attestations: write
+    with:
+      component_name: org-infra-test-trivy
+      containerfile_path: .github/ci-tests/ghcr-publish/Containerfile
+      context_path: .github/ci-tests/ghcr-publish
+      image_name: complytime/org-infra-test-trivy
+      allow_unprotected_ref: true
+
+  test-scan-no-attestation:
+    name: Test Scan (No Attestation)
+    needs: build-test-image
+    uses: ./.github/workflows/reusable_trivy_image_scan.yml
+    permissions:
+      packages: write
+      security-events: write
+      id-token: write
+    with:
+      image_ref: ${{ needs.build-test-image.outputs.image_ref }}
+
+  test-scan-with-attestation:
+    name: Test Scan (With Attestation)
+    needs: [build-test-image, test-scan-no-attestation]
+    uses: ./.github/workflows/reusable_trivy_image_scan.yml
+    permissions:
+      packages: write
+      security-events: write
+      id-token: write
+    with:
+      image_ref: ${{ needs.build-test-image.outputs.image_ref }}
+      image_digest: ${{ needs.build-test-image.outputs.digest }}
+
+  verify-scan-results:
+    name: Verify Scan Results
+    needs: [build-test-image, test-scan-no-attestation, test-scan-with-attestation]
+    runs-on: ubuntu-latest
+    permissions:
+      contents: read
+      packages: write
+    steps:
+      - name: Verify scan passed (no attestation)
+        env:
+          SCAN_PASSED: ${{ needs.test-scan-no-attestation.outputs.scan_passed }}
+        run: |
+          echo "scan_passed: $SCAN_PASSED"
+          if [[ "$SCAN_PASSED" != "true" ]]; then
+            echo "::error::Expected scan_passed='true', got '$SCAN_PASSED'"
+            exit 1
+          fi
+          echo "::notice::Scan passed (no attestation mode)"
+
+      - name: Verify no attestation (no digest provided)
+        env:
+          ATTESTATION: ${{ needs.test-scan-no-attestation.outputs.attestation_attached }}
+        run: |
+          echo "attestation_attached: $ATTESTATION"
+          if [[ "$ATTESTATION" == "true" ]]; then
+            echo "::error::Attestation should NOT be attached when no digest provided"
+            exit 1
+          fi
+          echo "::notice::Confirmed: no attestation without digest"
+
+      - name: Verify scan passed (with attestation)
+        env:
+          SCAN_PASSED: ${{ needs.test-scan-with-attestation.outputs.scan_passed }}
+        run: |
+          echo "scan_passed: $SCAN_PASSED"
+          if [[ "$SCAN_PASSED" != "true" ]]; then
+            echo "::error::Expected scan_passed='true', got '$SCAN_PASSED'"
+            exit 1
+          fi
+          echo "::notice::Scan passed (with attestation mode)"
+
+      - name: Verify attestation attached (with digest)
+        env:
+          ATTESTATION: ${{ needs.test-scan-with-attestation.outputs.attestation_attached }}
+        run: |
+          echo "attestation_attached: $ATTESTATION"
+          if [[ "$ATTESTATION" != "true" ]]; then
+            echo "::error::Expected attestation_attached='true', got '$ATTESTATION'"
+            exit 1
+          fi
+          echo "::notice::Attestation attached"
+
+      - name: Install cosign
+        uses: sigstore/cosign-installer@6f9f17788090df1f26f669e9d70d6ae9567deba6 # v4.1.2
+
+      - name: Login to GHCR
+        uses: docker/login-action@650006c6eb7dba73a995cc03b0b2d7f5ca915bee # v4.2.0
+        with:
+          registry: ghcr.io
+          username: ${{ github.repository_owner }}
+          password: ${{ secrets.GITHUB_TOKEN }}
+
+      - name: Verify vuln attestation via cosign
+        env:
+          IMAGE: ${{ needs.build-test-image.outputs.image }}
+          DIGEST: ${{ needs.build-test-image.outputs.digest }}
+        run: |
+          echo "Checking vuln attestation for ${IMAGE}@${DIGEST}"
+
+          cosign verify-attestation \
+            --type vuln \
+            --certificate-identity-regexp="^https://github.com/complytime/.*" \
+            --certificate-oidc-issuer="https://token.actions.githubusercontent.com" \
+            "${IMAGE}@${DIGEST}" || {
+              echo "::error::Vuln attestation not found"
+              exit 1
+            }
+
+          echo "::notice::Vuln attestation verified"
+
+      - name: Cleanup test image
+        if: always()
+        env:
+          GH_TOKEN: ${{ secrets.GITHUB_TOKEN }}
+          IMAGE_REF_OUTPUT: ${{ needs.build-test-image.outputs.image_ref }}
+        run: |
+          IMAGE_REF="$IMAGE_REF_OUTPUT"
+          TAG="${IMAGE_REF##*:}"
+
+          echo "Deleting package version with tag: $TAG"
+
+          gh api "/orgs/complytime/packages/container/org-infra-test-trivy/versions" \
+            --jq ".[] | select(.metadata.container.tags[] | . == \"$TAG\") | .id" | \
+          while read -r VERSION_ID; do
+            echo "Deleting version ID: $VERSION_ID"
+            gh api --method DELETE \
+              "/orgs/complytime/packages/container/org-infra-test-trivy/versions/$VERSION_ID" \
+              || echo "Failed to delete version $VERSION_ID"
+          done

--- a/.github/workflows/reusable_trivy_image_scan.yml
+++ b/.github/workflows/reusable_trivy_image_scan.yml
@@ -68,6 +68,7 @@ jobs:
         id: trivy
         uses: aquasecurity/trivy-action@ed142fd0673e97e23eac54620cfb913e5ce36c25 # 0.36.0
         with:
+          version: 'v0.70.0'
           scan-type: 'image'
           scanners: 'vuln'
           image-ref: ${{ inputs.image_ref }}

--- a/.github/workflows/reusable_trivy_image_scan.yml
+++ b/.github/workflows/reusable_trivy_image_scan.yml
@@ -1,0 +1,118 @@
+# Reusable Trivy Image Scan Workflow
+# ===================================
+# Container image scan for OS packages and runtime dependencies.
+# Optionally attaches a cosign vuln attestation to the image for supply chain verification.
+#
+# Requires elevated permissions (packages: write, id-token: write) so it is kept
+# separate from the lighter-weight source/dependency scan workflow
+# (reusable_vuln_scan.yml) to avoid forcing those permissions on callers that
+# only need OSV or Trivy source scanning.
+
+name: Reusable Trivy Image Scan
+
+on:
+  workflow_call:
+    inputs:
+      image_ref:
+        description: 'Image reference for image scan, e.g., ghcr.io/org/image:sha-<sha>'
+        required: true
+        type: string
+      image_digest:
+        description: 'Image digest (e.g., sha256:abc...). If provided, vuln attestation is attached to image.'
+        type: string
+        default: ''
+      trivy_severity:
+        description: 'Severity levels to report'
+        type: string
+        default: 'HIGH,CRITICAL'
+    outputs:
+      scan_passed:
+        description: 'Whether Trivy image scan completed successfully (no vulns found)'
+        value: ${{ jobs.trivy_image.outputs.scan_passed }}
+      attestation_attached:
+        description: 'Whether vuln attestation was attached to image'
+        value: ${{ jobs.trivy_image.outputs.attestation_attached || 'false' }}
+
+permissions:
+  contents: none
+  packages: none
+  security-events: none
+  id-token: none
+  actions: none
+
+concurrency:
+  group: trivy-image-${{ github.workflow }}-${{ github.ref }}-${{ inputs.image_ref }}
+  cancel-in-progress: true
+
+jobs:
+  trivy_image:
+    name: Trivy Image Scan
+    runs-on: ubuntu-latest
+    timeout-minutes: 15
+    outputs:
+      scan_passed: ${{ steps.scan_result.outputs.passed }}
+      attestation_attached: ${{ steps.attest.outputs.attached }}
+    permissions:
+      packages: write         # Push attestation to registry
+      security-events: write  # Upload SARIF
+      id-token: write         # Keyless signing of attestation
+    steps:
+      - name: Login to GHCR
+        uses: docker/login-action@650006c6eb7dba73a995cc03b0b2d7f5ca915bee # v4.2.0
+        with:
+          registry: ghcr.io
+          username: ${{ github.repository_owner }}
+          password: ${{ secrets.GITHUB_TOKEN }}
+
+      - name: Run Trivy image scanner
+        id: trivy
+        uses: aquasecurity/trivy-action@ed142fd0673e97e23eac54620cfb913e5ce36c25 # 0.36.0
+        with:
+          scan-type: 'image'
+          scanners: 'vuln'
+          image-ref: ${{ inputs.image_ref }}
+          severity: ${{ inputs.trivy_severity }}
+          ignore-unfixed: true
+          format: 'sarif'
+          output: 'trivy-image-scan-${{ github.workflow_sha }}-${{ github.run_number }}.sarif'
+          # NOTE: exit-code 0 because trivy-action's exit-code behavior is inconsistent
+          # with SARIF format. We parse SARIF to check for actual findings instead.
+          exit-code: '0'
+
+      - name: Upload SARIF
+        if: ${{ always() }}
+        uses: github/codeql-action/upload-sarif@7211b7c8077ea37d8641b6271f6a365a22a5fbfa # v4.36.0
+        with:
+          sarif_file: 'trivy-image-scan-${{ github.workflow_sha }}-${{ github.run_number }}.sarif'
+          category: 'trivy-image'
+
+      - name: Check scan result
+        id: scan_result
+        if: ${{ steps.trivy.outcome == 'success' }}
+        env:
+          SARIF_FILE: trivy-image-scan-${{ github.workflow_sha }}-${{ github.run_number }}.sarif
+        run: |
+          COUNT=$(jq '[.runs[].results[] | select(.level == "error")] | length' "$SARIF_FILE")
+          [ "$COUNT" -eq 0 ] || { echo "::error::Found $COUNT HIGH/CRITICAL vulns"; exit 1; }
+
+      # Attestation: attach vuln scan proof to image (travels with cosign copy)
+      - name: Install Cosign
+        if: ${{ inputs.image_digest != '' }}
+        uses: sigstore/cosign-installer@6f9f17788090df1f26f669e9d70d6ae9567deba6 # v4.1.2
+
+      - name: Attest vulnerability scan
+        id: attest
+        if: ${{ inputs.image_digest != '' }}
+        env:
+          IMAGE_REF: ${{ inputs.image_ref }}
+          DIGEST: ${{ inputs.image_digest }}
+          SARIF_FILE: trivy-image-scan-${{ github.workflow_sha }}-${{ github.run_number }}.sarif
+        run: |
+          # Defense-in-depth: validate digest format before using in cosign
+          if ! echo "$DIGEST" | grep -qE '^sha256:[a-f0-9]{64}$'; then
+            echo "::error::Invalid image_digest format (expected sha256:<64-hex>): '$DIGEST'"
+            exit 1
+          fi
+          IMAGE="${IMAGE_REF%%[:@]*}@${DIGEST}"
+          cosign attest --predicate "$SARIF_FILE" --type vuln --yes "$IMAGE"
+          echo "attached=true" >> "$GITHUB_OUTPUT"

--- a/.github/workflows/reusable_trivy_image_scan.yml
+++ b/.github/workflows/reusable_trivy_image_scan.yml
@@ -95,6 +95,7 @@ jobs:
         run: |
           COUNT=$(jq '[.runs[].results[] | select(.level == "error")] | length' "$SARIF_FILE")
           [ "$COUNT" -eq 0 ] || { echo "::error::Found $COUNT HIGH/CRITICAL vulns"; exit 1; }
+          echo "passed=true" >> "$GITHUB_OUTPUT"
 
       # Attestation: attach vuln scan proof to image (travels with cosign copy)
       - name: Install Cosign

--- a/.github/workflows/reusable_vuln_scan.yml
+++ b/.github/workflows/reusable_vuln_scan.yml
@@ -67,6 +67,7 @@ jobs:
         id: trivy
         uses: aquasecurity/trivy-action@ed142fd0673e97e23eac54620cfb913e5ce36c25 # 0.36.0
         with:
+          version: 'v0.70.0'
           scan-type: 'fs'
           scanners: 'secret,misconfig'
           severity: ${{ inputs.trivy_severity }}

--- a/.github/workflows/reusable_vuln_scan.yml
+++ b/.github/workflows/reusable_vuln_scan.yml
@@ -2,8 +2,10 @@
 # ======================================
 # - OSV-Scanner: Google's Open Source Vulnerabilities database for dependency CVEs
 # - Trivy Source: Filesystem scan for secrets and misconfig (vuln handled by OSV)
-# - Trivy Image: Container image scan for OS packages and runtime dependencies
-# NOTE: If enable_osv is false but you want vuln scanning, use enable_trivy_image.
+#
+# Container image scanning is handled separately by reusable_trivy_image_scan.yml
+# to avoid forcing elevated permissions (packages: write, id-token: write) on
+# callers that only need source/dependency scanning.
 
 name: Reusable Vulnerabilities Scan
 
@@ -18,40 +20,18 @@ on:
         description: 'Enable Trivy source scan (secrets + misconfig)'
         type: boolean
         default: false
-      enable_trivy_image:
-        description: 'Enable Trivy image scan (requires image_ref)'
-        type: boolean
-        default: false
-      image_ref:
-        description: 'Image reference for image scan, e.g., ghcr.io/org/image:sha-<sha>'
-        type: string
-        default: ''
-      image_digest:
-        description: 'Image digest (e.g., sha256:abc...). If provided, vuln attestation is attached to image.'
-        type: string
-        default: ''
       trivy_severity:
         description: 'Severity levels to report'
         type: string
         default: 'HIGH,CRITICAL'
-    outputs:
-      trivy_image_scan_passed:
-        description: 'Whether Trivy image scan completed successfully (no vulns or skipped)'
-        value: ${{ jobs.trivy_image.outputs.scan_passed || 'true' }}
-      vuln_attestation_attached:
-        description: 'Whether vuln attestation was attached to image'
-        value: ${{ jobs.trivy_image.outputs.attestation_attached || 'false' }}
 
 permissions:
   contents: none
-  packages: none
   security-events: none
-  id-token: none
   actions: none
 
 concurrency:
-  # Include image_ref to differentiate source scan (empty) vs image scan (has ref)
-  group: vuln-scan-${{ github.workflow }}-${{ github.ref }}-${{ inputs.image_ref || 'source' }}
+  group: vuln-scan-${{ github.workflow }}-${{ github.ref }}
   cancel-in-progress: true
 
 jobs:
@@ -111,77 +91,3 @@ jobs:
         run: |
           COUNT=$(jq '[.runs[].results[] | select(.level == "error")] | length' "$SARIF_FILE")
           [ "$COUNT" -eq 0 ] || { echo "::error::Found $COUNT HIGH/CRITICAL findings"; exit 1; }
-
-  trivy_image:
-    name: Trivy Image Scan
-    # Gate on ref_protected: this job requires write permissions for attestation
-    if: ${{ inputs.enable_trivy_image && inputs.image_ref != '' }}
-    runs-on: ubuntu-latest
-    timeout-minutes: 15
-    outputs:
-      scan_passed: ${{ steps.scan_result.outputs.passed }}
-      attestation_attached: ${{ steps.attest.outputs.attached }}
-    permissions:
-      packages: write         # Push attestation to registry
-      security-events: write  # Upload SARIF
-      id-token: write         # Keyless signing of attestation
-    steps:
-      - name: Login to GHCR
-        uses: docker/login-action@650006c6eb7dba73a995cc03b0b2d7f5ca915bee # v4.2.0
-        with:
-          registry: ghcr.io
-          username: ${{ github.repository_owner }}
-          password: ${{ secrets.GITHUB_TOKEN }}
-
-      - name: Run Trivy image scanner
-        id: trivy
-        uses: aquasecurity/trivy-action@ed142fd0673e97e23eac54620cfb913e5ce36c25 # 0.36.0
-        with:
-          scan-type: 'image'
-          scanners: 'vuln'
-          image-ref: ${{ inputs.image_ref }}
-          severity: ${{ inputs.trivy_severity }}
-          ignore-unfixed: true
-          format: 'sarif'
-          output: 'trivy-image-scan-${{ github.workflow_sha }}-${{ github.run_number }}.sarif'
-          # NOTE: exit-code 0 because trivy-action's exit-code behavior is inconsistent
-          # with SARIF format. We parse SARIF to check for actual findings instead.
-          exit-code: '0'
-
-      - name: Upload SARIF
-        if: ${{ always() }}
-        uses: github/codeql-action/upload-sarif@7211b7c8077ea37d8641b6271f6a365a22a5fbfa # v4.36.0
-        with:
-          sarif_file: 'trivy-image-scan-${{ github.workflow_sha }}-${{ github.run_number }}.sarif'
-          category: 'trivy-image'
-
-      - name: Check scan result
-        id: scan_result
-        if: ${{ steps.trivy.outcome == 'success' }}
-        env:
-          SARIF_FILE: trivy-image-scan-${{ github.workflow_sha }}-${{ github.run_number }}.sarif
-        run: |
-          COUNT=$(jq '[.runs[].results[] | select(.level == "error")] | length' "$SARIF_FILE")
-          [ "$COUNT" -eq 0 ] || { echo "::error::Found $COUNT HIGH/CRITICAL vulns"; exit 1; }
-
-      # Attestation: attach vuln scan proof to image (travels with cosign copy)
-      - name: Install Cosign
-        if: ${{ inputs.image_digest != '' }}
-        uses: sigstore/cosign-installer@6f9f17788090df1f26f669e9d70d6ae9567deba6 # v4.1.2
-
-      - name: Attest vulnerability scan
-        id: attest
-        if: ${{ inputs.image_digest != '' }}
-        env:
-          IMAGE_REF: ${{ inputs.image_ref }}
-          DIGEST: ${{ inputs.image_digest }}
-          SARIF_FILE: trivy-image-scan-${{ github.workflow_sha }}-${{ github.run_number }}.sarif
-        run: |
-          # Defense-in-depth: validate digest format before using in cosign
-          if ! echo "$DIGEST" | grep -qE '^sha256:[a-f0-9]{64}$'; then
-            echo "::error::Invalid image_digest format (expected sha256:<64-hex>): '$DIGEST'"
-            exit 1
-          fi
-          IMAGE="${IMAGE_REF%%[:@]*}@${DIGEST}"
-          cosign attest --predicate "$SARIF_FILE" --type vuln --yes "$IMAGE"
-          echo "attached=true" >> "$GITHUB_OUTPUT"


### PR DESCRIPTION
## Summary

The `trivy_image` job in `reusable_vuln_scan.yml` requires elevated permissions
(`packages: write`, `id-token: write`) that cause **startup failures** in callers
that only need source/dependency scanning. GitHub validates all job permissions at
parse time, even for conditionally-skipped jobs.

This PR extracts the `trivy_image` job into a dedicated `reusable_trivy_image_scan.yml`
so callers can independently opt into image scanning with the required permissions,
without affecting the lighter-weight vuln scan workflow.

| File | Change |
|------|--------|
| `reusable_trivy_image_scan.yml` | **New** -- standalone reusable workflow with the extracted `trivy_image` job |
| `reusable_vuln_scan.yml` | **Slimmed** -- removed `trivy_image` job, its inputs (`enable_trivy_image`, `image_ref`, `image_digest`), outputs, and cleaned up permissions and concurrency group |

## Related Issues

- Fixes startup failure in [complytime/.github Security Checks](https://github.com/complytime/.github/actions/runs/26514040649)
- Dependent PR: complytime/complytime-collector-components#247

## Review Hints

- The two files should be reviewed together. The new `reusable_trivy_image_scan.yml` is a direct extraction of the `trivy_image` job from `reusable_vuln_scan.yml` with its own inputs/outputs.

- All reusable workflow references in consumer repos are pinned to SHA `cfd981e` (v0.2.1). Nothing breaks until a SHA is bumped, giving a safe migration window.

- After this merges and is tagged, consumer repos that use image scanning in their publish pipelines (`complytime-collector-components`) need to update their `ci_publish_ghcr.yml` to call `reusable_trivy_image_scan.yml` instead of `reusable_vuln_scan.yml` with `enable_trivy_image: true`. A draft PR is already prepared: complytime/complytime-collector-components#247.

- The synced `ci_security.yml` across the org does not need changes -- it never used `enable_trivy_image`. The next org sync will resolve the startup failures automatically.