### PR TITLE
fix: skip GazeCRAP regression check when baseline is zero

### DIFF
--- a/scripts/compare-crapload.sh
+++ b/scripts/compare-crapload.sh
@@ -151,17 +151,24 @@ while IFS=$'\t' read -r key crap gaze_crap; do
 
 		crap_regressed=$(echo "$crap - $b_crap > $EPSILON" | bc -l)
 		crap_improved=$(echo "$b_crap - $crap > $EPSILON" | bc -l)
-		gaze_regressed=$(echo "$gaze_crap - $b_gaze > $EPSILON" | bc -l)
-		gaze_improved=$(echo "$b_gaze - $gaze_crap > $EPSILON" | bc -l)
 		if ((crap_regressed)); then
 			has_regression=true
 		elif ((crap_improved)); then
 			has_improvement=true
 		fi
-		if ((gaze_regressed)); then
-			has_regression=true
-		elif ((gaze_improved)); then
-			has_improvement=true
+		# Only evaluate GazeCRAP regression when baseline had contract
+		# coverage (b_gaze > 0). A baseline of 0 means GazeCRAP was not
+		# computable — no contract coverage existed for the function.
+		# Transitioning from 0 to any positive value represents new
+		# measurement (tests were added), not quality degradation.
+		if [[ "$b_gaze" != "0" ]]; then
+			gaze_regressed=$(echo "$gaze_crap - $b_gaze > $EPSILON" | bc -l)
+			gaze_improved=$(echo "$b_gaze - $gaze_crap > $EPSILON" | bc -l)
+			if ((gaze_regressed)); then
+				has_regression=true
+			elif ((gaze_improved)); then
+				has_improvement=true
+			fi
 		fi
 
 		if [[ "$has_regression" = "true" ]]; then


### PR DESCRIPTION
## Problem

The CRAP load comparison script flags GazeCRAP regressions when a function's GazeCRAP score increases beyond the epsilon threshold. However, a baseline GazeCRAP of `0` does not mean "perfect" — it means "no contract coverage existed, so GazeCRAP could not be computed."

When a PR adds tests that introduce contract coverage for a previously-untested function, GazeCRAP transitions from `0` to a positive value (e.g., `5`). The script incorrectly treats this `0 → 5` delta as a regression, even though it represents new measurement — not quality degradation.

### Real-world example

In [complytime/complyctl#536](https://github.com/complytime/complyctl/pull/536), the function `config.go:LoadFrom` had:
- **Baseline**: CRAP=30, GazeCRAP=0 (no contract coverage)
- **Current**: CRAP=7.3, GazeCRAP=5 (tests added, coverage improved)

CRAP improved by 22.7 points, but GazeCRAP went `0 → 5`, which the script flagged as a regression. This was the **sole failure** blocking the PR after all other regressions were resolved.

## Fix

Only evaluate GazeCRAP regression when the baseline value is non-zero (`b_gaze != 0`). When baseline GazeCRAP is `0`, the function had no contract coverage — there is no prior quality level to regress from.

```bash
# Before: always checked
gaze_regressed=$(echo "$gaze_crap - $b_gaze > $EPSILON" | bc -l)

# After: only checked when baseline had contract coverage
if [[ "$b_gaze" != "0" ]]; then
    gaze_regressed=$(echo "$gaze_crap - $b_gaze > $EPSILON" | bc -l)
fi
```

## Impact

- PRs that add test coverage to previously-untested functions will no longer be falsely flagged
- PRs that regress GazeCRAP on functions that already had contract coverage (baseline > 0) are still correctly flagged
- No change to CRAP score regression detection (only GazeCRAP affected)