### PR TITLE
fix(ci): add JSON validation guard to crapload workflow

### DIFF
--- a/.github/workflows/reusable_crapload_analysis.yml
+++ b/.github/workflows/reusable_crapload_analysis.yml
@@ -244,6 +244,17 @@ jobs:
             "${pkg_array[@]}" > /tmp/crapload-current.json 2>/tmp/gaze-crap-stderr.txt || true
           cat /tmp/gaze-crap-stderr.txt >&2 || true
 
+          # Guard: if gaze produced invalid JSON (e.g. unsupported
+          # flag), fail fast with a clear message instead of silently
+          # cascading to a false "fail" status downstream.
+          if ! jq -e '.summary' /tmp/crapload-current.json >/dev/null 2>&1; then
+            echo "::error::gaze crap produced invalid or empty JSON output."
+            echo "::error::This usually means the installed gaze version" \
+              "does not support a flag used by this workflow (e.g. --baseline)." \
+              "Upgrade gaze or pin gaze-version to a compatible release."
+            exit 1
+          fi
+
           # Extract outputs from gaze crap JSON.
           CRAPLOAD=$(jq -r '.summary.crapload // 0' /tmp/crapload-current.json)
           GAZE_CRAPLOAD=$(jq -r '.summary.gaze_crapload // 0' /tmp/crapload-current.json)


### PR DESCRIPTION
## Problem

The `reusable_crapload_analysis.yml` workflow fails with a misleading
"CRAP load check failed" on repos like complyctl ([failed run](https://github.com/complytime/complyctl/actions/runs/28356745758/job/84001441952?pr=604)).

**Root cause**: The workflow uses `gaze crap --baseline=...`, but
`go install gaze@latest` resolves to the latest tagged release which
doesn't have `--baseline` yet (merged in gaze `main`, unreleased).
The `unknown flag` error produces empty stdout, which silently cascades:

1. `gaze crap --baseline=...` errors → stdout (`/tmp/crapload-current.json`) is empty
2. `|| true` swallows the exit code
3. `jq -r '.comparison.passed // true'` on empty input → empty string
4. `"" != "true"` → `STATUS="fail"`
5. "Enforce threshold" sees `fail` → exits 1 with no useful context

## Fix

Add a JSON validation guard after `gaze crap`. If gaze produced
invalid or empty JSON (unsupported flag, crash, etc.), the step fails
immediately with a clear error pointing to a version mismatch instead
of silently producing a false failure.

## Resolution path

Once gaze tags a release with `--baseline` support, the guard becomes
a no-op safety net — gaze produces valid JSON and the check passes
through.