### PR TITLE
feat: add GitHub Job Summary to Trivy scan workflows

### DIFF
--- a/.github/workflows/reusable_trivy_image_scan.yml
+++ b/.github/workflows/reusable_trivy_image_scan.yml
@@ -87,6 +87,36 @@ jobs:
           sarif_file: 'trivy-image-scan-${{ github.workflow_sha }}-${{ github.run_number }}.sarif'
           category: 'trivy-image'
 
+      - name: Publish findings to summary
+        if: ${{ steps.trivy.outcome == 'success' }}
+        env:
+          SARIF_FILE: trivy-image-scan-${{ github.workflow_sha }}-${{ github.run_number }}.sarif
+          REPO: ${{ github.repository }}
+          IMAGE_REF: ${{ inputs.image_ref }}
+        run: |
+          jq -r --arg repo "$REPO" --arg image "$IMAGE_REF" '
+            [.runs[] | (.results // [])[] | select(.level == "error")] |
+            if length == 0 then
+              "### Trivy Image Scan -- No Findings\n\nImage: `" + $image + "`\n\nNo HIGH/CRITICAL vulnerabilities detected.\n"
+            else
+              "### Trivy Image Scan -- \(length) Vulnerability(ies)\n\n" +
+              "Image: `" + $image + "`\n\n" +
+              "| # | CVE / Rule | File | Description |\n" +
+              "|---|-----------|------|-------------|\n" +
+              (to_entries | map(
+                .value as $f |
+                (($f.locations // [])[0] // {} | .physicalLocation // {}) as $loc |
+                ($loc.artifactLocation.uri // "N/A") as $file |
+                ($f.message.text // ""
+                  | gsub("\n"; " ") | gsub("\\|"; "&#124;")
+                  | if length > 100 then .[0:100] + "..." else . end
+                ) as $desc |
+                "| \(.key + 1) | `\($f.ruleId // "unknown")` | `\($file)` | \($desc) |"
+              ) | join("\n")) +
+              "\n\n> Full SARIF details in [Code Scanning alerts](https://github.com/" + $repo + "/security/code-scanning).\n"
+            end
+          ' "$SARIF_FILE" >> "$GITHUB_STEP_SUMMARY"
+
       - name: Check scan result
         id: scan_result
         if: ${{ steps.trivy.outcome == 'success' }}

--- a/.github/workflows/reusable_vuln_scan.yml
+++ b/.github/workflows/reusable_vuln_scan.yml
@@ -85,6 +85,35 @@ jobs:
           sarif_file: 'trivy-source-scan-${{ github.workflow_sha }}-${{ github.run_number }}.sarif'
           category: 'trivy-source'
 
+      - name: Publish findings to summary
+        if: ${{ steps.trivy.outcome == 'success' }}
+        env:
+          SARIF_FILE: trivy-source-scan-${{ github.workflow_sha }}-${{ github.run_number }}.sarif
+          REPO: ${{ github.repository }}
+        run: |
+          jq -r --arg repo "$REPO" '
+            [.runs[] | (.results // [])[] | select(.level == "error")] |
+            if length == 0 then
+              "### Trivy Source Scan -- No Findings\n\nNo HIGH/CRITICAL findings detected.\n"
+            else
+              "### Trivy Source Scan -- \(length) Finding(s)\n\n" +
+              "| # | Rule ID | File | Line | Description |\n" +
+              "|---|---------|------|------|-------------|\n" +
+              (to_entries | map(
+                .value as $f |
+                (($f.locations // [])[0] // {} | .physicalLocation // {}) as $loc |
+                ($loc.artifactLocation.uri // "N/A") as $file |
+                ($loc.region.startLine // "-") as $line |
+                ($f.message.text // ""
+                  | gsub("\n"; " ") | gsub("\\|"; "&#124;")
+                  | if length > 100 then .[0:100] + "..." else . end
+                ) as $desc |
+                "| \(.key + 1) | `\($f.ruleId // "unknown")` | `\($file)` | \($line) | \($desc) |"
+              ) | join("\n")) +
+              "\n\n> Full SARIF details in [Code Scanning alerts](https://github.com/" + $repo + "/security/code-scanning).\n"
+            end
+          ' "$SARIF_FILE" >> "$GITHUB_STEP_SUMMARY"
+
       - name: Fail on findings
         if: ${{ steps.trivy.outcome == 'success' }}
         env:


### PR DESCRIPTION
## Summary

Render a findings table in the GitHub Actions Job Summary so maintainers can see what was reported directly from the run page, instead of navigating to the Code Scanning alerts tab.

### Problem

When Trivy scans find vulnerabilities, the job annotation only says `Found N HIGH/CRITICAL findings` with no detail about what was actually found. Example: [complytime-providers run](https://github.com/complytime/complytime-providers/actions/runs/27005381831/job/79695558181?pr=57).

### Solution

Add a **Publish findings to summary** step to both Trivy workflows that parses the SARIF output and renders a markdown table into `$GITHUB_STEP_SUMMARY`:

- **`reusable_vuln_scan.yml`** (source scan): table with Rule ID, File, Line, Description
- **`reusable_trivy_image_scan.yml`** (image scan): table with CVE/Rule, File, Description + scanned image reference

Both include a footer link to the full SARIF in Code Scanning alerts.

### Example output (source scan)

| # | Rule ID | File | Line | Description |
|---|---------|------|------|-------------|
| 1 | `aws-access-key-id` | `config/credentials.go` | 42 | AWS Access Key ID detected in source code |
| 2 | `DS002` | `Dockerfile` | 1 | Specify at least 1 USER command in Dockerfile with non-root user as argument |

### What stays unchanged

- No new permissions required (`$GITHUB_STEP_SUMMARY` is always writable)
- Existing fail-on-findings / check-scan-result logic untouched
- SARIF upload to Code Scanning unchanged
- Consumer workflows (`ci_security.yml`) need no changes -- reusable workflows are called by reference
- All org repos get this improvement automatically