### PR TITLE
feat(ci): add production council review workflow chain

### DIFF
--- a/.github/workflows/ci_council_review.yml
+++ b/.github/workflows/ci_council_review.yml
@@ -1,0 +1,44 @@
+---
+name: Council Review
+
+# --------------------------------------------------------------------------
+# Thin consumer workflow for AI council review. Triggered by workflow_run
+# when the collect workflow completes (fork PR support), or manually via
+# workflow_dispatch. Delegates all review logic to reusable_council_review.yml.
+# --------------------------------------------------------------------------
+on:
+  workflow_dispatch:
+    inputs:
+      triggering_run_id:
+        description: >-
+          Run ID of the collect workflow (for artifact download).
+          Required for manual testing.
+        required: true
+        type: number
+  workflow_run:  # zizmor: ignore[dangerous-triggers]
+    workflows: ["Council Review - Collect PR Diff"]
+    types: [completed]
+
+concurrency:
+  group: council-review-${{ github.event.workflow_run.head_sha || github.run_id }}
+  cancel-in-progress: true
+
+permissions: {}
+
+jobs:
+  council-review:
+    name: AI Council Review
+    if: >-
+      github.event_name == 'workflow_dispatch' ||
+      github.event.workflow_run.conclusion == 'success'
+    uses: ./.github/workflows/reusable_council_review.yml  # zizmor: ignore[unpinned-uses]
+    permissions:
+      contents: read
+      id-token: write
+      pull-requests: write
+      actions: read
+    with:
+      triggering-run-id: ${{ github.event.inputs.triggering_run_id || github.event.workflow_run.id }}
+    secrets:
+      GCP_WORKLOAD_IDENTITY_PROVIDER: ${{ secrets.GCP_WORKLOAD_IDENTITY_PROVIDER }}
+      GCP_PROJECT_ID: ${{ secrets.GCP_PROJECT_ID }}

--- a/.github/workflows/ci_council_review_collect.yml
+++ b/.github/workflows/ci_council_review_collect.yml
@@ -1,0 +1,83 @@
+---
+name: Council Review - Collect PR Diff
+
+# --------------------------------------------------------------------------
+# Fork-safe PR diff collection for AI council review. Runs on pull_request
+# (no secrets needed), collects the PR diff and metadata, then uploads as
+# an artifact for ci_council_review.yml to pick up via workflow_run.
+# --------------------------------------------------------------------------
+on:
+  pull_request:
+    types: [opened, synchronize, reopened, ready_for_review]
+    branches: [main]
+
+permissions: {}
+
+jobs:
+  gate-check:
+    name: Gate Check
+    runs-on: ubuntu-latest
+    permissions:
+      contents: read
+    outputs:
+      should_collect: ${{ steps.gate.outputs.should_collect }}
+    steps:
+      - name: Evaluate gate conditions
+        id: gate
+        env:
+          PR_AUTHOR: ${{ github.event.pull_request.user.login }}
+          PR_DRAFT: ${{ github.event.pull_request.draft }}
+        run: |
+          if [[ "${PR_DRAFT}" == "true" ]]; then
+            echo "::notice::Draft PR — skipping council review"
+            echo "should_collect=false" >> "$GITHUB_OUTPUT"
+            exit 0
+          fi
+          if [[ "${PR_AUTHOR}" == "dependabot[bot]" ]]; then
+            echo "::notice::Dependabot PR — skipping council review"
+            echo "should_collect=false" >> "$GITHUB_OUTPUT"
+            exit 0
+          fi
+          echo "should_collect=true" >> "$GITHUB_OUTPUT"
+
+  collect-diff:
+    name: Collect PR Diff
+    needs: gate-check
+    if: needs.gate-check.outputs.should_collect == 'true'
+    runs-on: ubuntu-latest
+    permissions:
+      contents: read
+      pull-requests: read
+    steps:
+      - name: Collect PR diff
+        env:
+          GH_TOKEN: ${{ github.token }}
+          PR_NUMBER: ${{ github.event.pull_request.number }}
+        run: |
+          gh pr diff "${PR_NUMBER}" \
+            --repo "${{ github.repository }}" > pr-diff.patch
+
+      - name: Write PR metadata
+        env:
+          PR_NUMBER: ${{ github.event.pull_request.number }}
+          PR_HEAD_SHA: ${{ github.event.pull_request.head.sha }}
+          PR_BASE_REF: ${{ github.event.pull_request.base.ref }}
+          PR_TITLE: ${{ github.event.pull_request.title }}
+        run: |
+          jq -n \
+            --arg number "${PR_NUMBER}" \
+            --arg head_sha "${PR_HEAD_SHA}" \
+            --arg base_ref "${PR_BASE_REF}" \
+            --arg title "${PR_TITLE}" \
+            --arg repo "${{ github.repository }}" \
+            '{number: $number, head_sha: $head_sha, base_ref: $base_ref, title: $title, repo: $repo}' \
+            > pr-meta.json
+
+      - name: Upload diff artifact
+        uses: actions/upload-artifact@043fb46d1a93c77aae656e7c1c64a875d1fc6a0a # v7.0.1
+        with:
+          name: council-review-diff
+          path: |
+            pr-diff.patch
+            pr-meta.json
+          retention-days: 1

