### PR TITLE
feat(ci): add org-owned dependency detection and auto-merge

### DIFF
--- a/.github/workflows/ci_dependencies.yml
+++ b/.github/workflows/ci_dependencies.yml
@@ -4,6 +4,8 @@ name: Dependencies
 # Orchestrates dependency review for all PRs and dependabot-specific
 # processing: structured PR comments with review data and auto-approval
 # for safe dependency updates (non-major, 24h+ release age, no vulnerabilities).
+# Org-owned dependencies (same GitHub org) skip the release age gate and
+# get auto-merge enabled for patch/minor updates.
 # --------------------------------------------------------------------------
 
 on:
@@ -49,6 +51,7 @@ jobs:
           DEP_NAME: ${{ needs.call_dependabot_reviewer.outputs.dep_name }}
           DEP_VERSION: ${{ needs.call_dependabot_reviewer.outputs.dep_version }}
           RELEASE_AGE_HOURS: ${{ needs.call_dependabot_reviewer.outputs.release_age_hours }}
+          IS_ORG_OWNED: ${{ needs.call_dependabot_reviewer.outputs.is_org_owned }}
         with:
           issue-number: ${{ github.event.pull_request.number }}
           edit-mode: replace
@@ -62,9 +65,10 @@ jobs:
             | **Dependencies Review** | **${{ env.REVIEW_CONCLUSION }}** | [View logs](https://github.com/${{ github.repository }}/actions/runs/${{ github.run_id }}) |
             | **Calculated Risk** | **${{ env.RISK_LEVEL }}** | `${{ env.DEP_NAME }}` v${{ env.DEP_VERSION }} |
             | **Release Age** | **${{ (env.RELEASE_AGE_HOURS == '-1' || env.RELEASE_AGE_HOURS == '') && 'unknown' || format('{0}h', env.RELEASE_AGE_HOURS) }}** | ${{ (env.RELEASE_AGE_HOURS == '-1' || env.RELEASE_AGE_HOURS == '') && 'Release date unavailable — manual review required' || format('Released {0} hours ago', env.RELEASE_AGE_HOURS) }} |
+            | **Ownership** | **${{ env.IS_ORG_OWNED == 'true' && 'org-owned' || 'third-party' }}** | ${{ env.IS_ORG_OWNED == 'true' && 'Same organization — trusted source' || 'External dependency' }} |
             | **Dependency Usage** | ${{ env.UPDATES_COUNT == '0' && 'unavailable' || format('{0} repos', env.UPDATES_COUNT) }} | Informational only — does not affect approval |
 
-            **Auto-approval:** ${{ env.RISK_LEVEL != 'high' && env.REVIEW_CONCLUSION == 'success' && env.RELEASE_AGE_HOURS != '-1' && fromJSON(env.RELEASE_AGE_HOURS) >= fromJSON(env.MIN_RELEASE_AGE_HOURS) && '✅ Approved' || '⏳ Manual review required' }}
+            **Auto-approval:** ${{ (env.IS_ORG_OWNED == 'true' && env.RISK_LEVEL != 'high' && env.REVIEW_CONCLUSION == 'success') && '✅ Approved + auto-merge requested (org-owned)' || (env.RISK_LEVEL != 'high' && env.REVIEW_CONCLUSION == 'success' && env.RELEASE_AGE_HOURS != '-1' && fromJSON(env.RELEASE_AGE_HOURS) >= fromJSON(env.MIN_RELEASE_AGE_HOURS)) && '✅ Approved' || '⏳ Manual review required' }}
 
             ---
 
@@ -81,26 +85,54 @@ jobs:
     runs-on: ubuntu-latest
     needs: [call_deps_reviewer, call_dependabot_reviewer]
     permissions:
-      pull-requests: write  # Necessary to approve a PR
+      contents: write  # Required for gh pr merge --auto
+      pull-requests: write  # Required to approve a PR
     steps:
       - name: Auto-approve if Confident
+        id: auto_approve
         if: >-
-          needs.call_dependabot_reviewer.outputs.risk_level != 'high' &&
-          needs.call_deps_reviewer.outputs.review_conclusion == 'success' &&
-          needs.call_dependabot_reviewer.outputs.release_age_hours != '-1' &&
-          fromJSON(needs.call_dependabot_reviewer.outputs.release_age_hours) >= fromJSON(env.MIN_RELEASE_AGE_HOURS)
+          (needs.call_dependabot_reviewer.outputs.risk_level != 'high' &&
+           needs.call_deps_reviewer.outputs.review_conclusion == 'success' &&
+           needs.call_dependabot_reviewer.outputs.release_age_hours != '-1' &&
+           fromJSON(needs.call_dependabot_reviewer.outputs.release_age_hours) >= fromJSON(env.MIN_RELEASE_AGE_HOURS))
+          ||
+          (needs.call_dependabot_reviewer.outputs.is_org_owned == 'true' &&
+           needs.call_dependabot_reviewer.outputs.risk_level != 'high' &&
+           needs.call_deps_reviewer.outputs.review_conclusion == 'success')
         uses: actions/github-script@3a2844b7e9c422d3c10d287c895573f7108da1b3 # v9.0.0
+        env:
+          RISK_LEVEL: ${{ needs.call_dependabot_reviewer.outputs.risk_level }}
+          REVIEW_CONCLUSION: ${{ needs.call_deps_reviewer.outputs.review_conclusion }}
+          RELEASE_AGE_HOURS: ${{ needs.call_dependabot_reviewer.outputs.release_age_hours }}
+          IS_ORG_OWNED: ${{ needs.call_dependabot_reviewer.outputs.is_org_owned }}
         with:
           script: |
-            const risk = '${{ needs.call_dependabot_reviewer.outputs.risk_level }}';
-            const review = '${{ needs.call_deps_reviewer.outputs.review_conclusion }}';
-            const releaseAge = '${{ needs.call_dependabot_reviewer.outputs.release_age_hours }}';
+            const risk = process.env.RISK_LEVEL;
+            const review = process.env.REVIEW_CONCLUSION;
+            const releaseAge = process.env.RELEASE_AGE_HOURS;
+            const isOrgOwned = process.env.IS_ORG_OWNED;
+            const ownership = isOrgOwned === 'true' ? 'org-owned' : 'third-party';
+            const ageInfo = isOrgOwned === 'true' ? 'skipped (org-owned)' : `${releaseAge}h`;
 
             github.rest.pulls.createReview({
               owner: context.repo.owner,
               repo: context.repo.repo,
               pull_number: context.issue.number,
               event: 'APPROVE',
-              body: `Automatically approved: risk=${risk}, review=${review}, release_age=${releaseAge}h.`
+              body: `Automatically approved: risk=${risk}, review=${review}, ownership=${ownership}, release_age=${ageInfo}.`
             });
-            console.log(`Dependabot PR approved: risk=${risk}, review=${review}, release_age=${releaseAge}h`);
+            console.log(`Dependabot PR approved: risk=${risk}, review=${review}, ownership=${ownership}, release_age=${ageInfo}`);
+
+      - name: Enable Auto-merge for Org-owned
+        if: >-
+          steps.auto_approve.outcome == 'success' &&
+          needs.call_dependabot_reviewer.outputs.is_org_owned == 'true'
+        continue-on-error: true
+        env:
+          GH_TOKEN: "${{ secrets.GITHUB_TOKEN }}"
+        run: |
+          echo "Enabling auto-merge for org-owned dependency..."
+          gh pr merge "${{ github.event.pull_request.number }}" \
+            --auto --squash \
+            --repo "${{ github.repository }}"
+          echo "Auto-merge enabled successfully."

--- a/.github/workflows/ci_dependencies.yml
+++ b/.github/workflows/ci_dependencies.yml
@@ -35,7 +35,7 @@ jobs:
 
   comment_on_dependabot_prs:
     name: Dependabot Comment
-    if: github.actor == 'dependabot[bot]'
+    if: github.event.pull_request.user.login == 'dependabot[bot]'
     runs-on: ubuntu-latest
     needs: [call_deps_reviewer, call_dependabot_reviewer]
     permissions:
@@ -81,7 +81,7 @@ jobs:
 
   approve_dependabot_prs:
     name: Dependabot Auto-approve
-    if: github.actor == 'dependabot[bot]'
+    if: github.event.pull_request.user.login == 'dependabot[bot]'
     runs-on: ubuntu-latest
     needs: [call_deps_reviewer, call_dependabot_reviewer]
     permissions:

--- a/.github/workflows/reusable_dependabot_reviewer.yml
+++ b/.github/workflows/reusable_dependabot_reviewer.yml
@@ -23,6 +23,9 @@ on:
       release_age_hours:
         description: "Hours since the dependency version was released, -1 if unknown"
         value: "${{ jobs.dependabot_review.outputs.release_age_hours }}"
+      is_org_owned:
+        description: "Whether the dependency belongs to the same GitHub org as the consuming repo"
+        value: "${{ jobs.dependabot_review.outputs.is_org_owned }}"
 
 # This workflow is passive so ensure the minimal permissions even if the
 # inherited token is more lenient.
@@ -43,6 +46,7 @@ jobs:
       dep_name: "${{ steps.get_dep_info.outputs.dep_name }}"
       dep_version: "${{ steps.get_dep_info.outputs.dep_version }}"
       release_age_hours: "${{ steps.check_release_age.outputs.release_age_hours }}"
+      is_org_owned: "${{ steps.detect_org_ownership.outputs.is_org_owned }}"
 
     steps:
       - name: Checkout Repository
@@ -157,6 +161,29 @@ jobs:
           echo "dep_version=${dep_version_final}" >> "$GITHUB_OUTPUT"
 
           echo "Final: DEP_NAME=$dep_name DEP_VERSION=$dep_version_final FROM=$from_version TO=$to_version TYPE=$update_type USES=$uses_query"
+
+      - name: Detect Org Ownership
+        id: detect_org_ownership
+        shell: bash
+        env:
+          REPO_OWNER: "${{ github.repository_owner }}"
+        run: |
+          dep="$DEP_NAME"
+          is_org_owned="false"
+
+          if [[ -n "$dep" ]]; then
+            dep_owner="$(echo "$dep" | cut -d'/' -f1)"
+            if [[ "$dep_owner" == "$REPO_OWNER" ]]; then
+              is_org_owned="true"
+              echo "Org-owned dependency: $dep (owner=$dep_owner matches $REPO_OWNER)"
+            else
+              echo "Third-party dependency: $dep (owner=$dep_owner != $REPO_OWNER)"
+            fi
+          else
+            echo "No dependency name available. Defaulting to third-party."
+          fi
+
+          echo "is_org_owned=$is_org_owned" >> "$GITHUB_OUTPUT"
 
       - name: Classify Risk Based on Semantic Version
         id: classify_risk

--- a/openspec/changes/org-owned-dependabot-fast-path/.openspec.yaml
+++ b/openspec/changes/org-owned-dependabot-fast-path/.openspec.yaml
@@ -1,0 +1,2 @@
+schema: spec-driven
+created: 2026-06-04

--- a/openspec/changes/org-owned-dependabot-fast-path/design.md
+++ b/openspec/changes/org-owned-dependabot-fast-path/design.md
@@ -7,6 +7,9 @@ vulnerabilities and a release age of at least 24 hours receive one automated
 approval. There is no distinction between third-party and org-owned
 dependencies.
 
+This change extends the pipeline established by
+`specs/006-robust-dependabot-approval/`.
+
 When org-infra cuts a release, the sync script updates SHA-pinned workflow
 references across all consumer repos. Dependabot then creates PRs to bump
 these references. Each PR bumps a workflow the organization authored
@@ -19,14 +22,22 @@ The current workflow architecture:
 ci_dependencies.yml (synced to all repos)
   ├── call_deps_reviewer       → reusable_deps_reviewer.yml (remote)
   ├── call_dependabot_reviewer → reusable_dependabot_reviewer.yml (remote)
-  ├── comment_on_dependabot_prs
-  └── approve_dependabot_prs
+  ├── comment_on_dependabot_prs  (parallel with approve job)
+  └── approve_dependabot_prs    (parallel with comment job)
 ```
 
-Key constraint: `ci_dependencies.yml` is synced via `sync-config.yml`.
-The reusable workflows are called remotely at SHA-pinned refs. Changes to
-reusable workflows take effect immediately after release. Changes to
-`ci_dependencies.yml` require a sync cycle.
+Key constraint: `ci_dependencies.yml` is synced via `sync-config.yml` to all
+org repos except `community` (approximately 10 consumer repos). The reusable
+workflows are called remotely at SHA-pinned refs. Changes to reusable workflows
+take effect after a release and sync cycle (the sync script pins consumer
+workflows to the release SHA). Changes to `ci_dependencies.yml` require the
+same sync cycle.
+
+**Note on job parallelism:** The `comment_on_dependabot_prs` and
+`approve_dependabot_prs` jobs both depend on `[call_deps_reviewer,
+call_dependabot_reviewer]` and execute in parallel. The comment job cannot
+observe the outcome of the auto-merge step. The PR comment reports approval
+*intent* (based on the same conditions), not post-facto auto-merge results.
 
 ## Goals / Non-Goals
 
@@ -61,6 +72,11 @@ repo_owner: github.repository_owner  ("complytime")
 match → org-owned
 ```
 
+**Case sensitivity:** GitHub normalizes both `github.repository_owner` and
+Dependabot's `dependency-name` metadata to lowercase. The comparison is
+case-sensitive in bash, which is correct since both inputs are already
+normalized by GitHub.
+
 **Alternatives considered:**
 
 - **Hardcoded org name**: Rejected. Breaks for forks, makes the reusable
@@ -84,12 +100,12 @@ not `ci_dependencies.yml`.
 
 - **Check in ci_dependencies.yml**: Rejected. Would duplicate logic in every
   consumer repo and couldn't be updated without a sync cycle. Placing it in the
-  reusable workflow means all consumers get the signal immediately after a
-  release.
+  reusable workflow means all consumers get the signal after the next release
+  and sync.
 
 **Rationale:** Composability principle -- the reusable workflow already owns
 dependency analysis. Adding ownership detection there keeps the signal close
-to its source and available to all consumers without sync.
+to its source and available to all consumers via the existing sync mechanism.
 
 ### D3: Skip release age for org-owned, keep for third-party
 
@@ -126,20 +142,30 @@ the `gh` CLI.
 - **Direct merge (skip auto-merge, merge immediately)**: Rejected. This would
   bypass branch protection rules. Auto-merge respects all protection rules and
   waits for required status checks and reviews.
-
-**Merge method:** `--squash` is used because Dependabot PRs are single-commit
-updates and squash produces a clean history. This matches the common pattern
-across the organization.
+- **`gh pr merge --auto` without specifying merge method**: Considered. This
+  would inherit the repository's default merge method. However, `--squash` is
+  chosen explicitly because Dependabot PRs are single-commit updates and squash
+  produces a clean history. If a repository has disabled squash merges, the
+  step fails gracefully via `continue-on-error: true` (same as when auto-merge
+  is disabled entirely).
 
 **Failure handling:** If auto-merge cannot be enabled (repo setting disabled,
-insufficient permissions), the `gh` command fails with a non-zero exit code.
-This is handled with `continue-on-error: true` so the approval still stands.
-The PR comment reports the auto-merge status.
+merge method not allowed, insufficient permissions), the `gh` command fails
+with a non-zero exit code. This is handled with `continue-on-error: true` so
+the approval still stands. The step outcome is visible in the workflow run logs
+but is not propagated to the PR comment (see Context note on job parallelism).
 
