### PR TITLE
docs: add Renovate integration hygiene fixes

### DIFF
--- a/.github/release-drafter.yml
+++ b/.github/release-drafter.yml
@@ -78,6 +78,7 @@ exclude-labels:
 exclude-contributors:
   - "github-actions[bot]"
   - "dependabot[bot]"
+  - "complytime-renovate[bot]"
 
 version-resolver:
   major:

--- a/docs/RENOVATE_GO_TOOLCHAIN.md
+++ b/docs/RENOVATE_GO_TOOLCHAIN.md
@@ -172,6 +172,26 @@ retention). Download from the GitHub Actions run page to inspect
 which repos were scanned, what updates were found, and what actions
 were taken.
 
+### Merge conflicts with Dependabot PRs
+
+Renovate runs `go mod tidy` and `go mod vendor` after bumping the
+toolchain version (`postUpdateOptions` in the preset). This
+regenerates `go.sum` and vendor contents. If a Dependabot PR
+modifying the same `go.sum` is open concurrently, the second PR to
+merge will encounter a merge conflict.
+
+Resolution options:
+
+- **Rebase the conflicting PR** manually or via the GitHub UI
+  "Update branch" button.
+- **Merge the smaller PR first** -- Renovate toolchain patches are
+  typically one-line `go.mod` changes and resolve cleanly after
+  rebase.
+
+This is a timing issue, not a functional conflict. Dependabot manages
+module dependencies; Renovate manages the toolchain directive. They
+do not overlap in scope.
+
 ## Further reading
 
 - [Renovate gomod manager](https://docs.renovatebot.com/modules/manager/gomod/)


### PR DESCRIPTION
## Summary

Follow-up to #357. Addresses two cross-org integration gaps discovered during review.

Fixes #384

### Changes

- **`.github/release-drafter.yml`**: Add `complytime-renovate[bot]` to `exclude-contributors` to prevent bot noise in release notes (matches existing `dependabot[bot]` exclusion).
- **`docs/RENOVATE_GO_TOOLCHAIN.md`**: Add troubleshooting entry for `go.sum` merge conflicts between concurrent Dependabot and Renovate PRs.

### Context

Renovate's `postUpdateOptions` runs `go mod tidy` and `go mod vendor` after toolchain bumps, which regenerates `go.sum`. When a Dependabot PR modifying the same `go.sum` is open concurrently, the second to merge hits a merge conflict. This is documented as a timing issue with resolution steps.