--- a/.github/workflows/reusable_council_review.yml
+++ b/.github/workflows/reusable_council_review.yml
@@ -1,0 +1,213 @@
+---
+name: Reusable Council Review
+
+# --------------------------------------------------------------------------
+# Reusable workflow for AI council review using OpenCode on Vertex AI via
+# WIF authentication. Downloads the PR diff artifact, authenticates to GCP,
+# delegates review to the council-review-action composite action, and posts
+# inline review comments on the PR.
+#
+# Called by ci_council_review.yml (consumer workflow).
+# --------------------------------------------------------------------------
+on:
+  workflow_call:
+    inputs:
+      triggering-run-id:
+        description: Run ID of the collect workflow (for artifact download)
+        required: true
+        type: string
+      model:
+        description: Model ID for the AI review
+        required: false
+        type: string
+        default: "google-vertex-anthropic/claude-sonnet-4-6"
+      max-diff-lines:
+        description: Maximum diff lines to send for review
+        required: false
+        type: string
+        default: "2000"
+    secrets:
+      GCP_WORKLOAD_IDENTITY_PROVIDER:
+        required: false
+      GCP_PROJECT_ID:
+        required: false
+
+permissions: {}
+
+jobs:
+  review:
+    name: Council Review
+    runs-on: ubuntu-latest
+    permissions:
+      contents: read
+      id-token: write
+      pull-requests: write
+      actions: read
+    env:
+      VERTEX_LOCATION: global
+    steps:
+      - name: Check WIF credentials
+        id: gate
+        env:
+          HAS_WIF: ${{ secrets.GCP_WORKLOAD_IDENTITY_PROVIDER != '' }}
+        run: |
+          if [[ "${HAS_WIF}" != "true" ]]; then
+            echo "::notice::No WIF credentials — skipping council review"
+            echo "should_review=false" >> "$GITHUB_OUTPUT"
+            exit 0
+          fi
+          echo "should_review=true" >> "$GITHUB_OUTPUT"
+
+      - name: Checkout
+        if: steps.gate.outputs.should_review == 'true'
+        uses: actions/checkout@df4cb1c069e1874edd31b4311f1884172cec0e10 # v6.0.3
+        with:
+          persist-credentials: false
+
+      - name: Download diff artifact
+        if: steps.gate.outputs.should_review == 'true'
+        uses: actions/download-artifact@3e5f45b2cfb9172054b4087a40e8e0b5a5461e7c # v8.0.1
+        with:
+          name: council-review-diff
+          run-id: ${{ inputs.triggering-run-id }}
+          github-token: ${{ github.token }}
+
+      - name: Extract PR metadata
+        if: steps.gate.outputs.should_review == 'true'
+        id: meta
+        run: |
+          PR_NUMBER=$(jq -r '.number' pr-meta.json)
+          PR_HEAD_SHA=$(jq -r '.head_sha' pr-meta.json)
+          {
+            echo "pr_number=${PR_NUMBER}"
+            echo "pr_head_sha=${PR_HEAD_SHA}"
+          } >> "$GITHUB_OUTPUT"
+
+      - name: Authenticate to Google Cloud (WIF)
+        if: steps.gate.outputs.should_review == 'true'
+        uses: google-github-actions/auth@7c6bc770dae815cd3e89ee6cdf493a5fab2cc093 # v3.0.0
+        with:
+          project_id: ${{ secrets.GCP_PROJECT_ID }}
+          workload_identity_provider: ${{ secrets.GCP_WORKLOAD_IDENTITY_PROVIDER }}
+
+      - name: Set up gcloud CLI
+        if: steps.gate.outputs.should_review == 'true'
+        uses: google-github-actions/setup-gcloud@aa5489c8933f4cc7a4f7d45035b3b1440c9c10db # v3.0.1
+
+      # TODO: remove continue-on-error once council review is stable
+      - name: Run council review
+        if: steps.gate.outputs.should_review == 'true'
+        id: review
+        continue-on-error: true
+        uses: unbound-force/unbound-force/council-review-action@4cf0d47802933466657369e397fce06742287c44  # feat/council-review-action
+        with:
+          model: ${{ inputs.model }}
+          max-diff-lines: ${{ inputs.max-diff-lines }}
+          diff-path: pr-diff.patch
+          meta-path: pr-meta.json
+          github-token: ${{ github.token }}
+
+      - name: Clean up previous bot reviews and comments
+        if: steps.gate.outputs.should_review == 'true'
+        env:
+          GH_TOKEN: ${{ github.token }}
+          PR_NUMBER: ${{ steps.meta.outputs.pr_number }}
+          REPO: ${{ github.repository }}
+        run: |
+          gh api "repos/${REPO}/issues/${PR_NUMBER}/comments" \
+            --paginate --jq '.[] | select(.body | contains("<!-- council-review-bot -->")) | .id' | \
+          while read -r comment_id; do
+            if [[ -n "${comment_id}" ]]; then
+              gh api "repos/${REPO}/issues/comments/${comment_id}" --method DELETE || true
+            fi
+          done
+
+          gh api "repos/${REPO}/pulls/${PR_NUMBER}/reviews" \
+            --paginate --jq '.[] | select(.user.login == "github-actions[bot]" and (.body | contains("council-review-bot"))) | .id' | \
+          while read -r review_id; do
+            if [[ -n "${review_id}" ]]; then
+              gh api "repos/${REPO}/pulls/${PR_NUMBER}/reviews/${review_id}" \
+                --method PUT --field body='~~Superseded by updated council review.~~' || true
+              gh api "repos/${REPO}/pulls/${PR_NUMBER}/reviews/${review_id}/comments" \
+                --paginate --jq '.[].id' | \
+              while read -r rc_id; do
+                gh api "repos/${REPO}/pulls/comments/${rc_id}" --method DELETE || true
+              done
+            fi
+          done
+
+      - name: Post inline review
+        if: >-
+          steps.gate.outputs.should_review == 'true' &&
+          steps.review.outcome == 'success' &&
+          steps.review.outputs.review-mode == 'inline'
+        env:
+          GH_TOKEN: ${{ github.token }}
+          PR_NUMBER: ${{ steps.meta.outputs.pr_number }}
+          PR_HEAD_SHA: ${{ steps.meta.outputs.pr_head_sha }}
+          MODEL: ${{ inputs.model }}
+          REPO: ${{ github.repository }}
+          REVIEW_JSON: ${{ steps.review.outputs.review-json }}
+        run: |
+          COMMENT_COUNT=$(jq '.inline_comments | length' "${REVIEW_JSON}")
+
+          {
+            echo "<!-- council-review-bot -->"
+            echo "## AI Council Review"
+            echo ""
+            jq -r '.summary' "${REVIEW_JSON}"
+            echo ""
+            echo "---"
+            echo "_Model: \`${MODEL}\` | Commit: \`${PR_HEAD_SHA:0:7}\` | Inline comments: ${COMMENT_COUNT}_"
+          } > review_body.txt
+
+          if [[ "${COMMENT_COUNT}" -gt 0 ]]; then
+            jq -n \
+              --arg commit_id "${PR_HEAD_SHA}" \
+              --rawfile body review_body.txt \
+              --argjson comments "$(jq '[.inline_comments[] | {path, line, side: "RIGHT", body}]' "${REVIEW_JSON}")" \
+              '{commit_id: $commit_id, body: $body, event: "COMMENT", comments: $comments}' | \
+            gh api "repos/${REPO}/pulls/${PR_NUMBER}/reviews" \
+              --method POST --input - || {
+              echo "::warning::Inline review post failed, falling back to PR comment"
+              {
+                echo ""
+                echo "<details>"
+                echo "<summary>Inline findings (${COMMENT_COUNT})</summary>"
+                echo ""
+                jq -r '.inline_comments[] | "#### \(.path):\(.line)\n\(.body)\n"' "${REVIEW_JSON}"
+                echo "</details>"
+              } >> review_body.txt
+              gh pr comment "${PR_NUMBER}" --repo "${REPO}" --body-file review_body.txt
+            }
+          else
+            gh pr comment "${PR_NUMBER}" --repo "${REPO}" --body-file review_body.txt
+          fi
+
+      - name: Post comment review (fallback)
+        if: >-
+          steps.gate.outputs.should_review == 'true' &&
+          steps.review.outcome == 'success' &&
+          steps.review.outputs.review-mode == 'comment'
+        env:
+          GH_TOKEN: ${{ github.token }}
+          PR_NUMBER: ${{ steps.meta.outputs.pr_number }}
+          PR_HEAD_SHA: ${{ steps.meta.outputs.pr_head_sha }}
+          MODEL: ${{ inputs.model }}
+          REPO: ${{ github.repository }}
+          REVIEW_JSON: ${{ steps.review.outputs.review-json }}
+        run: |
+          {
+            echo "<!-- council-review-bot -->"
+            echo "## AI Council Review"
+            echo ""
+            if [[ -s "${REVIEW_JSON}" ]]; then
+              jq -r '.summary' "${REVIEW_JSON}"
+            else
+              echo "_Council review produced no output._"
+            fi
+            echo ""
+            echo "---"
+            echo "_Model: \`${MODEL}\` | Commit: \`${PR_HEAD_SHA:0:7}\`_"
+          } > review_fallback.txt
+          gh pr comment "${PR_NUMBER}" --repo "${REPO}" --body-file review_fallback.txt

