### PR TITLE
fix: add workflows permission to sync workflow app token

### DIFF
--- a/.github/workflows/sync_org_repositories.yml
+++ b/.github/workflows/sync_org_repositories.yml
@@ -23,7 +23,7 @@ on:
 
 # Minimal permissions for the workflow GITHUB_TOKEN.
 # The GitHub App token (generated below) carries its own permissions
-# (contents:write, pull_requests:write) scoped to target repos.
+# (contents:write, pull_requests:write, workflows:write) scoped to target repos.
 # Note: the sync script also clones the org's .github repository
 # (for peribolos.yaml) using the App token, not this GITHUB_TOKEN.
 permissions:
@@ -51,6 +51,7 @@ jobs:
           owner: ${{ github.repository_owner }} # zizmor: ignore[github-app]
           permission-contents: write
           permission-pull-requests: write
+          permission-workflows: write
 
       - name: Set up Python
         uses: actions/setup-python@ece7cb06caefa5fff74198d8649806c4678c61a1 # v6.3.0


### PR DESCRIPTION
## Problem

The Sync Organization Repositories workflow fails when pushing workflow files
(`.github/workflows/ci_*.yml`) to target repositories. GitHub requires the
special `workflows` permission for a GitHub App to create or update files
under `.github/workflows/`. The error:

```
! [remote rejected] sync-repo-standards-20260630103454 -> sync-repo-standards-20260630103454
(refusing to allow a GitHub App to create or update workflow
`.github/workflows/ci_checks.yml` without `workflows` permission)
```

## Root Cause

Commit `66e8217` added explicit `permission-contents: write` and
`permission-pull-requests: write` to scope the app token to least privilege.
This was correct, but incomplete — the `workflows` permission was not included.
When explicit `permission-*` inputs are provided, only those permissions are
requested, so `workflows` must be explicitly listed.

## Fix

- Add `permission-workflows: write` to the `actions/create-github-app-token`
  step in `sync_org_repositories.yml`.
- Update the header comment to document all three scoped permissions.

## Required Admin Action

The `complytime-repo-sync` GitHub App installation must also have the
**Workflows: Read & Write** permission granted at the org level
(Settings > GitHub Apps > complytime-repo-sync > Permissions).

Closes #370