### PR TITLE
fix(ci): extract repo slug for reusable workflow release age detection

### DIFF
--- a/.github/workflows/reusable_dependabot_reviewer.yml
+++ b/.github/workflows/reusable_dependabot_reviewer.yml
@@ -239,16 +239,21 @@ jobs:
 
           case "$eco" in
             github_actions)
+              # Reusable workflow refs include the file path in the dep name
+              # (e.g., "org/repo/.github/workflows/reusable_foo.yml").
+              # Extract "org/repo" for GitHub API calls.
+              repo_slug="$(echo "$dep" | cut -d'/' -f1-2)"
+
               # Try GitHub Releases first (with and without v prefix)
-              release_date="$(gh api "repos/${dep}/releases/tags/v${version}" \
+              release_date="$(gh api "repos/${repo_slug}/releases/tags/v${version}" \
                 --jq '.published_at' 2>/dev/null)" || true
               if [[ -z "$release_date" || "$release_date" == "null" ]]; then
-                release_date="$(gh api "repos/${dep}/releases/tags/${version}" \
+                release_date="$(gh api "repos/${repo_slug}/releases/tags/${version}" \
                   --jq '.published_at' 2>/dev/null)" || true
               fi
               # Fall back to tag creation date
               if [[ -z "$release_date" || "$release_date" == "null" ]]; then
-                tag_url="$(gh api "repos/${dep}/git/ref/tags/v${version}" \
+                tag_url="$(gh api "repos/${repo_slug}/git/ref/tags/v${version}" \
                   --jq '.object.url' 2>/dev/null)" || true
                 if [[ -n "$tag_url" && "$tag_url" != "null" ]]; then
                   release_date="$(gh api "$tag_url" \


### PR DESCRIPTION
## Problem

Dependabot PRs bumping reusable workflow references (e.g., `complytime/org-infra/.github/workflows/reusable_security.yml`) always show **release age as unknown**, blocking auto-approval.

**Example**: https://github.com/complytime/org-infra/pull/308

## Root Cause

The `check_release_age` step in `reusable_dependabot_reviewer.yml` passes the full dependency name directly to the GitHub Releases API:

```
gh api "repos/complytime/org-infra/.github/workflows/reusable_security.yml/releases/tags/v0.3.0"
```

The API expects `repos/{owner}/{repo}/releases/tags/{tag}`, but the dependency name for reusable workflows includes the file path within the repo, producing an invalid API path that returns 404.

## Fix

Extract `owner/repo` from the dependency name before making API calls. For standard actions (e.g., `actions/checkout`), the name is already `owner/repo`, so the extraction is a no-op.

```
complytime/org-infra/.github/workflows/reusable_security.yml
├──────────────────┤
  cut -d'/' -f1-2  →  complytime/org-infra  →  valid API path
```

## Scope

- Single file: `reusable_dependabot_reviewer.yml`
- 4 lines added (comment + slug extraction), 3 substitutions
- No changes to approval logic, thresholds, or outputs
- No sync required (`ci_dependencies.yml` unchanged)