### PR TITLE
docs: adds quay release update

### DIFF
--- a/.complytime/complytime.yaml
+++ b/.complytime/complytime.yaml
@@ -3,7 +3,7 @@ policies:
     id: ampel-bp
 
 complypacks:
-  - url: quay.io/complytime/complypack-ampel-branch-protection:v0.4.0
+  - url: quay.io/complytime/complypack-ampel-branch-protection@latest
     id: ampel-bp-pack
 
 targets:

--- a/.complytime/complytime.yaml
+++ b/.complytime/complytime.yaml
@@ -3,7 +3,7 @@ policies:
     id: ampel-bp
 
 complypacks:
-  - url: quay.io/complytime/complypack-ampel-branch-protection@v0.4.0
+  - url: quay.io/complytime/complypack-ampel-branch-protection:v0.4.0
     id: ampel-bp-pack
 
 targets:

--- a/.complytime/complytime.yaml
+++ b/.complytime/complytime.yaml
@@ -3,7 +3,7 @@ policies:
     id: ampel-bp
 
 complypacks:
-  - url: ghcr.io/complytime/complypack-ampel-branch-protection@latest
+  - url: quay.io/complytime/complypack-ampel-branch-protection@v0.4.0
     id: ampel-bp-pack
 
 targets:

--- a/docs/COMPLYPACK_PUBLISH.md
+++ b/docs/COMPLYPACK_PUBLISH.md
@@ -292,7 +292,7 @@ Downstream repositories pull the complypack artifact in their
 
 ```yaml
 complypacks:
-  - url: quay.io/complytime/complypack-ampel-branch-protection@v1.0.0
+  - url: quay.io/complytime/complypack-ampel-branch-protection:v1.0.0
     id: ampel-bp-pack
 ```
 
@@ -320,7 +320,7 @@ immutable and ensure that every consumer pulls the exact same artifact.
        id: ampel-bp-pack
    ```
 
-Tag-based pins (e.g., `@v1.0.0`) are acceptable for development because Quay
+Tag-based pins (e.g., `:v1.0.0`) are acceptable for development because Quay
 tags are immutable in this pipeline (`fail_if_dest_exists: true`). Digest pins
 provide an additional guarantee that the reference cannot be altered by
 registry-side tag mutations.

--- a/docs/COMPLYPACK_PUBLISH.md
+++ b/docs/COMPLYPACK_PUBLISH.md
@@ -45,12 +45,13 @@ GHCR is the staging area. Every push to `main` that modifies files under
 commit-based tag. The artifact is signed with Sigstore keyless signing and
 includes SLSA provenance and SBOM attestations.
 
-Quay is the production registry. Promotion from GHCR to Quay happens through
+Quay is the production registry. The current procedure promotes from GHCR to Quay through
 two paths: automatically when a GitHub Release is published, or manually via
 `workflow_dispatch`. Manual promotion exists because GitHub Actions does not
 trigger downstream workflows from release events created by `GITHUB_TOKEN`-based
 workflows — see [Manual Quay Promotion](#manual-quay-promotion) for details.
-Quay tags are immutable — publishing the same tag twice fails.
+
+> **Note:** this limitation will be addressed in a follow-up PR by using an APP Token.
 
 ```text
 Push to main              Release published         workflow_dispatch

--- a/docs/COMPLYPACK_PUBLISH.md
+++ b/docs/COMPLYPACK_PUBLISH.md
@@ -37,32 +37,36 @@ pull these artifacts via the `complypacks:` section in their `complytime.yaml`.
 | Registry | Purpose | Tag format | Trigger |
 |----------|---------|------------|---------|
 | `ghcr.io/complytime/complypack-ampel-branch-protection` | Dev / test | `sha-<commit>` | Push to `main` (policy file changes) |
-| `quay.io/complytime/complypack-ampel-branch-protection` | Production | `v1.0.0` (semver) | GitHub Release published |
+| `quay.io/complytime/complypack-ampel-branch-protection` | Production | `vX.Y.Z` (semver) | GitHub Release published |
+| `quay.io/complytime/complypack-ampel-branch-protection` | Production | `vX.Y.Z` (semver) | `workflow_dispatch` (manual promotion) |
 
 GHCR is the staging area. Every push to `main` that modifies files under
 `compliance/ampel/branch-protection/` triggers a publish to GHCR with a
 commit-based tag. The artifact is signed with Sigstore keyless signing and
 includes SLSA provenance and SBOM attestations.
 
