### PR TITLE
chore: add user story issue template

### DIFF
--- a/.github/ISSUE_TEMPLATE/user_story.md
+++ b/.github/ISSUE_TEMPLATE/user_story.md
@@ -1,0 +1,34 @@
+---
+name: User Story
+about: A user story with acceptance criteria, out-of-scope boundaries, and a definition of done
+title: "[Story] "
+labels: ''
+assignees: ''
+
+---
+
+**[As]** Stakeholders:
+
+**[I want]** Business Outcome:
+
+**[So that]** Business Benefits:
+
+### Description
+
+What is the user benefit from this story?
+
+### Acceptance Criteria
+
+- [ ]
+- [ ]
+
+### Out of Scope
+
+### Definition of Done
+
+- [ ] Initial usage documentation have been created
+- [ ] The feature has been demonstrated successfully in the target environment
+- [ ] Proper testing has been completed (unit, integration, e2e, GitHub Actions)
+- [ ] Code has been reviewed for bugs and vulnerabilities
+- [ ] Technical debt has been documented if introduced
+- [ ] Community buy-in/awareness has been obtained


### PR DESCRIPTION
## Summary

- Adds `.github/ISSUE_TEMPLATE/user_story.md` for user stories
- Prefills issue title with `[Story] ` and includes As/I want/So that framing, Description, Acceptance Criteria, Out of Scope, and Definition of Done sections
- Aligns with existing org issue templates and complements the Task template

## Test plan

- [ ] Open **New issue** in a repo that syncs templates from `org-infra` (or in this repo after merge)
- [ ] Select **User Story** from the template chooser
- [ ] Confirm title prefix, user story fields, sections, and checklist items render correctly


Made with [Cursor](https://cursor.com)