### PR TITLE
fix: remediate pre-existing zizmor findings blocking CI

### DIFF
--- a/.github/workflows/ci_test_crapload.yml
+++ b/.github/workflows/ci_test_crapload.yml
@@ -30,6 +30,8 @@ jobs:
     steps:
       - name: Checkout code
         uses: actions/checkout@de0fac2e4500dabe0009e67214ff5f5447ce83dd # v6.0.2
+        with:
+          persist-credentials: false
 
       - name: Set up Python
         uses: actions/setup-python@a309ff8b426b58ec0e2a45f0f869d46889d02405 # v6.2.0

--- a/.github/workflows/release.yml
+++ b/.github/workflows/release.yml
@@ -58,11 +58,16 @@ jobs:
         uses: actions/checkout@de0fac2e4500dabe0009e67214ff5f5447ce83dd # v6.0.2
         with:
           fetch-depth: 0
+          persist-credentials: false
 
       - name: Create tag if it does not exist
         env:
           TAG: ${{ inputs.tag }}
+          GITHUB_TOKEN: ${{ secrets.GITHUB_TOKEN }}
         run: |
+          # Configure git to authenticate via the GITHUB_TOKEN since
+          # persist-credentials is disabled on the checkout step.
+          git config --local url."https://x-access-token:${GITHUB_TOKEN}@github.com/".insteadOf "https://github.com/"
           if git rev-parse "refs/tags/${TAG}" >/dev/null 2>&1; then
             echo "Tag ${TAG} already exists — skipping creation."
           else

--- a/.github/workflows/release_notes_preview.yml
+++ b/.github/workflows/release_notes_preview.yml
@@ -24,6 +24,7 @@ jobs:
         uses: actions/checkout@de0fac2e4500dabe0009e67214ff5f5447ce83dd # v6.0.2
         with:
           fetch-depth: 0
+          persist-credentials: false
 
       - name: Draft release notes (dry run)
         id: drafter

--- a/.github/workflows/resuable_publish_quay.yml
+++ b/.github/workflows/resuable_publish_quay.yml
@@ -96,34 +96,43 @@ jobs:
           SRC_TOKEN: ${{ secrets.source_token || secrets.GITHUB_TOKEN }}
           DEST_USER: ${{ secrets.dest_username }}
           DEST_PASS: ${{ secrets.dest_password }}
+          SOURCE_REGISTRY: ${{ inputs.source_registry }}
+          DEST_REGISTRY: ${{ inputs.dest_registry }}
+          ACTOR: ${{ github.actor }}
         run: |
-          echo "$SRC_TOKEN" | crane auth login ${{ inputs.source_registry }} -u ${{ github.actor }} --password-stdin
-          echo "$SRC_TOKEN" | cosign login ${{ inputs.source_registry }} -u ${{ github.actor }} --password-stdin
-          echo "$DEST_PASS" | crane auth login ${{ inputs.dest_registry }} -u "$DEST_USER" --password-stdin
-          echo "$DEST_PASS" | cosign login ${{ inputs.dest_registry }} -u "$DEST_USER" --password-stdin
+          echo "$SRC_TOKEN" | crane auth login "$SOURCE_REGISTRY" -u "$ACTOR" --password-stdin
+          echo "$SRC_TOKEN" | cosign login "$SOURCE_REGISTRY" -u "$ACTOR" --password-stdin
+          echo "$DEST_PASS" | crane auth login "$DEST_REGISTRY" -u "$DEST_USER" --password-stdin
+          echo "$DEST_PASS" | cosign login "$DEST_REGISTRY" -u "$DEST_USER" --password-stdin
 
       - name: Resolve source digest
         id: resolve
+        env:
+          SOURCE_TAG: ${{ inputs.source_tag }}
         run: |
