### PR TITLE
fix(ci): sanitize colons from compliance artifact filenames

### DIFF
--- a/.github/workflows/reusable_compliance.yml
+++ b/.github/workflows/reusable_compliance.yml
@@ -233,6 +233,22 @@ jobs:
               out.write(f"compliance_result={compliance_result}\n")
           PYEOF
 
+      - name: Sanitize artifact filenames
+        if: always()
+        run: |
+          # actions/upload-artifact rejects colons in filenames (NTFS
+          # limitation). complyctl embeds the OCI tag (e.g. ":latest")
+          # in report and evaluation-log filenames. Replace colons
+          # with dashes so artifacts upload successfully.
+          for f in report-*.md .complytime/scan/evaluation-log-*.yaml; do
+            [ -f "$f" ] || continue
+            sanitized="${f//:/-}"
+            if [ "$f" != "$sanitized" ]; then
+              mv "$f" "$sanitized"
+              echo "Renamed: $f -> $sanitized"
+            fi
+          done
+
       - name: Upload scan results
         if: always()
         uses: actions/upload-artifact@043fb46d1a93c77aae656e7c1c64a875d1fc6a0a # v7.0.1


### PR DESCRIPTION
## Problem

The scheduled compliance workflow fails on two upload steps:

- **Upload scan results**: `report-complytime-policies-ampel-branch-protection:latest-*.md`
- **Upload Gemara Evaluation Log**: `evaluation-log-complytime-policies-ampel-branch-protection:latest-*.yaml`

`actions/upload-artifact` rejects colons in filenames (NTFS limitation).
The colon comes from `complyctl scan` embedding the OCI tag reference
(`:latest`) in output filenames.

Failed run: https://github.com/complytime/org-infra/actions/runs/28411851966/job/84186291635

## Fix

Add a sanitization step before artifact uploads that renames files
with colons, replacing `:` with `-`. The compliance scan itself
passes -- only the artifact uploads were broken.

Note: the underlying fix belongs in `complyctl` (it should not produce
filenames with NTFS-invalid characters), but this workflow-side
workaround unblocks CI immediately.