### PR TITLE
chore: remove gemara-content-service from sync exclusion list

### DIFF
--- a/sync-config.yml
+++ b/sync-config.yml
@@ -10,7 +10,6 @@ exclude_repos:
   - nunya                       # Internal tooling (Jira migration)
   - roadmap                     # Internal tooling (roadmap scripts)
   - complyscribe                # Archived
-  - gemara-content-service      # Archived
 
 # Files and workflows to synchronize
 # Each entry specifies:


### PR DESCRIPTION
The gemara-content-service repository has been moved to complytime-labs and is no longer in this organization. Remove it from the `exclude_repos` list in `sync-config.yml`.

> Ready for review. Waiting for confirmation on complytime/complytime-collector-components#325 before merging.