-          DIGEST=$(crane digest "${SOURCE_REF}:${{ inputs.source_tag }}") || {
-            echo "::error::Source not found: ${SOURCE_REF}:${{ inputs.source_tag }}"
+          DIGEST=$(crane digest "${SOURCE_REF}:${SOURCE_TAG}") || {
+            echo "::error::Source not found: ${SOURCE_REF}:${SOURCE_TAG}"
             exit 1
           }
           echo "digest=${DIGEST}" >> "$GITHUB_OUTPUT"
 
       - name: Check destination availability
         if: ${{ inputs.fail_if_dest_exists }}
+        env:
+          DEST_TAG: ${{ inputs.dest_tag }}
         run: |
-          if crane manifest "${DEST_REF}:${{ inputs.dest_tag }}" &>/dev/null; then
-            echo "::error::Tag exists: ${DEST_REF}:${{ inputs.dest_tag }}"
+          if crane manifest "${DEST_REF}:${DEST_TAG}" &>/dev/null; then
+            echo "::error::Tag exists: ${DEST_REF}:${DEST_TAG}"
             echo "Use fail_if_dest_exists: false to overwrite"
             exit 1
           fi
 
       - name: Verify source signature
         if: ${{ inputs.verify_signature }}
+        env:
+          DIGEST: ${{ steps.resolve.outputs.digest }}
         run: |
-          cosign verify "${SOURCE_REF}@${{ steps.resolve.outputs.digest }}" \
+          cosign verify "${SOURCE_REF}@${DIGEST}" \
             --certificate-identity-regexp="$IDENTITY" \
             --certificate-oidc-issuer="$OIDC_ISSUER"
 
@@ -131,11 +140,14 @@ jobs:
         env:
           DIGEST: ${{ steps.resolve.outputs.digest }}
           SOURCE_TAG: ${{ inputs.source_tag }}
+          DEST_TAG: ${{ inputs.dest_tag }}
+          INCLUDE_SHA_TAGS: ${{ inputs.include_sha_tags }}
+          ADDITIONAL_TAGS: ${{ inputs.additional_tags }}
         run: |
-          cosign copy "${SOURCE_REF}@${DIGEST}" "${DEST_REF}:${{ inputs.dest_tag }}"
+          cosign copy "${SOURCE_REF}@${DIGEST}" "${DEST_REF}:${DEST_TAG}"
 
           # SHA tags for immutability (long + short)
-          if [[ "${{ inputs.include_sha_tags }}" == "true" ]]; then
+          if [[ "$INCLUDE_SHA_TAGS" == "true" ]]; then
             crane tag "${DEST_REF}@${DIGEST}" "${SOURCE_TAG}"
             # Short SHA: first 7 chars after 'sha-' prefix
             if [[ "$SOURCE_TAG" =~ ^sha-([a-f0-9]+)$ ]]; then
@@ -144,8 +156,8 @@ jobs:
           fi
 
           # Additional custom tags
-          if [[ -n "${{ inputs.additional_tags }}" ]]; then
-            IFS=',' read -ra TAGS <<< "${{ inputs.additional_tags }}"
+          if [[ -n "$ADDITIONAL_TAGS" ]]; then
+            IFS=',' read -ra TAGS <<< "$ADDITIONAL_TAGS"
             for TAG in "${TAGS[@]}"; do
               crane tag "${DEST_REF}@${DIGEST}" "${TAG// /}"
             done
@@ -153,7 +165,9 @@ jobs:
 
       - name: Verify destination signature
         if: ${{ inputs.verify_signature }}
+        env:
+          DIGEST: ${{ steps.resolve.outputs.digest }}
         run: |
-          cosign verify "${DEST_REF}@${{ steps.resolve.outputs.digest }}" \
+          cosign verify "${DEST_REF}@${DIGEST}" \
             --certificate-identity-regexp="$IDENTITY" \
             --certificate-oidc-issuer="$OIDC_ISSUER"

--- a/.github/workflows/reusable_ci.yml
+++ b/.github/workflows/reusable_ci.yml
@@ -24,6 +24,8 @@ jobs:
     steps:
       - name: Checkout Code
         uses: actions/checkout@de0fac2e4500dabe0009e67214ff5f5447ce83dd # v6.0.2
+        with:
+          persist-credentials: false
 
       - name: Install Dependencies
         if: ${{ github.event.pull_request.title != '' && github.event.pull_request.user.login != 'dependabot[bot]' }}

--- a/.github/workflows/reusable_crapload_analysis.yml
+++ b/.github/workflows/reusable_crapload_analysis.yml
@@ -80,6 +80,7 @@ jobs:
         uses: actions/checkout@de0fac2e4500dabe0009e67214ff5f5447ce83dd # v6.0.2
         with:
           fetch-depth: 0
+          persist-credentials: false
 
       - name: Detect changed packages
         id: detect-changes

--- a/.github/workflows/reusable_dependabot_reviewer.yml
+++ b/.github/workflows/reusable_dependabot_reviewer.yml
@@ -165,18 +165,18 @@ jobs:
           risk="high"
 
           # Primary: use update-type from commit metadata
-          if [[ -n "${{ env.UPDATE_TYPE }}" ]]; then
-            case "${{ env.UPDATE_TYPE }}" in
+          if [[ -n "$UPDATE_TYPE" ]]; then
+            case "$UPDATE_TYPE" in
               *semver-patch*) risk="low"; echo "Patch update (metadata)." ;;
               *semver-minor*) risk="medium"; echo "Minor update (metadata)." ;;
               *semver-major*) risk="high"; echo "Major update (metadata). Requires manual review." ;;
             esac
           # Fallback: compare semantic versions
