### PR TITLE
fix(ci): fetch live PR title for commitlint validation

### DIFF
--- a/.github/workflows/ci_checks.yml
+++ b/.github/workflows/ci_checks.yml
@@ -20,3 +20,4 @@ jobs:
     permissions:
       contents: read
       issues: read
+      pull-requests: read

--- a/.github/workflows/reusable_ci.yml
+++ b/.github/workflows/reusable_ci.yml
@@ -21,6 +21,7 @@ jobs:
     permissions:
       contents: read
       issues: read
+      pull-requests: read
     steps:
       - name: Checkout Code
         uses: actions/checkout@df4cb1c069e1874edd31b4311f1884172cec0e10 # v6.0.3
@@ -28,15 +29,17 @@ jobs:
           persist-credentials: false
 
       - name: Install Dependencies
-        if: ${{ github.event.pull_request.title != '' && github.event.pull_request.user.login != 'dependabot[bot]' }}
+        if: ${{ github.event_name == 'pull_request' && github.event.pull_request.user.login != 'dependabot[bot]' }}
         run: npm install @commitlint/cli @commitlint/config-conventional
 
       - name: Validate PR Title
-        if: ${{ github.event.pull_request.title != '' && github.event.pull_request.user.login != 'dependabot[bot]' }}
+        if: ${{ github.event_name == 'pull_request' && github.event.pull_request.user.login != 'dependabot[bot]' }}
         env:
-          PR_TITLE: "${{ github.event.pull_request.title }}"
+          GH_TOKEN: ${{ github.token }}
+          PR_NUMBER: ${{ github.event.pull_request.number }}
         run: |
-            echo "PR title provided: $PR_TITLE"
+            PR_TITLE=$(gh pr view "$PR_NUMBER" --repo "$GITHUB_REPOSITORY" --json title --jq '.title')
+            echo "PR title (live): $PR_TITLE"
             echo "$PR_TITLE" | npx commitlint --config commitlint.config.js
 
       - name: Run MegaLinter


### PR DESCRIPTION
## Summary

The commitlint PR title validation step in `reusable_ci.yml` uses `github.event.pull_request.title`, which comes from the webhook event payload at trigger time. This value is stale on manual re-runs and is not refreshed when the PR title is edited (since the `edited` event type is not in the default `pull_request` trigger types).

This caused CI to keep failing on PR #322 even after the title was corrected to follow Conventional Commits format.

This fix replaces the stale event payload reference with a live `gh pr view` call that fetches the current title from the GitHub API. It also adds `pull-requests: read` permission to both `ci_checks.yml` and `reusable_ci.yml` to allow the `gh` CLI to query the PR endpoint.

### Changes

- **`reusable_ci.yml`**: Fetch live PR title via `gh pr view` instead of `github.event.pull_request.title`. Align `if` conditions to use `github.event_name == 'pull_request'` instead of checking for a non-empty title string. Add `pull-requests: read` to job permissions.
- **`ci_checks.yml`**: Add `pull-requests: read` to the job permissions passed to the reusable workflow (the caller caps what the callee can request).

### Sync impact

`ci_checks.yml` syncs to all org repos (except `community`) via `sync-config.yml`. The permission change (`pull-requests: read`) will propagate on the next sync. This is a read-only permission expansion.

## Related Issues

- Fixes the root cause of CI failures on #322

## Review Hints

- The core logic change is in `reusable_ci.yml` lines 35-43. The `ci_checks.yml` change is a single permission line to unblock the reusable workflow.
- On `push` events (no PR context), `github.event_name` will not be `pull_request`, so both commitlint steps are correctly skipped.