--- a/openspec/changes/build-production-workflow/.openspec.yaml
+++ b/openspec/changes/build-production-workflow/.openspec.yaml
@@ -1,0 +1,2 @@
+schema: spec-driven
+created: 2026-06-03

--- a/openspec/changes/build-production-workflow/design.md
+++ b/openspec/changes/build-production-workflow/design.md
@@ -1,0 +1,180 @@
+# Build Production Workflow — Design
+
+## Context
+
+The council review test workflow (`ci_council_review_test.yml`) has validated
+end-to-end connectivity: GitHub Actions → ITPC WIF pool → `unbound-force` GCP
+project → Claude Sonnet 4.6 on Vertex AI via OpenCode CLI. Both `complytime`
+and `unbound-force` GitHub orgs are registered with ITPC and have
+`roles/aiplatform.user` IAM bindings on the `unbound-force` project.
+
+No production workflow exists yet. The org follows a reusable workflow pattern
+where `reusable_*.yml` workflows contain shared logic and `ci_*.yml` consumer
+workflows call them. Consumer workflows sync to downstream repos via
+`sync-config.yml`.
+
+**Stakeholders**: org-infra maintainers, downstream repos consuming the
+synced workflows, contributors using fork-and-pull.
+
+## Goals / Non-Goals
+
+**Goals:**
+
+- Three-file workflow chain matching org convention (collect + consumer + reusable)
+- Fork PR support via `workflow_run` (collect runs in fork context, review in upstream)
+- Keyless authentication via ITPC WIF (no stored credentials)
+- OpenCode CLI invocation with explicit model IDs via council-review-action
+- Graceful degradation when WIF secrets are absent
+- Cost controls (skip drafts, dependabot, concurrency, diff size limits)
+- Smart diff filtering (exclude lock files, vendor, generated code)
+- Inline review comments via GitHub Review API
+- Follows all org conventions (SHA-pinned actions, minimal permissions, naming)
+- Downstream repos receive consumer workflows via sync; reusable stays in org-infra
+
+**Non-Goals:**
+
+- Multi-model dynamic selection (future enhancement, not in v1)
+- Persona prompt engineering or review output formatting
+- GCP resource automation (Terraform/Pulumi)
+
+## Decisions
+
+### D1: Three-file workflow chain (org convention)
+
+**Decision**: Use the org's standard reusable workflow pattern:
+
+1. `ci_council_review_collect.yml` — fork-safe diff collection (synced)
+2. `ci_council_review.yml` — thin consumer calling the reusable (synced)
+3. `reusable_council_review.yml` — shared review logic (NOT synced, called cross-repo)
+
+The consumer and collect workflows are synced to downstream repos via
+`sync-config.yml`. Downstream repos call the reusable cross-repo:
+`complytime/org-infra/.github/workflows/reusable_council_review.yml@SHA`.
+
+**Alternative**: Single `pull_request` workflow with WIF gate.
+
+**Why rejected**: The org uses a fork-and-pull model — fork PRs lack secrets
+access. The two-step chain (collect in fork context, review in upstream
+context via `workflow_run`) ensures all PRs are reviewed. The three-file
+split matches how `ci_security.yml` / `reusable_security.yml` and other
+org workflows are structured.
+
+### D2: Composite action for review orchestration
+
+**Decision**: Delegate review logic to `council-review-action` in
+`unbound-force/unbound-force`. The composite action handles OpenCode
+installation, Divisor agent discovery, prompt construction, review execution,
+and output parsing. The reusable workflow handles org-specific concerns:
+WIF auth, diff collection, and comment posting.
+
+**Alternative**: Inline all review logic in the reusable workflow.
+
+**Why rejected**: The composite action is reusable across orgs, testable
+independently, and separates review methodology from infrastructure plumbing.
+
+### D3: OpenCode CLI via npm (pinned version)
+
+**Decision**: Install OpenCode CLI via `npm install -g opencode-ai@1.2.26`
+(pinned to a specific version validated in production by gaze).
+
+**Alternative A**: Claude Code CLI via `curl | bash`.
+
+**Why rejected**: OpenCode supports multiple providers (including
+`google-vertex-anthropic`) with native config, and the install script
+is a `downloadThenRun` pattern that Scorecard flags.
+
+**Alternative B**: Latest OpenCode via unpinned `npm install`.
+
+**Why rejected**: Supply-chain risk — unpinned install in a workflow with
+`id-token: write` and `pull-requests: write` permissions.
+
+### D4: Explicit model IDs, not aliases
+
+**Decision**: Use `google-vertex-anthropic/claude-sonnet-4-6` as the model ID.
+
+**Alternative**: Use short aliases like `sonnet`.
+
+**Why rejected**: Aliases can resolve to unexpected model versions. Explicit
+IDs with provider prefix ensure the correct model is called via the correct
+authentication path.
+
+### D5: `global` region for Vertex AI
+
+**Decision**: Set `VERTEX_LOCATION=global` for automatic capacity routing.
+
+**Alternative**: Pin to `us-east5` (confirmed working region).
+
+**Why rejected**: `global` routing was validated in the test workflow and
+provides resilience against regional capacity issues.
+
+### D6: Actions pinned to SHA
+
+**Decision**: Pin all actions to full 40-character SHAs.
+
+**Pinned versions:**
+
+| Action                               | Version | SHA                                        |
+| ------------------------------------ | ------- | ------------------------------------------ |
+| `actions/checkout`                   | v6.0.3  | `df4cb1c069e1874edd31b4311f1884172cec0e10` |
+| `actions/upload-artifact`            | v7.0.1  | `043fb46d1a93c77aae656e7c1c64a875d1fc6a0a` |
+| `actions/download-artifact`          | v8.0.1  | `3e5f45b2cfb9172054b4087a40e8e0b5a5461e7c` |
+| `google-github-actions/auth`         | v3.0.0  | `7c6bc770dae815cd3e89ee6cdf493a5fab2cc093` |
+| `google-github-actions/setup-gcloud` | v3.0.1  | `aa5489c8933f4cc7a4f7d45035b3b1440c9c10db` |
+| `council-review-action`              | (dev)   | SHA-pinned to feature branch commit        |
+
+### D7: Inline review via GitHub Review API
+
+**Decision**: Post review findings as inline comments on specific diff lines
+via the Pull Request Review API, with a collapsible `<details>` fallback
+when inline posting fails.
+
+**Alternative**: Post all findings as a single PR comment.
+
+**Why rejected**: Inline comments are more actionable — reviewers see
+findings on the exact lines they apply to. The fallback ensures findings
+are never lost.
+
+### D8: Smart diff filtering
+
+**Decision**: Filter out noise files (lock files, vendor directories,
+generated code, test fixtures) before applying the line budget. A
+`filter-diff-lines.py` script also drops inline comments targeting lines
+outside diff hunks (GitHub API rejects these with HTTP 422).
+
+**Alternative**: Naive `head -n` truncation.
+
+**Why rejected**: A `go.sum` with 1500 lines would consume 75% of the
+budget, leaving no room for actual code changes.
+
+## Risks / Trade-offs
+
+**[R1] `workflow_run` triggers only from default branch** — The `workflow_run`
+event only fires when the collect workflow definition exists on the `main`
+branch. During initial development, manual `workflow_dispatch` is needed for
+testing. → Acceptable; once merged to main, it works automatically.
+
+**[R2] Cost from Opus usage** — If Opus 4.6 is added later, cost per
+review increases. → Mitigated by gate checks, concurrency control, and
+GCP budget alerts.
+
+**[R3] OpenCode CLI breaking changes** — A breaking change in OpenCode
+could fail the workflow. → Mitigated by version pinning (`1.2.26`).
+
+**[R4] Artifact retention** — Artifacts are retained for 1 day. If the
+review workflow is delayed beyond that, the artifact will be deleted and
+the review will fail. → Acceptable; `workflow_run` triggers immediately.
+
+## Migration Plan
+
+1. **Create workflows**: Add `ci_council_review_collect.yml`,
+   `ci_council_review.yml`, and `reusable_council_review.yml`
+2. **Validate**: Open a test PR, verify collect runs, consumer triggers,
+   WIF auth succeeds, OpenCode responds, and inline comments are posted
+3. **Remove test workflow**: Delete `ci_council_review_test.yml`
+4. **Update sync config**: Add both `ci_*` files to `sync-config.yml`
+   (reusable stays only in org-infra, called cross-repo by downstream)
+5. **Sync to org repos**: Downstream repos receive the consumer workflows;
+   they call the reusable cross-repo with SHA pin
+
+**Rollback**: Remove the workflow files. No GCP resources need to be
+torn down — they are inert without the workflow invoking them.

