### PR TITLE
feat: add task issue template

### DIFF
--- a/.github/ISSUE_TEMPLATE/task.md
+++ b/.github/ISSUE_TEMPLATE/task.md
@@ -1,0 +1,26 @@
+---
+name: Task
+about: A tracked unit of work with sub-issues and a definition of done
+title: "[Task] "
+labels: ''
+assignees: ''
+
+---
+
+### Description
+
+What is this task and why does it matter?
+
+### Acceptance Criteria
+
+- [ ]
+- [ ]
+
+### Definition of Done
+
+- [ ] Initial usage documentation have been created
+- [ ] The feature has been demonstrated successfully in the target environment
+- [ ] Proper testing has been completed (unit, integration, e2e, GitHub Actions)
+- [ ] Code has been reviewed for bugs and vulnerabilities
+- [ ] Technical debt has been documented if introduced
+- [ ] Community buy-in/awareness has been obtained


### PR DESCRIPTION
## Summary

- Adds `.github/ISSUE_TEMPLATE/task.md` for tracked units of work
- Prefills issue title with `[Task] ` and includes Description, Acceptance Criteria, and Definition of Done sections
- Aligns with existing org issue templates (`bug_report.md`, `feature_request.md`)

## Test plan

- [ ] Open **New issue** in a repo that syncs templates from `org-infra` (or in this repo after merge)
- [ ] Select **Task** from the template chooser
- [ ] Confirm title prefix, sections, and checklist items render correctly


Made with [Cursor](https://cursor.com)