-Quay is the production registry. When a GitHub Release is published, the
-workflow promotes the GHCR artifact to Quay using `cosign copy` with source
-signature verification. Quay tags are immutable — publishing the same tag
-twice fails.
+Quay is the production registry. Promotion from GHCR to Quay happens through
+two paths: automatically when a GitHub Release is published, or manually via
+`workflow_dispatch`. Manual promotion exists because GitHub Actions does not
+trigger downstream workflows from release events created by `GITHUB_TOKEN`-based
+workflows — see [Manual Quay Promotion](#manual-quay-promotion) for details.
+Quay tags are immutable — publishing the same tag twice fails.
 
 ```text
-Push to main                        Release published
-     │                                    │
-     ▼                                    ▼
- publish-ghcr                     verify-ghcr-source
-     │                                    │
-     ▼                                    ▼
- sign-ghcr                         promote-quay
-     │                                    │
-     ▼                                    ▼
- ghcr.io/complytime/              quay.io/complytime/
-   complypack-ampel-                complypack-ampel-
-   branch-protection:               branch-protection:
-   sha-abc123                       v1.0.0
+Push to main              Release published         workflow_dispatch
+     │                          │                   (promote_quay=true)
+     ▼                          │                         │
+ publish-ghcr                   ▼                         ▼
+     │                    verify-ghcr-source       verify-ghcr-source
+     ▼                          │                         │
+ sign-ghcr                      ▼                         ▼
+     │                     promote-quay              promote-quay
+     ▼                          │                         │
+ ghcr.io/complytime/            ▼                         ▼
+   complypack-ampel-      quay.io/complytime/       quay.io/complytime/
+   branch-protection:       complypack-ampel-         complypack-ampel-
+   sha-abc123               branch-protection:        branch-protection:
+                            v1.0.0                    v0.5.0
 ```
 
 ## Workflows
@@ -95,7 +99,14 @@ Consumer workflow specific to org-infra's ampel branch-protection policies.
 
 - `push` to `main` with changes in `compliance/ampel/branch-protection/**`
 - `release` published (any semver tag)
-- `workflow_dispatch` with optional `tag_override` input
+- `workflow_dispatch` with the following inputs:
+
+| Input | Required | Description |
+|-------|----------|-------------|
+| `tag_override` | no | Custom GHCR tag (leave empty for default `sha-<commit>`) |
+| `promote_quay` | no | Set `true` to skip GHCR publish and promote an existing GHCR artifact to Quay |
+| `release_tag` | when `promote_quay=true` | Quay destination tag (e.g., `v0.5.0`) |
+| `source_sha` | no | Source commit SHA to promote (defaults to current HEAD) |
 
 ## Cutting a Release
 
@@ -164,6 +175,70 @@ workflow.
 Quay tags are immutable. You cannot overwrite an existing release. If you need
 to republish, use a new version tag (e.g., `v1.0.1`).
 
+## Manual Quay Promotion
+
+### Why manual promotion exists
+
+GitHub Actions has a known limitation: release events created by workflows
+that authenticate with `GITHUB_TOKEN` do not trigger other workflows. This
+means that if your release is cut by an automated workflow (or by any process
+using `GITHUB_TOKEN`), the `release: published` trigger in
+`ci_publish_complypack.yml` will not fire and the Quay promotion will not
+happen.
+
+Manual promotion via `workflow_dispatch` bypasses this limitation by letting
+you promote an existing GHCR artifact to Quay without relying on the release
+event trigger.
+
+### Steps
+
+1. **Identify the source commit** whose GHCR artifact you want to promote:
+
+   ```bash
+   # Find the commit SHA for the GHCR artifact you want to promote
+   gh run list \
+     --repo complytime/org-infra \
+     --workflow ci_publish_complypack.yml \
+     --limit 5
+   ```
+
+2. **Trigger the manual promotion**:
+
+   ```bash
+   gh workflow run ci_publish_complypack.yml \
+     --repo complytime/org-infra \
+     -f promote_quay=true \
+     -f release_tag=v0.5.0 \
+     -f source_sha=abc123def456
+   ```
+
+   Replace `v0.5.0` with the desired semver tag and `abc123def456` with the
+   full commit SHA. If `source_sha` is omitted, the workflow uses the current
+   HEAD of the default branch.
+
+3. **Monitor the promotion**:
+
+   ```bash
+   gh run watch --repo complytime/org-infra
+   ```
+
+4. **Verify the Quay artifact**:
+
+   ```bash
+   crane manifest \
+     quay.io/complytime/complypack-ampel-branch-protection:v0.5.0
+   ```
+
+### When to use manual promotion
+
+- **Automated releases**: When a CI workflow creates the GitHub Release using
+  `GITHUB_TOKEN`, the promotion workflow will not trigger automatically.
+- **Retroactive promotion**: When you need to promote a specific older commit
+  that already has a signed GHCR artifact.
+- **Re-promotion after failure**: When the release-triggered promotion failed
+  and you need to retry without creating a new release (use a new version tag
+  since Quay tags are immutable).
+
 ## Local Testing
 
 ### Prerequisites
@@ -217,11 +292,47 @@ Downstream repositories pull the complypack artifact in their
 
 ```yaml
 complypacks:
-  - quay.io/complytime/complypack-ampel-branch-protection:v1.0.0
+  - url: quay.io/complytime/complypack-ampel-branch-protection@v1.0.0
+    id: ampel-bp-pack
 ```
 
 The `complyctl get` command resolves the OCI reference, pulls the artifact,
 and extracts the policy files for the compliance scan.
+
+### Digest pinning
+
+For production use, pin to a digest instead of a mutable tag. Digests are
+immutable and ensure that every consumer pulls the exact same artifact.
+
+1. **Get the digest** after Quay promotion:
+
+   ```bash
+   crane digest \
+     quay.io/complytime/complypack-ampel-branch-protection:v1.0.0
+   # Output: sha256:abc123...
+   ```
+
+2. **Pin to the digest** in `complytime.yaml`:
+
+   ```yaml
+   complypacks:
+     - url: quay.io/complytime/complypack-ampel-branch-protection@sha256:abc123...
+       id: ampel-bp-pack
+   ```
+
+Tag-based pins (e.g., `@v1.0.0`) are acceptable for development because Quay
+tags are immutable in this pipeline (`fail_if_dest_exists: true`). Digest pins
+provide an additional guarantee that the reference cannot be altered by
+registry-side tag mutations.
+
+### Updating dependent repositories after a release
+
+After promoting a new version to Quay:
+
+1. Retrieve the digest for the new tag (see above).
+2. Update the `complypacks` entry in each dependent repository's
+   `.complytime/complytime.yaml` to reference the new version or digest.
+3. Open a PR in each dependent repository with the updated pin.
 
 ## Related
 


### PR DESCRIPTION
## Summary

This PR adds some supplemental documentation (pending until quay release) for the changes to the org-infra workflows that require manual `workflow_dispatch` triggering for promoting to quay from ghcr. Additionally, the `.complytime/complytime.yaml` points to the `v0.4.0` tagged image in quay. This will be updated once the quay release is cut. This documentation will be updated in the complyctl repo for users updating their workspace configuration file and looking to point the `policies` and `complypacks` to the same registry image digest.  

<details>
  <summary>Example complytime.yaml</summary>

```yaml
policies:
  - url: quay.io/complytime/policies-ampel-branch-protection@latest
    id: ampel-bp

complypacks:
  - url: quay.io/complytime/complypack-ampel-branch-protection@v0.4.0
    id: ampel-bp-pack

targets:
  - id: complytime-org-infra
    policies:
      - ampel-bp
    variables:
      url: https://github.com/complytime/org-infra
      specs: builtin:github/branch-rules.yaml

  - id: complytime-complyctl
    policies:
      - ampel-bp
    variables:
      url: https://github.com/complytime/complyctl
      specs: builtin:github/branch-rules.yaml
```

</details>

## Related Issues


- Supports Issue #341 
- Depends on quay release for accuracy

## Review Hints

- Test in Devpod environment in `complyctl` repo using the `.complytime/complytime.yaml`. 
- Review the workflow [runs](https://github.com/complytime/org-infra/actions/runs/27633883573) for publishing to [quay](https://quay.io/repository/complytime/complypack-ampel-branch-protection)