--- a/openspec/changes/build-production-workflow/proposal.md
+++ b/openspec/changes/build-production-workflow/proposal.md
@@ -1,0 +1,63 @@
+# Build Production Workflow
+
+## Why
+
+The council review concept has been validated end-to-end: ITPC WIF
+authentication works, Claude Sonnet 4.6 and Opus 4.6 respond via Vertex AI,
+and the test workflow (`ci_council_review_test.yml`) confirms the full chain
+from GitHub Actions OIDC token to model response. However, no production
+workflow exists. The test workflow must be replaced with a production
+workflow that follows the org's conventions and handles gate checks, inline
+review posting, and bot comment deduplication.
+
+Tracked internally.
+
+## Non-goals
+
+- Multi-provider support (Bedrock, direct Anthropic API)
+- Automating GCP resource provisioning (Terraform, Pulumi)
+- Changing persona definitions or review output formatting
+- Service account creation or key management
+- Open-source model integration (DeepSeek, Qwen, Gemma)
+
+## What Changes
+
+- **New**: `ci_council_review_collect.yml` — fork-safe workflow triggered on
+  `pull_request` that collects the PR diff and metadata, uploads as an artifact
+- **New**: `ci_council_review.yml` — thin consumer triggered on `workflow_run`
+  that calls the reusable workflow with secrets and the triggering run ID
+- **New**: `reusable_council_review.yml` — shared review logic that downloads
+  the artifact, authenticates via WIF, delegates to the council-review-action
+  composite action, and posts inline review comments on the PR
+- **Remove**: `ci_council_review_test.yml` — temporary test workflow,
+  replaced by the production workflows above
+
+## Capabilities
+
+### New Capabilities
+
+- `council-review-workflow`: Production AI council review via three-file chain
+  matching org convention: fork-safe collect (no secrets) → thin consumer
+  (triggers reusable) → reusable review (WIF auth, composite action, posting).
+  Includes gate checks (drafts, dependabot, missing WIF credentials), inline
+  review posting via GitHub Review API, smart diff filtering, and bot comment
+  deduplication. Consumer workflows sync to downstream repos; reusable stays
+  in org-infra and is called cross-repo.
+
+### Modified Capabilities
+
+(none)
+
+## Impact
+
+- **Workflows**: Three new workflow files, one removed
+- **Sync**: `ci_council_review_collect.yml` and `ci_council_review.yml` synced
+  to downstream repos; `reusable_council_review.yml` stays only in org-infra
+- **Secrets**: Requires `GCP_WORKLOAD_IDENTITY_PROVIDER` and `GCP_PROJECT_ID`
+  org secrets (already configured)
+- **GCP**: Uses existing `unbound-force` project with WIF IAM bindings
+  (already granted for both `complytime` and `unbound-force` orgs)
+- **Dependencies**: `google-github-actions/auth@v3` (SHA-pinned),
+  `google-github-actions/setup-gcloud@v3` (SHA-pinned), OpenCode CLI
+  (pinned `opencode-ai@1.2.26`), `council-review-action` composite action
+  (SHA-pinned)