-### D5: Separate job for auto-merge with `contents: write`
+### D5: Auto-merge in the existing approval job with `contents: write`
 
 Auto-merge is performed in the existing `approve_dependabot_prs` job, which
 gains `contents: write` permission alongside the existing `pull-requests: write`.
+
+**Blast radius:** `ci_dependencies.yml` is synced to approximately 10 consumer
+repos. The `contents: write` permission is scoped to a single job
+(`approve_dependabot_prs`) which only runs when `github.actor ==
+'dependabot[bot]'` and only enables auto-merge when all conditions are met
+(org-owned + patch/minor + review passes). This is the minimum permission
+required for `gh pr merge --auto`.
 
 **Alternatives considered:**
 
@@ -150,10 +176,10 @@ gains `contents: write` permission alongside the existing `pull-requests: write`
   needs (`issues: read`, `pull-requests: write`). Mixing merge permissions with
   the comment job would over-permission that job.
 
-**Security note:** `contents: write` is the minimum required to enable
-auto-merge. The job only runs when `github.actor == 'dependabot[bot]'` and only
-enables auto-merge when all conditions are met. This permission propagates to
-all consumer repos via sync.
+**Security note:** The consumer workflow MUST trigger on `pull_request`, not
+`pull_request_target`. The `pull_request_target` trigger runs in the base
+branch context with elevated secrets and permissions, which would make
+`contents: write` exploitable by any fork.
 
 ## Risks / Trade-offs
 
