### PR TITLE
ci: add PR-triggered auto-labeler workflow

### DIFF
--- a/.github/workflows/ci_auto_label.yml
+++ b/.github/workflows/ci_auto_label.yml
@@ -26,7 +26,6 @@ jobs:
     steps:
       - uses: release-drafter/release-drafter@693d20e7c1ce1a81d3a41962f85914253b518449  # v7.3.1
         with:
-          disable-releaser: true
           dry-run: true
         env:
           GITHUB_TOKEN: ${{ secrets.GITHUB_TOKEN }}

--- a/.github/workflows/ci_auto_label.yml
+++ b/.github/workflows/ci_auto_label.yml
@@ -27,6 +27,6 @@ jobs:
       - uses: release-drafter/release-drafter@693d20e7c1ce1a81d3a41962f85914253b518449  # v7.3.1
         with:
           disable-releaser: true
-          disable-autolabeler: false
+          dry-run: true
         env:
           GITHUB_TOKEN: ${{ secrets.GITHUB_TOKEN }}

--- a/.github/workflows/ci_auto_label.yml
+++ b/.github/workflows/ci_auto_label.yml
@@ -1,0 +1,32 @@
+# SPDX-License-Identifier: Apache-2.0
+#
+# --------------------------------------------------------------------------
+# Auto-label PRs using release-drafter's autolabeler rules defined in
+# .github/release-drafter.yml. Without this workflow the autolabeler
+# section is dormant — labels would only be applied at release time,
+# which is too late to be useful for triage and changelog previews.
+# --------------------------------------------------------------------------
+
+name: Auto-label PRs
+
+on:
+  pull_request:
+    types: [opened, reopened, synchronize]
+
+permissions: {}
+
+jobs:
+  label:
+    runs-on: ubuntu-latest
+
+    permissions:
+      contents: read
+      pull-requests: write
+
+    steps:
+      - uses: release-drafter/release-drafter@693d20e7c1ce1a81d3a41962f85914253b518449  # v7.3.1
+        with:
+          disable-releaser: true
+          disable-autolabeler: false
+        env:
+          GITHUB_TOKEN: ${{ secrets.GITHUB_TOKEN }}


### PR DESCRIPTION
## Summary

The autolabeler rules in `.github/release-drafter.yml` (lines 104–140) define label mappings by file path and PR title pattern, but they are never activated during day-to-day development. The existing `release.yml` and `release_notes_preview.yml` workflows only trigger on `workflow_dispatch`, so PRs don't get auto-labeled until release time — too late to be useful for triage and changelog previews.

## Changes

- Add `ci_auto_label.yml` — a lightweight workflow that runs release-drafter on `pull_request` events (`opened`, `reopened`, `synchronize`) with `disable-releaser: true` so only the autolabeler fires (no draft release is created).
- Pins to the same release-drafter SHA already used in `release.yml` and `release_notes_preview.yml` (`v7.3.1`).
- Follows the `ci_` workflow naming convention.
- Minimal permissions: `contents: read`, `pull-requests: write`.

## Context

Mirrors the approach from complytime-labs/complytime-policies-internal#22. The release-drafter config already has comprehensive autolabeler rules — this workflow is the missing trigger to make them fire on every PR.