### PR TITLE
fix(ci): skip GHCR publish tests on dependabot PRs

### DIFF
--- a/.github/workflows/ci_test_publish_ghcr.yml
+++ b/.github/workflows/ci_test_publish_ghcr.yml
@@ -35,7 +35,8 @@ jobs:
     needs: check-changes
     if: >-
       needs.check-changes.outputs.ghcr_files_changed == 'true' &&
-      github.event.pull_request.head.repo.full_name == github.repository
+      github.event.pull_request.head.repo.full_name == github.repository &&
+      github.actor != 'dependabot[bot]'
     uses: ./.github/workflows/reusable_publish_ghcr.yml
     permissions:
       contents: read
@@ -194,7 +195,8 @@ jobs:
     needs: check-changes
     if: >-
       needs.check-changes.outputs.ghcr_files_changed == 'true' &&
-      github.event.pull_request.head.repo.full_name == github.repository
+      github.event.pull_request.head.repo.full_name == github.repository &&
+      github.actor != 'dependabot[bot]'
     uses: ./.github/workflows/reusable_publish_ghcr.yml
     permissions:
       contents: read


### PR DESCRIPTION
## Summary

`dependabot[bot]` is not an org member, so the org membership check in `reusable_publish_ghcr.yml` always fails for dependabot PRs that touch GHCR-related files (e.g., bumping `docker/setup-qemu-action`). The fork detection guard from #291 does not help because dependabot branches live in the same repository, not a fork.

This adds a `github.actor != 'dependabot[bot]'` condition to both GHCR test jobs (`test-unprotected-org-member` and `test-attestations-override`) so they skip cleanly instead of producing false failures.

## Related Issues

- Fixes the CI failure on #287 (dependabot PR bumping `docker/setup-qemu-action`)
- Builds on #291 which added the fork PR detection guard
- Follow-up enhancement: #294

## Review Hints

- Single-file change in `ci_test_publish_ghcr.yml`: two identical one-line additions to existing `if` conditions (lines 38 and 197).
- #294 tracks a follow-up to add a build-only mode to `reusable_publish_ghcr.yml` for deeper validation of dependabot PRs without requiring GHCR push access.