### PR TITLE
fix: add id-token permission to promote-quay job

### DIFF
--- a/.github/workflows/ci_publish_complypack.yml
+++ b/.github/workflows/ci_publish_complypack.yml
@@ -119,6 +119,7 @@ jobs:
     uses: ./.github/workflows/reusable_publish_quay.yml
     permissions:
       packages: read
+      id-token: write   # Required by reusable_publish_quay.yml for Sigstore keyless signing
     with:
       source_registry: ghcr.io
       source_image: complytime/complypack-ampel-branch-protection


### PR DESCRIPTION
## Problem

The `ci_publish_complypack.yml` workflow fails with a **startup failure** on any trigger (including `workflow_dispatch`):

```
Error calling workflow 'complytime/org-infra/.github/workflows/reusable_publish_quay.yml@3fee7cb...'.
The nested job 'promote' is requesting 'id-token: write', but is only allowed 'id-token: none'.
```

Failed run: https://github.com/complytime/org-infra/actions/runs/27426608613

## Root Cause

GitHub Actions validates permissions across **all jobs at parse time**, regardless of `if:` conditions. The `promote-quay` job calls `reusable_publish_quay.yml`, whose `promote` job requests `id-token: write` for Sigstore keyless signing. The caller only grants `packages: read`, and the workflow-level default is `id-token: none`.

Even though `promote-quay` is gated by `if: github.event_name == 'release'` and would be skipped on `workflow_dispatch`, the permission mismatch prevents the entire workflow from loading.

## Fix

Add `id-token: write` to the `promote-quay` job permissions, matching what the callee requires. No behavioral change for the GHCR publish path.

## Verification

After merging, re-trigger the workflow via `workflow_dispatch` on `main`.