@@ -161,22 +187,29 @@ all consumer repos via sync.
   Mitigation: The permission is scoped to a job that only runs for
   `dependabot[bot]` PRs and only triggers auto-merge under strict conditions
   (org-owned + patch/minor + review passes). The permission scope is the minimum
-  required.
+  required. Downstream repo maintainers are notified via the sync PR
+  description.
 
 - **[Risk] Repo does not have "Allow auto-merge" enabled** --
   Mitigation: `gh pr merge --auto` fails gracefully when the setting is
-  disabled. The step uses `continue-on-error: true`. The approval still stands;
-  the comment reports "auto-merge unavailable".
+  disabled. The step uses `continue-on-error: true`. The approval still stands.
+  Repos can enable "Allow auto-merge" in Settings > General at any time.
 
 - **[Risk] `github.repository_owner` changes if a repo is transferred** --
   Mitigation: This is correct behavior. If a repo is transferred to a different
   org, the ownership check should reflect the new owner. No special handling
   needed.
 
-- **[Trade-off] Squash merge enforced for auto-merged Dependabot PRs** --
-  Some repos might prefer merge commits. However, Dependabot PRs are
-  single-commit updates where squash is the cleanest option. If this becomes an
-  issue, the merge method can be parameterized in a future iteration.
+- **[Risk] Squash merge method not allowed in a repo** --
+  Mitigation: `gh pr merge --auto --squash` fails gracefully via
+  `continue-on-error: true`. The approval still stands. If this becomes a
+  widespread issue, the merge method can be parameterized in a future iteration.
+
+- **[Trade-off] `continue-on-error: true` masks auto-merge failure details** --
+  The workflow run shows the step as green even when auto-merge failed.
+  Diagnostic information is available in the step logs but not surfaced in the
+  PR comment or workflow summary. This is acceptable because auto-merge is a
+  convenience optimization, not a critical path.
 
 ## Migration Plan
 
@@ -184,15 +217,29 @@ all consumer repos via sync.
    `ci_dependencies.yml`.
 2. Cut an org-infra release.
 3. Run `sync-org-repositories.py` to push the updated `ci_dependencies.yml`
-   to all consumer repos. The reusable workflow changes take effect immediately
-   via remote call.
+   to all consumer repos. The sync script pins consumer workflows to the
+   release SHA.
+
+**Intermediate state:** Between release and sync completion, the reusable
+workflow emits `is_org_owned` but consumer repos still run the old
+`ci_dependencies.yml` that does not consume this output. Existing behavior is
+preserved during this window. If the sync fails partway, affected repos
+continue with old behavior. Re-running the sync is safe (idempotent).
+
 4. Verify "Allow auto-merge" is enabled in target repos (admin action, outside
-   this change scope).
+   this change scope). Use `gh api repos/{owner}/{repo} --jq .allow_auto_merge`
+   to audit.
 5. Next Dependabot PR wave for org-infra workflow bumps should auto-approve
    and auto-merge where conditions are met.
 
-**Rollback:** Revert the `ci_dependencies.yml` changes and re-sync. The
-reusable workflow's `is_org_owned` output becomes unused but harmless.
+**Rollback:** Revert changes in order:
+1. If the defect is in `reusable_dependabot_reviewer.yml` (detection logic):
+   revert and release to take immediate effect via remote call.
+2. Revert `ci_dependencies.yml` changes and re-sync to all consumer repos.
+3. The `is_org_owned` output becomes unused but harmless.
+4. Note: rollback does not retroactively disable auto-merge on PRs where it
+   was already enabled. Maintainers would need to manually disable auto-merge
+   on in-flight PRs if needed.
 
 ## Open Questions
 

