### PR TITLE
feat(sync): include website repo in sync pipeline

### DIFF
--- a/sync-config.yml
+++ b/sync-config.yml
@@ -7,7 +7,6 @@
 # org-infra is excluded by default as it's the source repository
 exclude_repos:
   - org-infra                   # This repository itself
-  - website                     # Managed independently
   - nunya                       # Internal tooling (Jira migration)
   - roadmap                     # Internal tooling (roadmap scripts)
   - complyscribe                # Archived
@@ -74,6 +73,7 @@ files_to_sync:
       - complytime-demos
       - complytime-policies
       - community
+      - website
 
   - source: ruff.toml
     destination: ruff.toml
@@ -84,6 +84,7 @@ files_to_sync:
       - complytime-collector-components
       - complytime-providers
       - community
+      - website
 
   # AI Tooling
   - source: .specify/memory/constitution.md
@@ -210,6 +211,23 @@ dependabot:
         schedule:
           interval: "weekly"
         open-pull-requests-limit: 10
+        commit-message:
+          prefix: "chore"
+          include: "scope"
+
+    website:
+      - package-ecosystem: "npm"
+        directory: "/"
+        schedule:
+          interval: "weekly"
+        open-pull-requests-limit: 10
+        commit-message:
+          prefix: "chore"
+          include: "scope"
+      - package-ecosystem: "docker"
+        directory: "/.devcontainer"
+        schedule:
+          interval: "weekly"
         commit-message:
           prefix: "chore"
           include: "scope"


### PR DESCRIPTION
## Summary

- Remove `website` from global `exclude_repos` so it enters the sync pipeline
- Add `website` to `.golangci.yml` and `ruff.toml` per-file exclude lists (not a Go/Python repo)
- Add `website` dependabot override with `npm` and `docker` ecosystems, following the same pattern as `complyctl` and other repos

Addresses [review feedback](https://github.com/complytime/website/pull/20#discussion_r2123735893) from @marcusburghardt on complytime/website#20.

Closes #304

## Test plan

- [ ] `make lint` passes
- [ ] Dry-run sync against `website` repo shows dependabot.yml generated with npm, docker, and github-actions entries
- [ ] No unexpected files synced to website (verify .golangci.yml and ruff.toml are excluded)

Made with [Cursor](https://cursor.com)