### PR TITLE
fix(ci): disable SHA tags on complypack Quay promotion

### DIFF
--- a/.github/workflows/ci_publish_complypack.yml
+++ b/.github/workflows/ci_publish_complypack.yml
@@ -128,6 +128,7 @@ jobs:
       dest_tag: ${{ github.event.release.tag_name }}
       allowed_identity_regex: https://github.com/complytime/org-infra(/.*)?
       fail_if_dest_exists: true
+      include_sha_tags: false
     secrets:
       dest_username: ${{ secrets.QUAY_USERNAME }}
       dest_password: ${{ secrets.QUAY_PASSWORD }}


### PR DESCRIPTION
## Summary

Follow-up from [PR #314 review feedback](https://github.com/complytime/org-infra/pull/314#discussion_r3403799194) by @trevor-vaughan.

Disables SHA tag propagation when promoting complypack artifacts from GHCR to Quay. Quay serves as the production registry with semver release tags only — SHA tags are redundant there since GHCR already retains them for commit-level traceability.

### Change

Adds `include_sha_tags: false` to the `promote-quay` job in `ci_publish_complypack.yml`.

**Before**: Quay gets 3 tags per release (`v1.0.0`, `sha-<40-char>`, `sha-<7-char>`)
**After**: Quay gets 1 tag per release (`v1.0.0`)

### Rationale

- The [spec](openspec/changes/publish-complypack-ampel-bp/specs/complypack-publish/spec.md) describes Quay's role as "production, semver-tagged" and is silent on SHA tags
- The `include_sha_tags: true` default was inherited from `reusable_publish_quay.yml`, not a deliberate design choice
- GHCR retains SHA tags for traceability; the digest (immutable) is always available on both registries
- Cleaner tag list reduces consumer confusion