--- a/openspec/changes/org-owned-dependabot-fast-path/design.md
+++ b/openspec/changes/org-owned-dependabot-fast-path/design.md
@@ -1,3 +1,5 @@
+# Design: org-owned-dependabot-fast-path
+
 ## Context
 
 The Dependabot auto-approval pipeline (`ci_dependencies.yml` +
@@ -18,7 +20,7 @@ an external, untrusted source.
 
 The current workflow architecture:
 
-```
+```text
 ci_dependencies.yml (synced to all repos)
   ├── call_deps_reviewer       → reusable_deps_reviewer.yml (remote)
   ├── call_dependabot_reviewer → reusable_dependabot_reviewer.yml (remote)
@@ -65,7 +67,7 @@ observe the outcome of the auto-merge step. The PR comment reports approval
 Compare the first path segment of the dependency name against
 `github.repository_owner` (inherited from the caller in `workflow_call`).
 
-```
+```text
 dep_name:  "complytime/org-infra/.github/workflows/reusable_security.yml"
 dep_owner: "complytime"  (cut -d'/' -f1)
 repo_owner: github.repository_owner  ("complytime")
@@ -243,4 +245,4 @@ continue with old behavior. Re-running the sync is safe (idempotent).
 
 ## Open Questions
 
-_(none -- all decisions resolved during exploration)_
+*(none -- all decisions resolved during exploration)*

--- a/openspec/changes/org-owned-dependabot-fast-path/design.md
+++ b/openspec/changes/org-owned-dependabot-fast-path/design.md
@@ -1,0 +1,199 @@
+## Context
+
+The Dependabot auto-approval pipeline (`ci_dependencies.yml` +
+`reusable_dependabot_reviewer.yml` + `reusable_deps_reviewer.yml`) currently
+applies a uniform policy to all dependency updates: patch/minor bumps with no
+vulnerabilities and a release age of at least 24 hours receive one automated
+approval. There is no distinction between third-party and org-owned
+dependencies.
+
+When org-infra cuts a release, the sync script updates SHA-pinned workflow
+references across all consumer repos. Dependabot then creates PRs to bump
+these references. Each PR bumps a workflow the organization authored
+and released, yet the pipeline treats them identically to an update from
+an external, untrusted source.
+
+The current workflow architecture:
+
+```
+ci_dependencies.yml (synced to all repos)
+  ├── call_deps_reviewer       → reusable_deps_reviewer.yml (remote)
+  ├── call_dependabot_reviewer → reusable_dependabot_reviewer.yml (remote)
+  ├── comment_on_dependabot_prs
+  └── approve_dependabot_prs
+```
+
+Key constraint: `ci_dependencies.yml` is synced via `sync-config.yml`.
+The reusable workflows are called remotely at SHA-pinned refs. Changes to
+reusable workflows take effect immediately after release. Changes to
+`ci_dependencies.yml` require a sync cycle.
+
+## Goals / Non-Goals
+
+**Goals:**
+
+- Automatically detect org-owned dependencies at runtime without configuration.
+- Skip the 24-hour release age cooling period for org-owned patch/minor updates
+  that pass dependency review.
+- Enable GitHub auto-merge on approved org-owned Dependabot PRs so they merge
+  as soon as all branch protection rules are satisfied.
+- Continue requiring full manual review for major version bumps of org-owned
+  dependencies.
+
+**Non-Goals:**
+
+- Cross-organization trust (e.g., trusting `actions/*` or partner orgs).
+- Bypassing branch protection rules or merging without approval.
+- Changing behavior for third-party dependencies.
+- Auto-enabling the "Allow auto-merge" repository setting (admin action).
+
+## Decisions
+
+### D1: Ownership detection via `github.repository_owner`
+
+Compare the first path segment of the dependency name against
+`github.repository_owner` (inherited from the caller in `workflow_call`).
+
+```
+dep_name:  "complytime/org-infra/.github/workflows/reusable_security.yml"
+dep_owner: "complytime"  (cut -d'/' -f1)
+repo_owner: github.repository_owner  ("complytime")
+match → org-owned
+```
+
+**Alternatives considered:**
+
+- **Hardcoded org name**: Rejected. Breaks for forks, makes the reusable
+  workflow non-generic, violates Convention Over Configuration.
+- **Configurable allowlist (workflow input)**: Rejected. Adds configuration
+  surface, can drift from reality, and creates a security risk if misconfigured.
+  The user explicitly requested no configuration.
+- **GitHub API org membership check**: Rejected. Over-engineered for this use
+  case, adds API calls and latency, requires additional permissions.
+
+**Rationale:** `github.repository_owner` is available in every workflow run,
+requires no API calls, and is guaranteed to reflect the actual repository owner.
+The comparison is a zero-cost string match.
+
+### D2: Ownership check lives in the reusable workflow
+
+The `is_org_owned` output is produced by `reusable_dependabot_reviewer.yml`,
+not `ci_dependencies.yml`.
+
+**Alternatives considered:**
+
+- **Check in ci_dependencies.yml**: Rejected. Would duplicate logic in every
+  consumer repo and couldn't be updated without a sync cycle. Placing it in the
+  reusable workflow means all consumers get the signal immediately after a
+  release.
+
+**Rationale:** Composability principle -- the reusable workflow already owns
+dependency analysis. Adding ownership detection there keeps the signal close
+to its source and available to all consumers without sync.
+
+### D3: Skip release age for org-owned, keep for third-party
+
+For org-owned patch/minor dependencies, the auto-approval conditions are:
+1. Risk is not `high` (patch or minor)
+2. Dependency review passes
+3. Dependency is org-owned
+
+The 24-hour release age check is skipped entirely.
+
+For third-party dependencies, the existing conditions remain unchanged (risk
+not high + review passes + age known + age >= 24h).
+
+**Alternatives considered:**
+
+- **Reduced cooling period (e.g., 1 hour)**: Rejected. The cooling period
+  exists to catch supply chain attacks on third-party packages. For org-owned
+  deps, this threat model does not apply -- there is no meaningful difference
+  between 0h and 1h when you control the release process.
+- **Same conditions with auto-merge only**: Rejected. Still blocks auto-approval
+  when release age detection fails (which was the original bug, now fixed
+  separately).
+
+### D4: Auto-merge via `gh pr merge --auto --squash`
+
+After auto-approving an org-owned Dependabot PR, enable GitHub auto-merge using
+the `gh` CLI.
+
+**Alternatives considered:**
+
+- **GraphQL `enablePullRequestAutoMerge` mutation via actions/github-script**:
+  Viable but requires determining the PR node ID and adds complexity. The `gh`
+  CLI is pre-installed on runners and handles this transparently.
+- **Direct merge (skip auto-merge, merge immediately)**: Rejected. This would
+  bypass branch protection rules. Auto-merge respects all protection rules and
+  waits for required status checks and reviews.
+
+**Merge method:** `--squash` is used because Dependabot PRs are single-commit
+updates and squash produces a clean history. This matches the common pattern
+across the organization.
+
+**Failure handling:** If auto-merge cannot be enabled (repo setting disabled,
+insufficient permissions), the `gh` command fails with a non-zero exit code.
+This is handled with `continue-on-error: true` so the approval still stands.
+The PR comment reports the auto-merge status.
+
+### D5: Separate job for auto-merge with `contents: write`
+
+Auto-merge is performed in the existing `approve_dependabot_prs` job, which
+gains `contents: write` permission alongside the existing `pull-requests: write`.
+
+**Alternatives considered:**
+
+- **New dedicated job**: Would add workflow complexity and a parallel execution
+  branch. Since auto-merge logically follows auto-approval in the same decision
+  flow, keeping them together is simpler.
+- **Reuse the comment job**: Rejected. The comment job has different permission
+  needs (`issues: read`, `pull-requests: write`). Mixing merge permissions with
+  the comment job would over-permission that job.
+
+**Security note:** `contents: write` is the minimum required to enable
+auto-merge. The job only runs when `github.actor == 'dependabot[bot]'` and only
+enables auto-merge when all conditions are met. This permission propagates to
+all consumer repos via sync.
+
+## Risks / Trade-offs
+
+- **[Risk] `contents: write` propagated to all repos via sync** --
+  Mitigation: The permission is scoped to a job that only runs for
+  `dependabot[bot]` PRs and only triggers auto-merge under strict conditions
+  (org-owned + patch/minor + review passes). The permission scope is the minimum
+  required.
+
+- **[Risk] Repo does not have "Allow auto-merge" enabled** --
+  Mitigation: `gh pr merge --auto` fails gracefully when the setting is
+  disabled. The step uses `continue-on-error: true`. The approval still stands;
+  the comment reports "auto-merge unavailable".
+
+- **[Risk] `github.repository_owner` changes if a repo is transferred** --
+  Mitigation: This is correct behavior. If a repo is transferred to a different
+  org, the ownership check should reflect the new owner. No special handling
+  needed.
+
+- **[Trade-off] Squash merge enforced for auto-merged Dependabot PRs** --
+  Some repos might prefer merge commits. However, Dependabot PRs are
+  single-commit updates where squash is the cleanest option. If this becomes an
+  issue, the merge method can be parameterized in a future iteration.
+
+## Migration Plan
+
+1. Implement changes in both `reusable_dependabot_reviewer.yml` and
+   `ci_dependencies.yml`.
+2. Cut an org-infra release.
+3. Run `sync-org-repositories.py` to push the updated `ci_dependencies.yml`
+   to all consumer repos. The reusable workflow changes take effect immediately
+   via remote call.
+4. Verify "Allow auto-merge" is enabled in target repos (admin action, outside
+   this change scope).
+5. Next Dependabot PR wave for org-infra workflow bumps should auto-approve
+   and auto-merge where conditions are met.
+
+**Rollback:** Revert the `ci_dependencies.yml` changes and re-sync. The
+reusable workflow's `is_org_owned` output becomes unused but harmless.
+
+## Open Questions
+
+_(none -- all decisions resolved during exploration)_

--- a/openspec/changes/org-owned-dependabot-fast-path/proposal.md
+++ b/openspec/changes/org-owned-dependabot-fast-path/proposal.md
@@ -1,3 +1,5 @@
+# Proposal: org-owned-dependabot-fast-path
+
 ## Why
 
 Every org-infra release triggers dozens of Dependabot PRs across all consumer

--- a/openspec/changes/org-owned-dependabot-fast-path/proposal.md
+++ b/openspec/changes/org-owned-dependabot-fast-path/proposal.md
@@ -1,0 +1,73 @@
+## Why
+
+Every org-infra release triggers dozens of Dependabot PRs across all consumer
+repositories (one per reusable workflow reference, per repo). These PRs bump
+SHA-pinned references to workflows that the organization itself authored and
+released. The current auto-approval pipeline treats them identically to
+third-party dependencies: it requires a 24-hour release age cooling period and
+does not enable auto-merge. In repositories requiring two approvals, this means
+two humans must manually review each of these routine, self-authored bumps.
+
+The 24-hour cooling period is a supply chain attack mitigation designed for
+third-party dependencies where a compromised release could be consumed before
+detection. For org-owned dependencies, the organization controls the release
+process and the risk model is fundamentally different. Applying the same
+quarantine to self-authored releases creates unnecessary friction without
+meaningful security benefit.
+
+## What Changes
+
+- Detect org-owned dependencies by comparing the dependency owner against
+  `github.repository_owner` at runtime. No configuration or allowlists.
+- Skip the 24-hour release age requirement for org-owned dependencies that are
+  patch or minor updates and pass dependency review.
+- Enable GitHub auto-merge on the PR after auto-approval for org-owned
+  dependencies, so repositories with a single required approval merge
+  automatically and repositories requiring two approvals merge as soon as one
+  human approves.
+- Major version bumps of org-owned dependencies continue to require full manual
+  review (potential breaking changes).
+- Update the PR comment to surface the ownership signal and the auto-merge
+  status.
+
+## Non-goals
+
+- Configurable trust lists or cross-org trust relationships. Ownership is
+  strictly `github.repository_owner` matching the dependency's first path
+  segment.
+- Direct merge bypassing branch protection. Auto-merge respects all existing
+  protection rules (required reviews, status checks).
+- Changes to third-party dependency handling. The existing approval flow for
+  non-org-owned dependencies remains unchanged.
+
+## Capabilities
+
+### New Capabilities
+
+- `org-ownership-detection`: Detect whether a dependency originates from the
+  same GitHub organization as the consuming repository using
+  `github.repository_owner`. Output a boolean signal for downstream decision
+  logic.
+- `org-owned-auto-merge`: Enable GitHub auto-merge on Dependabot PRs that are
+  org-owned, patch/minor, and pass dependency review. Differentiate the approval
+  flow based on ownership trust level.
+
+### Modified Capabilities
+
+_(none — this adds new decision branches without changing existing third-party
+approval logic)_
+
+## Impact
+
+- **Workflows**: `reusable_dependabot_reviewer.yml` (new output),
+  `ci_dependencies.yml` (new approval branch, auto-merge step, updated comment
+  template).
+- **Permissions**: The auto-merge job in `ci_dependencies.yml` requires
+  `contents: write` in addition to the existing `pull-requests: write`. This
+  propagates to all consumer repos via sync.
+- **Repository settings**: Repos must have "Allow auto-merge" enabled in GitHub
+  settings for auto-merge to take effect. Where not enabled, the approval still
+  fires but auto-merge is a no-op.
+- **Sync**: `ci_dependencies.yml` changes require a sync cycle to propagate.
+  `reusable_dependabot_reviewer.yml` changes take effect immediately (called
+  remotely).

--- a/openspec/changes/org-owned-dependabot-fast-path/specs/org-owned-auto-merge/spec.md
+++ b/openspec/changes/org-owned-dependabot-fast-path/specs/org-owned-auto-merge/spec.md
@@ -1,3 +1,5 @@
+# Spec: org-owned-auto-merge
+
 ## ADDED Requirements
 
 ### Requirement: Auto-approve org-owned patch/minor without release age gate

--- a/openspec/changes/org-owned-dependabot-fast-path/specs/org-owned-auto-merge/spec.md
+++ b/openspec/changes/org-owned-dependabot-fast-path/specs/org-owned-auto-merge/spec.md
@@ -30,6 +30,12 @@ dependency review passes, without requiring a minimum release age.
   review concludes with failure
 - **THEN** the PR SHALL NOT be auto-approved
 
+#### Scenario: Org-owned bump with unknown update type
+
+- **WHEN** a Dependabot PR bumps an org-owned dependency but the update type
+  cannot be determined (risk defaults to high)
+- **THEN** the PR SHALL NOT be auto-approved (safe default preserved)
+
 ### Requirement: Third-party approval unchanged
 
 The approval pipeline SHALL continue to apply the existing approval conditions
@@ -51,8 +57,12 @@ passes, release age known, and release age at least 24 hours.
 ### Requirement: Enable auto-merge for org-owned approvals
 
 After auto-approving an org-owned Dependabot PR, the pipeline SHALL enable
-GitHub auto-merge on the PR. Auto-merge SHALL respect all branch protection
-rules configured on the target repository.
+GitHub auto-merge on the PR. Auto-merge relies on GitHub's built-in enforcement
+of branch protection rules. The implementation SHALL NOT bypass or circumvent
+branch protection through alternative merge mechanisms.
+
+The consumer workflow MUST trigger on `pull_request`, not `pull_request_target`.
+The auto-merge job MUST NOT run in the context of `pull_request_target` events.
 
 #### Scenario: Auto-merge enabled after org-owned approval
 
@@ -74,27 +84,30 @@ rules configured on the target repository.
 
 #### Scenario: Auto-merge unavailable in repo settings
 
-- **WHEN** auto-merge is enabled but the repository does not have "Allow
+- **WHEN** auto-merge is requested but the repository does not have "Allow
   auto-merge" turned on in its settings
 - **THEN** the auto-merge step SHALL fail gracefully without affecting the
-  approval, and the PR comment SHALL indicate that auto-merge is unavailable
+  approval
 
-### Requirement: PR comment reflects ownership and auto-merge status
+### Requirement: PR comment reflects ownership and approval decision
 
 The PR comment posted by the pipeline SHALL include the ownership
-classification and the auto-merge status to give maintainers full visibility
-into the automated decision.
+classification and the approval decision to give maintainers full visibility
+into the automated decision. The comment reports the approval *intent* based
+on conditions evaluated at comment time, not post-facto auto-merge outcomes
+(since the comment and approval jobs execute in parallel).
 
-#### Scenario: Org-owned dependency auto-approved with auto-merge
+#### Scenario: Org-owned dependency auto-approved with auto-merge requested
 
-- **WHEN** an org-owned Dependabot PR is auto-approved and auto-merge is
-  enabled
+- **WHEN** an org-owned Dependabot PR meets the auto-approval conditions
+  (patch/minor, review passes)
 - **THEN** the PR comment SHALL indicate the dependency is org-owned, the PR
-  was auto-approved, and auto-merge is enabled
+  was auto-approved, and auto-merge was requested
 
 #### Scenario: Third-party dependency auto-approved without auto-merge
 
-- **WHEN** a third-party Dependabot PR is auto-approved
+- **WHEN** a third-party Dependabot PR meets the auto-approval conditions
+  (patch/minor, review passes, release age >= 24h)
 - **THEN** the PR comment SHALL indicate the dependency is third-party, the PR
   was auto-approved, and auto-merge is not applicable
 

--- a/openspec/changes/org-owned-dependabot-fast-path/specs/org-owned-auto-merge/spec.md
+++ b/openspec/changes/org-owned-dependabot-fast-path/specs/org-owned-auto-merge/spec.md
@@ -1,0 +1,106 @@
+## ADDED Requirements
+
+### Requirement: Auto-approve org-owned patch/minor without release age gate
+
+The approval pipeline SHALL auto-approve Dependabot PRs for org-owned
+dependencies when the update is a patch or minor version bump and the
+dependency review passes, without requiring a minimum release age.
+
+#### Scenario: Org-owned minor bump with passing review
+
+- **WHEN** a Dependabot PR bumps an org-owned dependency with a minor version
+  update and the dependency review concludes with success
+- **THEN** the PR SHALL be auto-approved regardless of the release age
+
+#### Scenario: Org-owned patch bump with passing review
+
+- **WHEN** a Dependabot PR bumps an org-owned dependency with a patch version
+  update and the dependency review concludes with success
+- **THEN** the PR SHALL be auto-approved regardless of the release age
+
+#### Scenario: Org-owned major bump
+
+- **WHEN** a Dependabot PR bumps an org-owned dependency with a major version
+  update
+- **THEN** the PR SHALL NOT be auto-approved, regardless of review outcome
+
+#### Scenario: Org-owned bump with failing review
+
+- **WHEN** a Dependabot PR bumps an org-owned dependency but the dependency
+  review concludes with failure
+- **THEN** the PR SHALL NOT be auto-approved
+
+### Requirement: Third-party approval unchanged
+
+The approval pipeline SHALL continue to apply the existing approval conditions
+for third-party (non-org-owned) dependencies: risk not high, dependency review
+passes, release age known, and release age at least 24 hours.
+
+#### Scenario: Third-party patch bump with sufficient age
+
+- **WHEN** a Dependabot PR bumps a third-party dependency with a patch update,
+  the dependency review passes, and the release is at least 24 hours old
+- **THEN** the PR SHALL be auto-approved (existing behavior preserved)
+
+#### Scenario: Third-party bump with unknown release age
+
+- **WHEN** a Dependabot PR bumps a third-party dependency and the release age
+  cannot be determined
+- **THEN** the PR SHALL NOT be auto-approved (existing behavior preserved)
+
+### Requirement: Enable auto-merge for org-owned approvals
+
+After auto-approving an org-owned Dependabot PR, the pipeline SHALL enable
+GitHub auto-merge on the PR. Auto-merge SHALL respect all branch protection
+rules configured on the target repository.
+
+#### Scenario: Auto-merge enabled after org-owned approval
+
+- **WHEN** an org-owned Dependabot PR is auto-approved
+- **THEN** GitHub auto-merge SHALL be enabled on the PR
+
+#### Scenario: Repo with single required approval
+
+- **WHEN** auto-merge is enabled on an org-owned Dependabot PR and the
+  repository requires one approval and all status checks pass
+- **THEN** the PR SHALL merge automatically without further human intervention
+
+#### Scenario: Repo with two required approvals
+
+- **WHEN** auto-merge is enabled on an org-owned Dependabot PR and the
+  repository requires two approvals
+- **THEN** the PR SHALL merge automatically after one human provides the
+  second approval and all status checks pass
+
+#### Scenario: Auto-merge unavailable in repo settings
+
+- **WHEN** auto-merge is enabled but the repository does not have "Allow
+  auto-merge" turned on in its settings
+- **THEN** the auto-merge step SHALL fail gracefully without affecting the
+  approval, and the PR comment SHALL indicate that auto-merge is unavailable
+
+### Requirement: PR comment reflects ownership and auto-merge status
+
+The PR comment posted by the pipeline SHALL include the ownership
+classification and the auto-merge status to give maintainers full visibility
+into the automated decision.
+
+#### Scenario: Org-owned dependency auto-approved with auto-merge
+
+- **WHEN** an org-owned Dependabot PR is auto-approved and auto-merge is
+  enabled
+- **THEN** the PR comment SHALL indicate the dependency is org-owned, the PR
+  was auto-approved, and auto-merge is enabled
+
+#### Scenario: Third-party dependency auto-approved without auto-merge
+
+- **WHEN** a third-party Dependabot PR is auto-approved
+- **THEN** the PR comment SHALL indicate the dependency is third-party, the PR
+  was auto-approved, and auto-merge is not applicable
+
+#### Scenario: Dependency requiring manual review
+
+- **WHEN** a Dependabot PR is not auto-approved (any reason)
+- **THEN** the PR comment SHALL indicate manual review is required and display
+  the reason (e.g., major update, failed review, unknown release age for
+  third-party)

--- a/openspec/changes/org-owned-dependabot-fast-path/specs/org-ownership-detection/spec.md
+++ b/openspec/changes/org-owned-dependabot-fast-path/specs/org-ownership-detection/spec.md
@@ -1,0 +1,58 @@
+## ADDED Requirements
+
+### Requirement: Detect org-owned dependencies
+
+The Dependabot reviewer workflow SHALL determine whether a dependency
+originates from the same GitHub organization as the repository consuming it.
+The check SHALL compare the first path segment of the dependency name against
+the consuming repository's owner. The result SHALL be exposed as a workflow
+output for downstream decision logic.
+
+#### Scenario: Reusable workflow dependency from the same org
+
+- **WHEN** the dependency name is
+  `complytime/org-infra/.github/workflows/reusable_security.yml` and the
+  consuming repository owner is `complytime`
+- **THEN** the dependency SHALL be classified as org-owned
+
+#### Scenario: Standard action from the same org
+
+- **WHEN** the dependency name is `complytime/some-action` and the consuming
+  repository owner is `complytime`
+- **THEN** the dependency SHALL be classified as org-owned
+
+#### Scenario: Third-party dependency
+
+- **WHEN** the dependency name is `actions/checkout` and the consuming
+  repository owner is `complytime`
+- **THEN** the dependency SHALL NOT be classified as org-owned
+
+#### Scenario: Dependency with no recognizable owner segment
+
+- **WHEN** the dependency name cannot be split into an owner segment (e.g.,
+  a bare package name from a non-GitHub ecosystem)
+- **THEN** the dependency SHALL NOT be classified as org-owned
+
+### Requirement: No configuration for ownership detection
+
+The ownership detection mechanism SHALL NOT require any workflow inputs,
+environment variables, or allowlists to function. It SHALL rely solely on
+runtime context available in every workflow run.
+
+#### Scenario: Reusable workflow called without extra inputs
+
+- **WHEN** the Dependabot reviewer workflow is called by a consumer workflow
+  that provides no ownership-related inputs
+- **THEN** ownership detection SHALL still produce a correct result based on
+  the runtime context
+
+### Requirement: Ownership output available to callers
+
+The Dependabot reviewer workflow SHALL expose the ownership classification as
+a named output that can be consumed by downstream jobs in the calling workflow.
+
+#### Scenario: Consumer workflow reads ownership output
+
+- **WHEN** the Dependabot reviewer workflow completes
+- **THEN** the calling workflow SHALL be able to read the ownership
+  classification output and use it in conditional logic

--- a/openspec/changes/org-owned-dependabot-fast-path/specs/org-ownership-detection/spec.md
+++ b/openspec/changes/org-owned-dependabot-fast-path/specs/org-ownership-detection/spec.md
@@ -1,3 +1,5 @@
+# Spec: org-ownership-detection
+
 ## ADDED Requirements
 
 ### Requirement: Detect org-owned dependencies

--- a/openspec/changes/org-owned-dependabot-fast-path/specs/org-ownership-detection/spec.md
+++ b/openspec/changes/org-owned-dependabot-fast-path/specs/org-ownership-detection/spec.md
@@ -5,33 +5,65 @@
 The Dependabot reviewer workflow SHALL determine whether a dependency
 originates from the same GitHub organization as the repository consuming it.
 The check SHALL compare the first path segment of the dependency name against
-the consuming repository's owner. The result SHALL be exposed as a workflow
-output for downstream decision logic.
+the consuming repository's owner (`github.repository_owner`). The result SHALL
+be exposed as a workflow output named `is_org_owned` with string values `"true"`
+or `"false"` for downstream decision logic.
+
+The ownership classification is only meaningful when the PR author has been
+verified as `dependabot[bot]` by the existing actor gate. The `is_org_owned`
+output alone is not sufficient for trust decisions without the actor
+verification.
 
 #### Scenario: Reusable workflow dependency from the same org
 
 - **WHEN** the dependency name is
   `complytime/org-infra/.github/workflows/reusable_security.yml` and the
   consuming repository owner is `complytime`
-- **THEN** the dependency SHALL be classified as org-owned
+- **THEN** the output `is_org_owned` SHALL be `"true"`
 
 #### Scenario: Standard action from the same org
 
 - **WHEN** the dependency name is `complytime/some-action` and the consuming
   repository owner is `complytime`
-- **THEN** the dependency SHALL be classified as org-owned
+- **THEN** the output `is_org_owned` SHALL be `"true"`
 
 #### Scenario: Third-party dependency
 
 - **WHEN** the dependency name is `actions/checkout` and the consuming
   repository owner is `complytime`
-- **THEN** the dependency SHALL NOT be classified as org-owned
+- **THEN** the output `is_org_owned` SHALL be `"false"`
 
 #### Scenario: Dependency with no recognizable owner segment
 
 - **WHEN** the dependency name cannot be split into an owner segment (e.g.,
   a bare package name from a non-GitHub ecosystem)
-- **THEN** the dependency SHALL NOT be classified as org-owned
+- **THEN** the output `is_org_owned` SHALL be `"false"`
+
+#### Scenario: Empty dependency name
+
+- **WHEN** the dependency name is empty or unset (dependency info extraction
+  failed)
+- **THEN** the output `is_org_owned` SHALL be `"false"`
+
+#### Scenario: Forked repository consuming original org's dependency
+
+- **WHEN** a fork owned by `someuser` consumes a dependency from
+  `complytime/org-infra` and `github.repository_owner` is `someuser`
+- **THEN** the output `is_org_owned` SHALL be `"false"`
+
+#### Scenario: Transferred repository
+
+- **WHEN** a repository was transferred from `complytime` to `other-org` and
+  `github.repository_owner` now returns `other-org`
+- **THEN** dependencies from `complytime/*` SHALL be classified as `"false"`
+  (correct behavior -- ownership reflects the current state)
+
+#### Scenario: Unknown update type for org-owned dependency
+
+- **WHEN** a Dependabot PR bumps an org-owned dependency but the update type
+  cannot be determined (risk defaults to `high`)
+- **THEN** the output `is_org_owned` SHALL be `"true"` (ownership is
+  independent of risk classification; risk gating is handled downstream)
 
 ### Requirement: No configuration for ownership detection
 
@@ -49,10 +81,13 @@ runtime context available in every workflow run.
 ### Requirement: Ownership output available to callers
 
 The Dependabot reviewer workflow SHALL expose the ownership classification as
-a named output that can be consumed by downstream jobs in the calling workflow.
+a `workflow_call` output named `is_org_owned` (string, `"true"` or `"false"`)
+that can be consumed by downstream jobs in the calling workflow.
 
 #### Scenario: Consumer workflow reads ownership output
 
-- **WHEN** the Dependabot reviewer workflow completes
-- **THEN** the calling workflow SHALL be able to read the ownership
-  classification output and use it in conditional logic
+- **WHEN** the Dependabot reviewer workflow completes for an org-owned
+  dependency
+- **THEN** the calling workflow SHALL be able to read
+  `needs.call_dependabot_reviewer.outputs.is_org_owned` as `"true"` and use
+  it in conditional logic

--- a/openspec/changes/org-owned-dependabot-fast-path/tasks.md
+++ b/openspec/changes/org-owned-dependabot-fast-path/tasks.md
@@ -1,3 +1,5 @@
+# Tasks: org-owned-dependabot-fast-path
+
 ## 1. Org-Ownership Detection (reusable workflow)
 
 - [x] 1.1 Add `is_org_owned` output to the `workflow_call` outputs block in `.github/workflows/reusable_dependabot_reviewer.yml`
@@ -9,7 +11,9 @@
 
 - [x] 2.1 Add `contents: write` permission to the `approve_dependabot_prs` job in `.github/workflows/ci_dependencies.yml` (alongside existing `pull-requests: write`)
 - [x] 2.2 Add the `is_org_owned` output consumption from `call_dependabot_reviewer` in `.github/workflows/ci_dependencies.yml`
-- [x] 2.3 Update the `Auto-approve if Confident` step condition in `.github/workflows/ci_dependencies.yml` to create a compound condition: approve when EITHER (a) the existing third-party criteria are met (risk != high AND review passes AND release age known AND age >= 24h) OR (b) the dependency is org-owned AND risk is not high AND review passes (no release age requirement). If the compound expression is unwieldy in a single `if:`, consider splitting into two separate conditional steps
+- [x] 2.3 Update approval condition in `ci_dependencies.yml` with compound OR:
+  (a) third-party path (risk != high, review passes, age known, age >= 24h) or
+  (b) org-owned path (risk != high, review passes, no age requirement)
 - [x] 2.4 Update the approval review body message in the `actions/github-script` step to include the ownership signal (org-owned vs third-party) and indicate whether release age was checked or bypassed
 - [x] 2.5 Add a new step `Enable Auto-merge for Org-owned` in the `approve_dependabot_prs` job in `.github/workflows/ci_dependencies.yml` that runs `gh pr merge --auto --squash` conditional on the auto-approve step succeeding (`steps.<approve-step-id>.outcome == 'success'`) AND `is_org_owned == 'true'`. Use `continue-on-error: true` and `GH_TOKEN: ${{ secrets.GITHUB_TOKEN }}`
 

--- a/openspec/changes/org-owned-dependabot-fast-path/tasks.md
+++ b/openspec/changes/org-owned-dependabot-fast-path/tasks.md
@@ -1,0 +1,24 @@
+## 1. Org-Ownership Detection (reusable workflow)
+
+- [ ] 1.1 Add `is_org_owned` output to the `workflow_call` outputs block in `.github/workflows/reusable_dependabot_reviewer.yml`
+- [ ] 1.2 Add `REPO_OWNER: "${{ github.repository_owner }}"` to the job-level env or to a new step env in `.github/workflows/reusable_dependabot_reviewer.yml`
+- [ ] 1.3 Add a new step `Detect Org Ownership` (after `get_dep_info`) in `.github/workflows/reusable_dependabot_reviewer.yml` that extracts the first path segment of `DEP_NAME`, compares it to `REPO_OWNER`, and outputs `is_org_owned` (`true`/`false`)
+- [ ] 1.4 Wire the `is_org_owned` step output through the job outputs and `workflow_call` outputs in `.github/workflows/reusable_dependabot_reviewer.yml`
+
+## 2. Approval Logic Changes (consumer workflow)
+
+- [ ] 2.1 Add `contents: write` permission to the `approve_dependabot_prs` job in `.github/workflows/ci_dependencies.yml` (alongside existing `pull-requests: write`)
+- [ ] 2.2 Add the `is_org_owned` output consumption from `call_dependabot_reviewer` in `.github/workflows/ci_dependencies.yml`
+- [ ] 2.3 Update the `Auto-approve if Confident` step condition in `.github/workflows/ci_dependencies.yml` to also approve when the dependency is org-owned, risk is not high, and review passes (without requiring release age)
+- [ ] 2.4 Add a new step `Enable Auto-merge for Org-owned` in the `approve_dependabot_prs` job in `.github/workflows/ci_dependencies.yml` that runs `gh pr merge --auto --squash` when the dependency is org-owned, risk is not high, and review passes. Use `continue-on-error: true` and `GH_TOKEN: ${{ secrets.GITHUB_TOKEN }}`
+
+## 3. PR Comment Update (consumer workflow)
+
+- [ ] 3.1 Update the comment template in the `comment_on_dependabot_prs` job in `.github/workflows/ci_dependencies.yml` to add an `Ownership` row showing `org-owned` or `third-party`
+- [ ] 3.2 Update the `Auto-approval` line in the comment template in `.github/workflows/ci_dependencies.yml` to reflect the three possible states: auto-approved with auto-merge (org-owned), auto-approved (third-party), or manual review required
+
+## 4. Validation
+
+- [ ] 4.1 Run `make lint` to verify all YAML changes pass yamllint
+- [ ] 4.2 Verify all action `uses:` references in modified files remain SHA-pinned with inline version comments
+- [ ] 4.3 Review the complete diff to confirm third-party approval logic is unchanged and no permissions are broader than required

--- a/openspec/changes/org-owned-dependabot-fast-path/tasks.md
+++ b/openspec/changes/org-owned-dependabot-fast-path/tasks.md
@@ -1,24 +1,28 @@
 ## 1. Org-Ownership Detection (reusable workflow)
 
-- [ ] 1.1 Add `is_org_owned` output to the `workflow_call` outputs block in `.github/workflows/reusable_dependabot_reviewer.yml`
-- [ ] 1.2 Add `REPO_OWNER: "${{ github.repository_owner }}"` to the job-level env or to a new step env in `.github/workflows/reusable_dependabot_reviewer.yml`
-- [ ] 1.3 Add a new step `Detect Org Ownership` (after `get_dep_info`) in `.github/workflows/reusable_dependabot_reviewer.yml` that extracts the first path segment of `DEP_NAME`, compares it to `REPO_OWNER`, and outputs `is_org_owned` (`true`/`false`)
-- [ ] 1.4 Wire the `is_org_owned` step output through the job outputs and `workflow_call` outputs in `.github/workflows/reusable_dependabot_reviewer.yml`
+- [x] 1.1 Add `is_org_owned` output to the `workflow_call` outputs block in `.github/workflows/reusable_dependabot_reviewer.yml`
+- [x] 1.2 Add `REPO_OWNER: "${{ github.repository_owner }}"` to the step env of a new `Detect Org Ownership` step in `.github/workflows/reusable_dependabot_reviewer.yml`
+- [x] 1.3 Add the `Detect Org Ownership` step (after `get_dep_info`) in `.github/workflows/reusable_dependabot_reviewer.yml` that extracts the first path segment of `DEP_NAME` via `cut -d'/' -f1`, compares it to `REPO_OWNER`, and outputs `is_org_owned` (`true`/`false`). Default to `false` when `DEP_NAME` is empty
+- [x] 1.4 Wire the `is_org_owned` step output through the job outputs and `workflow_call` outputs in `.github/workflows/reusable_dependabot_reviewer.yml`
 
 ## 2. Approval Logic Changes (consumer workflow)
 
-- [ ] 2.1 Add `contents: write` permission to the `approve_dependabot_prs` job in `.github/workflows/ci_dependencies.yml` (alongside existing `pull-requests: write`)
-- [ ] 2.2 Add the `is_org_owned` output consumption from `call_dependabot_reviewer` in `.github/workflows/ci_dependencies.yml`
-- [ ] 2.3 Update the `Auto-approve if Confident` step condition in `.github/workflows/ci_dependencies.yml` to also approve when the dependency is org-owned, risk is not high, and review passes (without requiring release age)
-- [ ] 2.4 Add a new step `Enable Auto-merge for Org-owned` in the `approve_dependabot_prs` job in `.github/workflows/ci_dependencies.yml` that runs `gh pr merge --auto --squash` when the dependency is org-owned, risk is not high, and review passes. Use `continue-on-error: true` and `GH_TOKEN: ${{ secrets.GITHUB_TOKEN }}`
+- [x] 2.1 Add `contents: write` permission to the `approve_dependabot_prs` job in `.github/workflows/ci_dependencies.yml` (alongside existing `pull-requests: write`)
+- [x] 2.2 Add the `is_org_owned` output consumption from `call_dependabot_reviewer` in `.github/workflows/ci_dependencies.yml`
+- [x] 2.3 Update the `Auto-approve if Confident` step condition in `.github/workflows/ci_dependencies.yml` to create a compound condition: approve when EITHER (a) the existing third-party criteria are met (risk != high AND review passes AND release age known AND age >= 24h) OR (b) the dependency is org-owned AND risk is not high AND review passes (no release age requirement). If the compound expression is unwieldy in a single `if:`, consider splitting into two separate conditional steps
+- [x] 2.4 Update the approval review body message in the `actions/github-script` step to include the ownership signal (org-owned vs third-party) and indicate whether release age was checked or bypassed
+- [x] 2.5 Add a new step `Enable Auto-merge for Org-owned` in the `approve_dependabot_prs` job in `.github/workflows/ci_dependencies.yml` that runs `gh pr merge --auto --squash` conditional on the auto-approve step succeeding (`steps.<approve-step-id>.outcome == 'success'`) AND `is_org_owned == 'true'`. Use `continue-on-error: true` and `GH_TOKEN: ${{ secrets.GITHUB_TOKEN }}`
 
 ## 3. PR Comment Update (consumer workflow)
 
-- [ ] 3.1 Update the comment template in the `comment_on_dependabot_prs` job in `.github/workflows/ci_dependencies.yml` to add an `Ownership` row showing `org-owned` or `third-party`
-- [ ] 3.2 Update the `Auto-approval` line in the comment template in `.github/workflows/ci_dependencies.yml` to reflect the three possible states: auto-approved with auto-merge (org-owned), auto-approved (third-party), or manual review required
+- [x] 3.1 Update the comment template in the `comment_on_dependabot_prs` job in `.github/workflows/ci_dependencies.yml` to add an `Ownership` row showing `org-owned` or `third-party`
+- [x] 3.2 Update the `Auto-approval` line in the comment template in `.github/workflows/ci_dependencies.yml` to reflect the approval intent: auto-approved with auto-merge requested (org-owned), auto-approved (third-party), or manual review required. The comment reports intent based on conditions, not post-facto auto-merge outcome
 
 ## 4. Validation
 
-- [ ] 4.1 Run `make lint` to verify all YAML changes pass yamllint
-- [ ] 4.2 Verify all action `uses:` references in modified files remain SHA-pinned with inline version comments
-- [ ] 4.3 Review the complete diff to confirm third-party approval logic is unchanged and no permissions are broader than required
+- [x] 4.1 Run `make lint` to verify all YAML changes pass yamllint
+- [x] 4.2 Verify all action `uses:` references in modified files remain SHA-pinned with inline version comments
+- [x] 4.3 Review the complete diff to confirm: (a) third-party approval `if:` expression still contains `release_age_hours != '-1'` and `>= fromJSON(env.MIN_RELEASE_AGE_HOURS)`, (b) no permissions are broader than required, (c) workflow trigger remains `pull_request` (not `pull_request_target`)
+- [x] 4.4 Document the `contents: write` permission addition and its sync impact in the PR description
+<!-- spec-review: passed -->
+<!-- code-review: passed -->


### PR DESCRIPTION
## Summary

Add org-owned dependency detection and auto-merge to the Dependabot review
pipeline. When a Dependabot PR bumps a dependency from the same GitHub
organization, the pipeline skips the 24-hour release age cooling period
and enables GitHub auto-merge for patch/minor updates.

### Problem

Every org-infra release triggers dozens of Dependabot PRs across consumer
repositories bumping SHA-pinned reusable workflow references. These are
self-authored releases where the 24-hour supply chain cooling period adds
friction without security benefit. In repos requiring two approvals, two
humans must manually review each routine bump.

### Changes

**`.github/workflows/reusable_dependabot_reviewer.yml`**
- New `Detect Org Ownership` step comparing dependency owner against
  `github.repository_owner`
- New `is_org_owned` output (`true`/`false`) on `workflow_call`

**`.github/workflows/ci_dependencies.yml`**
- Compound approval condition: org-owned (patch/minor + review passes,
  no age requirement) OR third-party (existing conditions unchanged)
- New auto-merge step: `gh pr merge --auto --squash` for org-owned deps
  with `continue-on-error: true`
- Updated PR comment with Ownership row and tri-state approval status
- `contents: write` added to approval job (minimum for auto-merge)
- Approval review body uses `env:` + `process.env` (injection-safe pattern)

### Security Notes

- `contents: write` is scoped to the `approve_dependabot_prs` job which
  only runs for `dependabot[bot]` actor PRs
- Workflow trigger remains `pull_request` (not `pull_request_target`)
- Ownership detection is a zero-cost string match on `github.repository_owner`
  — no API calls, no configuration
- This permission propagates to all consumer repos via sync

### Prerequisite

Repos must have "Allow auto-merge" enabled in GitHub settings for
auto-merge to take effect. Where not enabled, the approval still fires
but auto-merge is a no-op.

### Related

- Bug fix PR: #310 (extract repo slug for release age detection)
- OpenSpec artifacts: `openspec/changes/org-owned-dependabot-fast-path/`