-          elif [[ -n "${{ env.FROM_VERSION }}" && -n "${{ env.TO_VERSION }}" ]]; then
-            from_major=$(echo "${{ env.FROM_VERSION }}" | cut -d. -f1)
-            from_minor=$(echo "${{ env.FROM_VERSION }}" | cut -d. -f2)
-            to_major=$(echo "${{ env.TO_VERSION }}" | cut -d. -f1)
-            to_minor=$(echo "${{ env.TO_VERSION }}" | cut -d. -f2)
+          elif [[ -n "$FROM_VERSION" && -n "$TO_VERSION" ]]; then
+            from_major=$(echo "$FROM_VERSION" | cut -d. -f1)
+            from_minor=$(echo "$FROM_VERSION" | cut -d. -f2)
+            to_major=$(echo "$TO_VERSION" | cut -d. -f1)
+            to_minor=$(echo "$TO_VERSION" | cut -d. -f2)
             if [[ "$from_major" -eq "$to_major" && "$from_minor" -eq "$to_minor" ]]; then
               risk="low"; echo "Patch update (semver)."
             elif [[ "$from_major" -eq "$to_major" && "$from_minor" -lt "$to_minor" ]]; then
@@ -223,10 +223,11 @@ jobs:
         id: check_release_age
         env:
           GH_TOKEN: "${{ secrets.GITHUB_TOKEN }}"
+          ECOSYSTEM: "${{ steps.detect_ecosystem.outputs.ecosystem }}"
         run: |
-          dep="${{ env.DEP_NAME }}"
-          version="${{ env.DEP_VERSION }}"
-          eco="${{ steps.detect_ecosystem.outputs.ecosystem }}"
+          dep="$DEP_NAME"
+          version="$DEP_VERSION"
+          eco="$ECOSYSTEM"
           release_date=""
 
           # Skip if no dependency info available
@@ -287,10 +288,11 @@ jobs:
         id: check_popularity
         env:
           GH_TOKEN: "${{ secrets.GITHUB_TOKEN }}"
+          ECOSYSTEM: "${{ steps.detect_ecosystem.outputs.ecosystem }}"
         run: |
-          dep="${{ env.DEP_NAME }}"
-          uses_query="${{ env.USES_QUERY }}"
-          eco="${{ steps.detect_ecosystem.outputs.ecosystem }}"
+          dep="$DEP_NAME"
+          uses_query="$USES_QUERY"
+          eco="$ECOSYSTEM"
 
           case "$eco" in
             python)
@@ -299,7 +301,7 @@ jobs:
               exit 0
               ;;
             go)