--- a/openspec/changes/build-production-workflow/specs/council-review-workflow/spec.md
+++ b/openspec/changes/build-production-workflow/specs/council-review-workflow/spec.md
@@ -1,0 +1,159 @@
+# Council Review Workflow Specification
+
+## ADDED Requirements
+
+### Requirement: Collect workflow gathers PR diff without secrets
+
+The collect workflow SHALL run on every `pull_request` event (opened,
+synchronize, reopened) without requiring any secrets or OIDC tokens. It
+SHALL collect the PR diff and upload it as a GitHub Actions artifact for
+the review workflow to consume.
+
+#### Scenario: Fork PR triggers collect
+
+- **WHEN** a contributor opens a PR from a fork
+- **THEN** the collect workflow runs successfully, uploads the diff
+  artifact, and completes without errors
+
+#### Scenario: Upstream branch PR triggers collect
+
+- **WHEN** an org member opens a PR from an upstream branch
+- **THEN** the collect workflow runs successfully and uploads the diff
+  artifact identically to a fork PR
+
+#### Scenario: Draft PR is skipped
+
+- **WHEN** a PR is marked as draft
+- **THEN** the collect workflow skips diff collection and exits with a
+  skip reason logged
+
+#### Scenario: Dependabot PR is skipped
+
+- **WHEN** the PR author is `dependabot[bot]`
+- **THEN** the collect workflow skips diff collection and exits with a
+  skip reason logged
+
+### Requirement: Review workflow authenticates via WIF and invokes model
+
+The review workflow SHALL trigger on `workflow_run` completion of the
+collect workflow. It SHALL authenticate to GCP via the ITPC WIF pool,
+download the diff artifact, invoke Claude via the Claude Code CLI, and
+post review results as a PR comment.
+
+#### Scenario: Successful end-to-end review
+
+- **WHEN** the collect workflow completes for a non-draft, non-dependabot PR
+  and WIF secrets are configured
+- **THEN** the review workflow authenticates to GCP, calls Claude with the
+  diff, and posts a structured review comment on the PR
+
+#### Scenario: WIF secrets not configured
+
+- **WHEN** the review workflow runs but `GCP_WORKLOAD_IDENTITY_PROVIDER`
+  is empty (e.g., new repo not yet scoped for secrets)
+- **THEN** the workflow logs a skip reason and exits without error
+
+#### Scenario: Collect workflow failed or was cancelled
+
+- **WHEN** the collect workflow did not complete successfully
+- **THEN** the review workflow does not run
+
+### Requirement: Review workflow posts results as PR comment
+
+The review workflow SHALL post structured review findings as a comment
+on the originating pull request. If a previous review comment exists
+for the same PR, it SHALL be updated rather than creating a duplicate.
+
+#### Scenario: First review on a PR
+
+- **WHEN** no prior council review comment exists on the PR
+- **THEN** a new comment is created with the review findings
+
+#### Scenario: Updated review after new push
+
+- **WHEN** a contributor pushes new commits and the review runs again
+- **THEN** the existing review comment is updated with the latest findings
+
+### Requirement: Concurrency control limits parallel reviews
+
+The workflow chain SHALL prevent multiple concurrent reviews for the
+same PR. Rapid pushes SHALL cancel the in-progress review and start
+a new one with the latest diff.
+
+#### Scenario: Rapid consecutive pushes
+
+- **WHEN** a contributor pushes twice in quick succession
+- **THEN** the first review run is cancelled and only the second runs
+  to completion
+
+### Requirement: Model invocation uses explicit model identifiers
+
+The workflow SHALL invoke Claude using explicit Vertex AI model IDs
+(not CLI aliases) to prevent silent model version drift.
+
+#### Scenario: Model called with explicit ID
+
+- **WHEN** the review workflow invokes Claude
+- **THEN** the CLI receives an explicit model ID that matches an enabled
+  model on the GCP project
+
+### Requirement: Reusable workflow encapsulates auth and invocation
+
+The reusable workflow SHALL accept secrets and inputs from the consumer
+workflow and encapsulate all WIF authentication, CLI installation, and
+model invocation logic. Consumer workflows SHALL not contain auth or
+invocation details.
+
+#### Scenario: Consumer calls reusable with secrets
+
+- **WHEN** a consumer workflow calls the reusable workflow with WIF
+  secrets and a diff artifact
+- **THEN** the reusable workflow handles authentication, CLI setup,
+  model invocation, and returns the review output
+
+#### Scenario: Different repo uses same reusable workflow
+
+- **WHEN** a downstream repo calls the same reusable workflow with its
+  own org-scoped secrets
+- **THEN** the review runs identically to org-infra
+
+### Requirement: Workflow files follow org conventions
+
+All workflow files SHALL follow the org's naming conventions, permission
+model, and action pinning requirements.
+
+#### Scenario: Naming convention
+
+- **WHEN** the workflows are created
+- **THEN** the reusable workflow is named `reusable_council_review.yml`
+  and consumer workflows use the `ci_` prefix
+
+#### Scenario: Action pinning
+
+- **WHEN** external actions are referenced in the workflows
+- **THEN** each reference uses a full 40-character SHA with an inline
+  version comment
+
+#### Scenario: Minimal permissions
+
+- **WHEN** workflow-level and job-level permissions are declared
+- **THEN** workflow-level permissions are `none` and job-level
+  permissions include only the minimum required for each job
+
+### Requirement: Consumer workflows sync to downstream repos
+
+The consumer workflows SHALL be added to the sync configuration so
+downstream repos receive them automatically.
+
+#### Scenario: Sync config updated
+
+- **WHEN** the workflows are merged to main
+- **THEN** `sync-config.yml` includes the consumer workflow files in
+  the sync list
+
+#### Scenario: Repo without secrets skips gracefully
+
+- **WHEN** a downstream repo receives the synced workflows but does
+  not have WIF secrets scoped
+- **THEN** the review workflow detects the missing secrets and skips
+  without error

