### PR TITLE
feat: add workflow_dispatch support for Quay promotion

### DIFF
--- a/.github/workflows/ci_publish_complypack.yml
+++ b/.github/workflows/ci_publish_complypack.yml
@@ -2,13 +2,19 @@
 # ==============================================
 # Dual-registry publish pipeline for the Ampel branch-protection complypack.
 #
-# Push to main / workflow_dispatch:
+# Push to main / workflow_dispatch (default):
 #   1. publish-ghcr — packs and pushes the complypack OCI artifact to GHCR (sha-<commit> tag)
 #   2. sign-ghcr    — signs the GHCR artifact with Sigstore keyless signing
 #
-# Release (published):
+# Release (published) / workflow_dispatch (promote_quay=true):
 #   3. verify-ghcr-source — verifies the GHCR artifact exists for the tagged commit
 #   4. promote-quay       — promotes the verified artifact from GHCR to Quay.io
+#
+# Manual Quay promotion:
+#   Use workflow_dispatch with promote_quay=true, release_tag, and source_sha
+#   to promote an existing GHCR artifact to Quay without cutting a new release.
+#   This is needed because release events from GITHUB_TOKEN-based workflows
+#   do not trigger downstream workflows (GitHub Actions limitation).
 
 name: Publish Complypack (Ampel Branch Protection)
 
@@ -26,6 +32,19 @@ on:
         description: 'Custom tag (leave empty for default sha-<commit>)'
         required: false
         type: string
+      promote_quay:
+        description: 'Promote existing GHCR artifact to Quay (skips GHCR publish)'
+        required: false
+        default: false
+        type: boolean
+      release_tag:
+        description: 'Quay destination tag (required when promote_quay is true, e.g., v0.4.0)'
+        required: false
+        type: string
+      source_sha:
+        description: 'Source commit SHA to promote (defaults to current HEAD)'
+        required: false
+        type: string
 
 permissions:
   contents: none
@@ -40,7 +59,9 @@ concurrency:
 
 jobs:
   publish-ghcr:
-    if: github.event_name == 'push' || github.event_name == 'workflow_dispatch'
+    if: >-
+      github.event_name == 'push'
+      || (github.event_name == 'workflow_dispatch' && !inputs.promote_quay)
     uses: ./.github/workflows/reusable_publish_complypack.yml
     permissions:
       contents: read
@@ -75,19 +96,31 @@ jobs:
       verify_vuln: false
 
   verify-ghcr-source:
-    if: github.event_name == 'release'
+    if: >-
+      github.event_name == 'release'
+      || (github.event_name == 'workflow_dispatch' && inputs.promote_quay)
     runs-on: ubuntu-latest
     timeout-minutes: 5
     permissions:
       packages: read
     steps:
+      - name: Validate promotion inputs
+        if: ${{ github.event_name == 'workflow_dispatch' }}
+        env:
+          RELEASE_TAG: ${{ inputs.release_tag }}
+        run: |
+          if [[ -z "$RELEASE_TAG" ]]; then
+            echo "::error::release_tag is required when promote_quay is true"
+            exit 1
+          fi
+
       - name: Setup crane
         uses: imjasonh/setup-crane@59c71e96a00b28651f10369ba3359a6d730740a0 # v0.6
 
       - name: Check GHCR artifact exists
         env:
           TOKEN: ${{ secrets.GITHUB_TOKEN }}
-          SOURCE_TAG: sha-${{ github.sha }}
+          SOURCE_TAG: sha-${{ inputs.source_sha || github.sha }}
           GH_ACTOR: ${{ github.actor }}
           REPO_URL: ${{ github.server_url }}/${{ github.repository }}
         run: |
@@ -123,10 +156,10 @@ jobs:
     with:
       source_registry: ghcr.io
       source_image: complytime/complypack-ampel-branch-protection
-      source_tag: ${{ format('sha-{0}', github.sha) }}
+      source_tag: ${{ format('sha-{0}', inputs.source_sha || github.sha) }}
       dest_registry: quay.io
       dest_image: complytime/complypack-ampel-branch-protection
-      dest_tag: ${{ github.event.release.tag_name }}
+      dest_tag: ${{ github.event.release.tag_name || inputs.release_tag }}
       allowed_identity_regex: https://github.com/complytime/org-infra(/.*)?
       fail_if_dest_exists: true
       include_sha_tags: false


### PR DESCRIPTION
## Summary

Add `workflow_dispatch` inputs to `ci_publish_complypack.yml` that enable manual Quay promotion without cutting a new GitHub release.

This is needed because GitHub Actions suppresses events created by workflows using `GITHUB_TOKEN` to prevent infinite loops. When `release.yml` creates a release with `GITHUB_TOKEN`, the `release: published` event fires but does not trigger `ci_publish_complypack.yml`. This leaves the Quay promotion path unreachable via the automated release flow.

### Changes

- **New inputs**: `promote_quay` (boolean), `release_tag` (string), `source_sha` (string)
- **Guard `publish-ghcr`** from running in promotion mode (`!inputs.promote_quay`)
- **Allow `verify-ghcr-source`** and `promote-quay` to run on `workflow_dispatch` when `promote_quay` is true
- **Input validation**: Fails early if `release_tag` is empty when `promote_quay` is true
- **Flexible SHA/tag references**: `source_sha` allows specifying the exact commit whose GHCR artifact to promote (defaults to `github.sha` if omitted)
- **Updated header comment** documenting the new promotion mode

### Usage

To promote an existing GHCR artifact to Quay:
1. Go to **Actions** > **Publish Complypack (Ampel Branch Protection)** > **Run workflow**
2. Select **`main`** as the branch
3. Set:
   - `promote_quay`: `true`
   - `release_tag`: e.g., `v0.4.0`
   - `source_sha`: the commit SHA that the release tag points to (`git rev-list -n1 v0.4.0`)

## Related Issues

- Workaround for the `GITHUB_TOKEN` event suppression limitation ([GitHub docs](https://docs.github.com/en/actions/using-workflows/triggering-a-workflow#triggering-a-workflow-from-a-workflow))

## Review Hints

- Single file change: `.github/workflows/ci_publish_complypack.yml`
- No changes to reusable workflows — all changes are in the consumer workflow only
- The `release` event path is unchanged; the new inputs only affect `workflow_dispatch`
- When `promote_quay` is false (default), the workflow behaves identically to before