### PR TITLE
chore: updates reusable_compliance.yml refs

### DIFF
--- a/.github/workflows/reusable_compliance.yml
+++ b/.github/workflows/reusable_compliance.yml
@@ -42,12 +42,14 @@ jobs:
         uses: actions/checkout@9c091bb21b7c1c1d1991bb908d89e4e9dddfe3e0 # v7.0.0
         with:
           repository: complytime/complyctl
+          ref: v1.0.0-beta.0
           persist-credentials: false
 
       - name: Checkout complytime-providers
         uses: actions/checkout@9c091bb21b7c1c1d1991bb908d89e4e9dddfe3e0 # v7.0.0
         with:
           repository: complytime/complytime-providers
+          ref: v0.1.0
           path: _providers
           persist-credentials: false
 


### PR DESCRIPTION
## Summary

This PR adds the `steps.with.ref` field in the `actions/checkout` steps for complyctl and complytime-providers.

The update adds the complyctl [`ref: v1.0.0-beta.0`](https://github.com/complytime/complyctl/releases/tag/v1.0.0-beta.0) and complytime-providers [`ref: v0.1.0`](https://github.com/complytime/complytime-providers/releases/tag/v0.1.0) for the `reusable_compliance.yml` workflow to build & run against the tagged release versions. 

These changes will be documented in a maintenance procedure of the `reusable_compliance.yml` to ensure project maintainers are aware of the required update when new releases are cut in `complyctl` and `complytime-providers`. 

**Note:** this could be added as a follow-up issue to introduce some additional synchronization for `complyctl` and `complytime-providers` releases to update the `steps.with.ref` with their tagged versions. 

## Related Issues

- Closes #342 

## Review Hints

- Successful workflow run [here](https://github.com/hbraswelrh/org-infra/actions/runs/28111082501/job/83238357720) using the consumer workflow `ci_compliance.yml` and the correct versions of the dependent repos. 
- complyctl [`ref: v1.0.0-beta.0`](https://github.com/complytime/complyctl/releases/tag/v1.0.0-beta.0) - complyctl commands should run with the changes associated with tag. 
- complytime-providers [`ref: v0.1.0`](https://github.com/complytime/complytime-providers/releases/tag/v0.1.0) - first release in `complytime-providers`. Check to make sure working as expected. 

**Review `reusable_compliance.yml`**

```yaml
    steps:
      - name: Checkout complyctl source
        uses: actions/checkout@9c091bb21b7c1c1d1991bb908d89e4e9dddfe3e0 # v7.0.0
        with:
          repository: complytime/complyctl
          ref: v1.0.0-beta.0
          persist-credentials: false

      - name: Checkout complytime-providers
        uses: actions/checkout@9c091bb21b7c1c1d1991bb908d89e4e9dddfe3e0 # v7.0.0
        with:
          repository: complytime/complytime-providers
          ref: v0.1.0
          path: _providers
          persist-credentials: false
```