--- a/openspec/changes/build-production-workflow/tasks.md
+++ b/openspec/changes/build-production-workflow/tasks.md
@@ -1,0 +1,37 @@
+# Build Production Workflow — Tasks
+
+## 1. Collect Workflow (fork-safe, pull_request trigger)
+
+- [x] 1.1 Create `.github/workflows/ci_council_review_collect.yml` with `pull_request` trigger (opened, synchronize, reopened, ready_for_review) targeting `main`
+- [x] 1.2 Add gate check: skip drafts and dependabot PRs
+- [x] 1.3 Collect PR diff via `gh pr diff` and write `pr-meta.json` with PR number, head SHA, base ref, title
+- [x] 1.4 Upload diff and metadata as `council-review-diff` artifact (1 day retention)
+- [x] 1.5 Set workflow-level `permissions: {}` (none) and job-level `permissions: { contents: read, pull-requests: read }`
+- [x] 1.6 Pin all actions to full 40-character SHA with inline version comment
+
+## 2. Consumer Workflow (thin, workflow_run trigger, synced to downstream)
+
+- [x] 2.1 Create `.github/workflows/ci_council_review.yml` with `workflow_run` trigger on "Council Review - Collect PR Diff" and `workflow_dispatch` for manual testing
+- [x] 2.2 Call `reusable_council_review.yml` with secrets and `triggering-run-id` input
+- [x] 2.3 Add concurrency group with `cancel-in-progress: true`
+- [x] 2.4 Set workflow-level `permissions: {}` (none); job-level permissions inherited by reusable
+
+## 3. Reusable Review Workflow (shared logic, NOT synced)
+
+- [x] 3.1 Create `.github/workflows/reusable_council_review.yml` with `workflow_call` trigger accepting `triggering-run-id`, `model`, `max-diff-lines`, and WIF secrets
+- [x] 3.2 Add WIF gate check: skip when WIF secrets are absent
+- [x] 3.3 Download `council-review-diff` artifact from triggering run
+- [x] 3.4 Authenticate via WIF using `google-github-actions/auth@v3` (SHA-pinned) and set up gcloud CLI
+- [x] 3.5 Delegate review to `council-review-action` composite action (SHA-pinned)
+- [x] 3.6 Clean up previous bot comments via `gh api` using `<!-- council-review-bot -->` marker
+- [x] 3.7 Post inline review via Pull Request Review API (with collapsible `<details>` fallback)
+- [x] 3.8 Post comment-only fallback when structured JSON is not available
+- [x] 3.9 Accept model and max-diff-lines as configurable inputs
+
+## 4. Validation and Cleanup
+
+- [x] 4.1 Verify all action `uses:` references are pinned to full 40-character SHAs
+- [x] 4.2 Open a test PR and verify: collect runs, consumer triggers, WIF auth succeeds, OpenCode responds, inline comments are posted
+- [x] 4.3 Test with a draft PR: verify gate skips with logged reason
+- [ ] 4.4 Delete `.github/workflows/ci_council_review_test.yml` after production validation succeeds
+- [ ] 4.5 Squash commits on the branch and open PR for review

