### PR TITLE
fix(ci): remove BuildKit provenance that causes "unknown on unknown" in Quay

### DIFF
--- a/.github/workflows/reusable_publish_ghcr.yml
+++ b/.github/workflows/reusable_publish_ghcr.yml
@@ -246,7 +246,7 @@ jobs:
             type=gha,scope=${{ inputs.component_name }}-main
           cache-to: type=gha,mode=max,scope=${{ inputs.component_name }}-${{ github.ref_name }}
           sbom: false
-          provenance: mode=max
+          provenance: false
           no-cache: ${{ inputs.force_rebuild }}
 
       - name: Export digest


### PR DESCRIPTION
BuildKit's `provenance: mode=max` wraps single-platform builds in an OCI image index containing a provenance attestation manifest with platform `{"os": "unknown", "architecture": "unknown"}`. When promoted to Quay via `crane copy`, this surfaces as a confusing extra entry.

Set `provenance: false` — the `attest-build-provenance` step already provides SLSA provenance as an OCI referrer (the modern, registry- friendly approach) for protected-ref builds. Dev builds do not need embedded provenance.

Assisted-by: Claude Code (claude-opus-4-6)

Fixes: #335