-              query="${dep} v${{ env.TO_VERSION }} filename:go.mod"
+              query="${dep} v${TO_VERSION} filename:go.mod"
               ;;
             github_actions)
               if [[ -n "${uses_query}" ]]; then

--- a/.github/workflows/reusable_dependabot_reviewer.yml
+++ b/.github/workflows/reusable_dependabot_reviewer.yml
@@ -51,6 +51,7 @@ jobs:
           repository: "${{ github.event.repository.full_name }}"
           ref: "${{ github.event.pull_request.head.sha }}"
           fetch-depth: 2
+          persist-credentials: false
 
       - name: Get Dependency Information
         id: get_dep_info

--- a/.github/workflows/reusable_deps_reviewer.yml
+++ b/.github/workflows/reusable_deps_reviewer.yml
@@ -34,6 +34,7 @@ jobs:
         with:
           repository: "${{ github.event.repository.full_name }}" # Checkout the caller repo
           fetch-depth: 0 # This may also capture vulnerabilities unrelated to the PR.
+          persist-credentials: false
 
       - name: Run Dependency Review
         id: dependency_review

--- a/.github/workflows/reusable_sonarqube.yml
+++ b/.github/workflows/reusable_sonarqube.yml
@@ -54,6 +54,7 @@ jobs:
         with:
           repository: "${{ github.event.repository.full_name }}"
           fetch-depth: 0 # This may also capture vulnerabilities unrelated to the PR.
+          persist-credentials: false
 
       - name: Download coverage file
         uses: actions/download-artifact@3e5f45b2cfb9172054b4087a40e8e0b5a5461e7c # v8.0.1

--- a/.github/workflows/sync_org_repositories.yml
+++ b/.github/workflows/sync_org_repositories.yml
@@ -40,6 +40,7 @@ jobs:
         uses: actions/checkout@de0fac2e4500dabe0009e67214ff5f5447ce83dd # v6.0.2
         with:
           fetch-depth: 1
+          persist-credentials: false
 
       - name: Generate GitHub App Token
         id: generate-token

--- a/.github/workflows/sync_org_repositories.yml
+++ b/.github/workflows/sync_org_repositories.yml
@@ -48,7 +48,9 @@ jobs:
         with:
           client-id: ${{ secrets.SYNC_APP_CLIENT_ID }}
           private-key: ${{ secrets.SYNC_APP_PRIVATE_KEY }}
-          owner: ${{ github.repository_owner }}
+          owner: ${{ github.repository_owner }} # zizmor: ignore[github-app]
+          permission-contents: write
+          permission-pull-requests: write
 
       - name: Set up Python
         uses: actions/setup-python@a309ff8b426b58ec0e2a45f0f869d46889d02405 # v6.2.0


### PR DESCRIPTION
## Summary

Remediates pre-existing zizmor security findings that are breaking CI on
main and blocking all Dependabot PRs (#301, #302).

Findings addressed:
- **artipacked** (9 medium): Add `persist-credentials: false` to checkout
  steps that were missing it
- **template-injection** (26 low/help): Replace `${{ inputs/env }}` template
  expansion in shell `run:` blocks with environment variables
- **github-app** (2 high): Scope GitHub App token permissions explicitly;
  suppress intentional all-repos scope with documented rationale

## Related Issues

- Unblocks #301, #302

## Review Hints

- Review each commit separately -- each addresses a distinct zizmor finding
  category.
- Commit 1 adds `persist-credentials: false` to 9 checkout steps. For
  `release.yml`, which needs `git push`, explicit token-based git auth is
  configured via `url.insteadOf`.
- Commit 2 (publish_quay) refactors shell commands to use env vars instead
  of template expansion. Runtime behavior is identical.
- Commit 3 (dependabot reviewer) replaces `${{ env.* }}` with shell `$VAR`
  syntax since values are already in GITHUB_ENV from prior steps.
- Commit 4 (sync workflow) preserves all-repos access intentionally since
  the workflow's purpose is to sync to every org repo. The inline zizmor
  suppression documents this decision.