--- a/sync-config.yml
+++ b/sync-config.yml
@@ -50,6 +50,18 @@ files_to_sync:
         repos:
           complytime-providers: "'.trivyignore.yaml'"
 
+  - source: .github/workflows/ci_council_review_collect.yml
+    destination: .github/workflows/ci_council_review_collect.yml
+    exclude_repos:
+      - .github
+      - community
+
+  - source: .github/workflows/ci_council_review.yml
+    destination: .github/workflows/ci_council_review.yml
+    exclude_repos:
+      - .github
+      - community
+
   - source: .github/workflows/ci_crapload.yml
     destination: .github/workflows/ci_crapload.yml
     exclude_repos:


### PR DESCRIPTION
## Summary

- Three-file workflow chain for AI council review using OpenCode on Vertex AI via ITPC WIF authentication, matching the org's reusable workflow convention
- `ci_council_review_collect.yml` (synced): fork-safe diff collection on `pull_request`, uploads PR diff and metadata as artifact
- `ci_council_review.yml` (synced): thin consumer on `workflow_run`, calls `reusable_council_review.yml` with secrets and triggering run ID
- `reusable_council_review.yml` (NOT synced): shared review logic — WIF auth, composite action call, inline comment posting. Called cross-repo by downstream repos
- Downstream repos receive the consumer workflows via `sync-config.yml` and call the reusable cross-repo (`complytime/org-infra/.github/workflows/reusable_council_review.yml@SHA`)

