### PR TITLE
fix: remove invalid run.skip-dirs from .golangci.yml sync template

### DIFF
--- a/.golangci.yml
+++ b/.golangci.yml
@@ -1,7 +1,4 @@
 version: "2"
-run:
-  skip-dirs:
-    - vendor
 linters:
   default: standard   # https://golangci-lint.run/usage/linters/#enabled-by-default
   enable:


### PR DESCRIPTION
## Problem

The `.golangci.yml` sync template contains an invalid `run.skip-dirs` field that was removed in golangci-lint v2. This causes `golangci-lint config verify` to fail:

```
jsonschema: "run" does not validate with "/properties/run/additionalProperties":
  additional properties 'skip-dirs' not allowed
```

This broke CI in downstream sync PRs (e.g. complytime/complytime-collector-components#281).

## Fix

Remove the entire `run:` section. Vendor directories are excluded by default in Go modules, so the `skip-dirs` directive was also redundant.

Fixes #356