### PR TITLE
fix(ci): checkout org-infra scripts in reusable CRAP Load workflow

### DIFF
--- a/.github/actionlint.yml
+++ b/.github/actionlint.yml
@@ -1,0 +1,15 @@
+# actionlint configuration
+# https://github.com/rhysd/actionlint/blob/main/docs/config.md
+#
+# actionlint v1.7.12 does not recognise the job.workflow_repository,
+# job.workflow_sha, and job.workflow_ref properties added by GitHub
+# for reusable workflows. These are documented context properties:
+# https://docs.github.com/en/actions/writing-workflows/choosing-what-your-workflow-does/accessing-contextual-information-about-workflow-runs#job-context
+#
+# Suppress false positives until actionlint ships updated type
+# definitions. Scoped to reusable workflows only, where these
+# properties are available.
+paths:
+  .github/workflows/reusable_*.yml:
+    ignore:
+      - 'property "workflow_(repository|sha|ref)" is not defined in object type'

--- a/.github/workflows/reusable_crapload_analysis.yml
+++ b/.github/workflows/reusable_crapload_analysis.yml
@@ -82,6 +82,15 @@ jobs:
           fetch-depth: 0
           persist-credentials: false
 
+      - name: Checkout org-infra scripts
+        uses: actions/checkout@df4cb1c069e1874edd31b4311f1884172cec0e10 # v6.0.3
+        with:
+          repository: ${{ job.workflow_repository }}
+          ref: ${{ job.workflow_sha }}
+          path: .workflow-scripts
+          sparse-checkout: scripts
+          persist-credentials: false
+
       - name: Detect changed packages
         id: detect-changes
         if: github.event_name == 'pull_request'
@@ -144,7 +153,7 @@ jobs:
           fi
 
           # Use the resolution script for consistent behavior
-          RESOLVED=$(bash scripts/resolve-go-packages.sh "$PACKAGES_INPUT")
+          RESOLVED=$(bash .workflow-scripts/scripts/resolve-go-packages.sh "$PACKAGES_INPUT")
           echo "packages=$RESOLVED" >> "$GITHUB_OUTPUT"
 
       - name: Install Gaze
@@ -199,7 +208,7 @@ jobs:
           GAZE_VERSION: ${{ inputs.gaze-version }}
         run: |
           # Call external script to avoid actionlint hang on large inline bash blocks
-          bash scripts/compare-crapload.sh \
+          bash .workflow-scripts/scripts/compare-crapload.sh \
             "/tmp/crapload-current.json" \
             "$BASELINE" \
             "$NEW_FUNC_THRESHOLD" \


### PR DESCRIPTION
## Summary

The reusable CRAP Load workflow at v0.3.0 references external scripts
(`scripts/resolve-go-packages.sh`, `scripts/compare-crapload.sh`) that live in
org-infra, but when a consuming repository calls the workflow via `workflow_call`,
`actions/checkout` checks out the **consumer's** code — not org-infra's. The
scripts are not found and the job fails with exit code 127.

## Changes

1. **Added a self-checkout step** using `job.workflow_repository` and
   `job.workflow_sha` to fetch org-infra's `scripts/` directory into
   `.workflow-scripts/` via sparse checkout
2. **Updated both script references** to use the new
   `.workflow-scripts/scripts/` path

## Design Decisions

- Uses the same checkout action pin (`v6.0.3 / df4cb1c0`) already in the workflow
- `job.workflow_sha` resolves to the exact commit SHA pinned in each consumer's
  `uses:` line — no hardcoded ref needed
- `job.workflow_repository` resolves to `complytime/org-infra` — portable even if
  forked
- `sparse-checkout: scripts` limits checkout to ~2 files
- `.workflow-scripts/` subdirectory avoids conflicts with consumer repo files
- `persist-credentials: false` follows least-privilege security practice

## Impact

- **Zero changes** required in any consuming repository
- No new permissions needed (uses existing `contents: read`)
- No workflow input changes

## Verification

- `make lint` passes (yamllint + ruff)

Closes #317