## Architecture

```
ci_council_review_collect.yml (pull_request) [synced to downstream]
  ├─ Gate check (skip drafts, dependabot)
  ├─ Collect PR diff via gh pr diff
  ├─ Write pr-meta.json (PR number, head SHA, title)
  └─ Upload artifact (council-review-diff, 1-day retention)
         │
         ▼  workflow_run trigger
ci_council_review.yml (workflow_run / workflow_dispatch) [synced to downstream]
  └─ Calls reusable_council_review.yml with secrets + triggering-run-id
         │
         ▼  workflow_call
reusable_council_review.yml (workflow_call) [stays in org-infra]
  ├─ WIF gate check (skip if no secrets)
  ├─ Download artifact from collect run
  ├─ WIF auth → Vertex AI
  ├─ council-review-action (composite, in unbound-force/unbound-force)
  │   ├─ Install OpenCode (pinned 1.2.26)
  │   ├─ Filter noise files from diff
  │   ├─ Discover Divisor agents
  │   ├─ Build prompt (delegates to .opencode/ commands)
  │   ├─ opencode run → Claude on Vertex AI
  │   ├─ Parse structured JSON from JSONL
  │   └─ Filter inline comments to diff-visible lines
  ├─ Clean up previous bot comments
  └─ Post inline review (or fallback PR comment)
```

## Test plan

- [x] Collect workflow triggers on `pull_request` events
- [x] Gate correctly skips draft PRs
- [x] Artifact uploaded with correct pr-meta.json and diff
- [x] WIF auth succeeds (ITPC pool → `unbound-force` project)
- [x] OpenCode responds with structured JSON review
- [x] Inline review comments posted on specific diff lines
- [x] Fallback to PR comment when inline posting fails
- [x] Noise files (go.sum, vendor/) filtered from diff
- [ ] Full chain (collect → workflow_run → reusable) fires after merge to main
- [ ] Delete `ci_council_review_test.yml` after merge