### PR TITLE
fix(compliance): correct require-pull-request policy and OCI tag syntax

### DIFF
--- a/compliance/ampel/branch-protection/require-pull-request.json
+++ b/compliance/ampel/branch-protection/require-pull-request.json
@@ -10,7 +10,7 @@
   "tenets": [
     {
       "id": "01",
-      "code": "(has(predicates[0].data.values) && type(predicates[0].data.values) == list && predicates[0].data.values.exists(rule, rule.type == \"update\")) || (has(predicates[0].data.values) && type(predicates[0].data.values) != list && has(predicates[0].data.values.push_access_levels) && has(predicates[0].data.values.merge_access_levels) && (size(predicates[0].data.values.push_access_levels) == 0 || predicates[0].data.values.push_access_levels.all(p, p.access_level == 0)) && size(predicates[0].data.values.merge_access_levels) > 0 && predicates[0].data.values.merge_access_levels.exists(m, m.access_level > 0))",
+      "code": "(has(predicates[0].data.values) && type(predicates[0].data.values) == list && predicates[0].data.values.exists(rule, rule.type == \"pull_request\")) || (has(predicates[0].data.values) && type(predicates[0].data.values) != list && has(predicates[0].data.values.push_access_levels) && has(predicates[0].data.values.merge_access_levels) && (size(predicates[0].data.values.push_access_levels) == 0 || predicates[0].data.values.push_access_levels.all(p, p.access_level == 0)) && size(predicates[0].data.values.merge_access_levels) > 0 && predicates[0].data.values.merge_access_levels.exists(m, m.access_level > 0))",
       "predicates": {
         "types": [
           "http://github.com/carabiner-dev/snappy/specs/github/branch-rules.yaml",
@@ -22,7 +22,7 @@
       },
       "error": {
         "message": "Direct pushes are enabled so Pull/Merge requests are not required.",
-        "guidance": "GitHub: Create a branch ruleset and enable 'Restrict updates'. GitLab: Configure branch protection with push_access_levels either empty or set to access_level 0 (No access), and ensure merge_access_levels is non-empty with at least one access_level > 0."
+        "guidance": "GitHub: Create a branch ruleset and add the 'Require a pull request before merging' rule. GitLab: Configure branch protection with push_access_levels either empty or set to access_level 0 (No access), and ensure merge_access_levels is non-empty with at least one access_level > 0."
       }
     }
   ]

--- a/complytime.yaml
+++ b/complytime.yaml
@@ -1,5 +1,5 @@
 policies:
-  - url: quay.io/complytime/policies-ampel-branch-protection:latest
+  - url: quay.io/complytime/policies-ampel-branch-protection@latest
     id: ampel-bp
 
 targets:


### PR DESCRIPTION
## Summary

Fixes the daily Compliance Checks CI workflow failure ([run #77](https://github.com/complytime/org-infra/actions/runs/26922340130)) caused by two distinct issues:

1. **`require-pull-request` granular policy (compliance failure):** The CEL expression checked for a GitHub ruleset rule of type `"update"` (Restrict updates), which blocks all ref updates — including PR merges — for non-bypass users. When this rule was disabled to unblock development, the compliance check started failing. Changed to check for `"pull_request"` rule type instead, which enforces PRs while allowing merges after approval. Updated guidance text accordingly.

2. **OCI tag syntax in `complytime.yaml` (artifact upload failure):** The policy URL used `:latest` (colon separator), which propagated into report filenames causing `actions/upload-artifact` to reject them. Replaced with `@latest` to align with the convention in `complytime-policies`.

## Related Issues

- Closes the recurring Compliance Checks CI failure visible in [workflow runs](https://github.com/complytime/org-infra/actions/workflows/ci_compliance.yml)

## Review Hints

- Each commit addresses one issue independently and is best reviewed in sequence.

- **Commit 1** (`require-pull-request.json`): The key change is `rule.type == "update"` to `rule.type == "pull_request"` in the CEL expression. The `pull_request` rule type is already present in the rulesets (confirmed by `minimum-approvals.json` checks passing against it). The GitLab side of the expression is unchanged.

- **Commit 2** (`complytime.yaml`): Single character change from `:` to `@` in the OCI reference.

- After merging, verify via a manual `workflow_dispatch` of `ci_compliance.yml` that both targets (`complytime-org-infra` and `complytime-complyctl`) pass all policy checks and artifacts upload successfully.