### PR TITLE
feat: add source/test path inputs to reusable SonarCloud workflow

### DIFF
--- a/.github/workflows/reusable_sonarqube.yml
+++ b/.github/workflows/reusable_sonarqube.yml
@@ -27,6 +27,16 @@ on:
         required: false
         type: string
         description: 'The Sonar Scanner property for coverage, e.g., sonar.typescript.lcov.reportPaths.'
+      sonar_sources:
+        required: false
+        type: string
+        default: ''
+        description: 'Comma-separated list of source directories (e.g., src/,lib/). Maps to sonar.sources.'
+      sonar_tests:
+        required: false
+        type: string
+        default: ''
+        description: 'Comma-separated list of test directories (e.g., tests/). Maps to sonar.tests.'
     secrets:
       SONAR_TOKEN:
         required: true
@@ -78,10 +88,14 @@ jobs:
           SONAR_PROJECT_KEY: ${{ inputs.sonar_project_key }}
           COVERAGE_FILE_PATH: ${{ inputs.coverage_file_path }}
           LANGUAGE_SCANNER_PROPERTY: ${{ inputs.language_scanner_property }}
+          SONAR_SOURCES: ${{ inputs.sonar_sources }}
+          SONAR_TESTS: ${{ inputs.sonar_tests }}
         with:
           projectBaseDir: ${{ github.workspace }} # Ensure scan starts at the repo root
           args: >
-            "-Dsonar.organization=${{ env.SONAR_ORGANIZATION }}"
-            "-Dsonar.projectKey=${{ env.SONAR_PROJECT_KEY }}"
-            "-Dsonar.qualitygate.wait=true"
-            "${{ env.COVERAGE_FILE_PATH && format('-D{0}={1}', env.LANGUAGE_SCANNER_PROPERTY, env.COVERAGE_FILE_PATH) || '' }}"
+            -Dsonar.organization=${{ env.SONAR_ORGANIZATION }}
+            -Dsonar.projectKey=${{ env.SONAR_PROJECT_KEY }}
+            -Dsonar.qualitygate.wait=true
+            ${{ env.COVERAGE_FILE_PATH && format('-D{0}={1}', env.LANGUAGE_SCANNER_PROPERTY, env.COVERAGE_FILE_PATH) || '' }}
+            ${{ env.SONAR_SOURCES && format('-Dsonar.sources={0}', env.SONAR_SOURCES) || '' }}
+            ${{ env.SONAR_TESTS && format('-Dsonar.tests={0}', env.SONAR_TESTS) || '' }}

--- a/openspec/changes/sonarcloud-source-test-inputs/design.md
+++ b/openspec/changes/sonarcloud-source-test-inputs/design.md
@@ -1,0 +1,103 @@
+## Context
+
+`reusable_sonarqube.yml` (87 lines) currently accepts 5 inputs focused on organization/project
+identity and coverage reporting. The scanner `args` block hardcodes `sonar.organization`,
+`sonar.projectKey`, and `sonar.qualitygate.wait=true`, with a conditional coverage flag.
+
+Without `sonar.sources` and `sonar.tests`, SonarCloud scans the entire repo as source code,
+including test files, scripts, and configs. This inflates code smell counts, duplication metrics,
+and skews coverage percentages.
+
+Key files:
+- `.github/workflows/reusable_sonarqube.yml` -- reusable workflow (target of changes)
+- `specs/002-sonarqube-workflow/quickstart.md` -- consumer setup documentation
+- `specs/002-sonarqube-workflow/spec.md` -- feature specification
+
+## Goals / Non-Goals
+
+### Goals
+
+- Allow callers to scope SonarCloud analysis to specific source and test directories
+- Fix the empty-string argument defect in the coverage `args` line
+- Maintain full backward compatibility (all new inputs optional with empty defaults)
+
+### Non-Goals
+
+- Adding a generic `extra_args` input
+- Adding language-version inputs (e.g., `sonar.python.version`)
+- Modifying sync-config or creating a consumer workflow
+
+## Decisions
+
+### Decision 1: Dedicated inputs, not a generic `extra_args`
+
+**Decision**: Add `sonar_sources` and `sonar_tests` as explicit, typed string inputs.
+
+**Rationale**: All 15 reusable workflows in the org use strictly explicit inputs (60 total
+inputs, zero free-form catch-alls). The only exception is `scan-args` in
+`reusable_scheduled.yml`, which is a deliberate pass-through to an upstream Google workflow.
+A generic `extra_args` would violate the established org convention and Principle VII
+(Convention Over Configuration).
+
+**Alternative rejected**: `extra_args` free-form string -- flexible but inconsistent with org
+patterns, harder to discover, and higher misconfiguration risk.
+
+### Decision 2: Exclude `sonar_language_version`
+
+**Decision**: Do not add a `sonar_language_version` (or `sonar_python_version`) input.
+
+**Rationale**: `sonar.python.version` is the only language-version property currently relevant
+in the org. Adding it as an input creates a Python-specific parameter on a language-agnostic
+workflow. Go repos would see a meaningless input. Repos needing this property can set it via
+`sonar-project.properties` in the repo root, which SonarCloud reads automatically.
+
+**Alternative rejected**: Adding `sonar_python_version` -- too narrow. Adding a generic
+`sonar_language_version` with a companion `sonar_language_version_property` -- too complex for
+a single edge case.
+
+### Decision 3: Fix the empty-string quoting on line 87
+
+**Decision**: Remove the outer double quotes from the conditional coverage `-D` flag so that
+an empty expression produces no token rather than an empty-string argument.
+
+Current (problematic):
+```yaml
+"${{ env.COVERAGE_FILE_PATH && format('-D{0}={1}', ...) || '' }}"
+```
+
+Fixed:
+```yaml
+${{ env.COVERAGE_FILE_PATH && format('-D{0}={1}', ...) || '' }}
+```
+
+**Rationale**: sonarqube-scan-action v8.2.0 is a Node.js action that parses `args` via
+`string-argv`. Quoted empty string `""` becomes an empty positional argument to sonar-scanner.
+Without quotes, an empty expression produces whitespace that `string-argv` ignores.
+
+**Same pattern applied to new inputs**: The new conditional `-D` flags for `sonar_sources`
+and `sonar_tests` use the unquoted pattern to avoid the same issue.
+
+### Decision 4: Use `env:` indirection for new inputs
+
+**Decision**: Map new inputs to `env:` variables in the step's `env:` block, then reference
+via `${{ env.* }}` in the `args` block. Do not use `${{ inputs.* }}` directly in `args`.
+
+**Rationale**: This matches the existing pattern in the workflow (lines 74-80) and aligns
+with the org's security convention of environment variable indirection to prevent script
+injection.
+
+## Risks / Trade-offs
+
+**[Risk: None] Backward compatibility**: All new inputs have empty-string defaults. Existing
+callers pass no value, so the conditional `-D` flags evaluate to empty and produce no scanner
+arguments. Behavior is identical to current.
+
+**[Risk: Low] Quoting fix changes behavior for edge cases**: If any caller currently relies
+on the empty-string argument being passed (unlikely -- it would be a bug in the caller),
+removing it changes behavior. Mitigation: this is a bug fix, not a behavior change.
+
+**[Trade-off] sonar-project.properties vs. workflow inputs**: Repos can already configure
+`sonar.sources` and `sonar.tests` via a `sonar-project.properties` file in the repo root.
+Workflow inputs provide a centralized alternative but create two configuration paths. This
+is acceptable because workflow inputs take precedence (they're CLI `-D` flags) and the
+quickstart docs will clarify the precedence.

--- a/openspec/changes/sonarcloud-source-test-inputs/proposal.md
+++ b/openspec/changes/sonarcloud-source-test-inputs/proposal.md
@@ -1,0 +1,83 @@
+## Why
+
+The reusable SonarCloud workflow (`reusable_sonarqube.yml`) does not expose inputs for
+project-specific SonarCloud properties like `sonar.sources` and `sonar.tests`. Repos migrating
+from inline workflows to the reusable workflow lose these settings, causing SonarCloud to treat
+the entire repository as source code (including test files, scripts, and configs), which skews
+quality metrics.
+
+This was identified during the complyscribe migration (complytime/complyscribe#815) and filed
+as complytime/org-infra#146.
+
+Additionally, the existing `args` block has a quoting defect on the conditional coverage line:
+when `coverage_file_path` is empty, the outer double quotes produce an empty-string argument
+(`""`) that `string-argv` (used by sonarqube-scan-action v8.2.0) parses as a positional argument
+to sonar-scanner, which may cause warnings or failures.
+
+## What Changes
+
+- Add two optional inputs to `reusable_sonarqube.yml`: `sonar_sources` and `sonar_tests`,
+  with empty-string defaults (preserving backward compatibility)
+- Append conditional `-D` flags for the new inputs to the scanner `args` block
+- Fix the empty-string quoting defect on the existing conditional coverage line (line 87)
+- Update spec documentation (`specs/002-sonarqube-workflow/quickstart.md` and `spec.md`)
+
+## Non-goals
+
+- Adding a generic `extra_args` free-form input. The org follows a strict explicit inputs
+  pattern across all 15 reusable workflows (60 total inputs, zero catch-all string inputs).
+  A free-form input would be an anti-pattern.
+- Adding a `sonar_language_version` input (e.g., `sonar.python.version`). This property is
+  language-specific and does not generalize well -- Go repos would not use it. Repos that need
+  it should set it via `sonar-project.properties` in the repo root.
+
+## Capabilities
+
+### New Capabilities
+
+- `sonar-source-path-config`: Callers can specify `sonar_sources` and `sonar_tests` inputs to
+  control which directories SonarCloud treats as source code vs. test code, preventing metric
+  skew from scanning non-source files.
+
+### Modified Capabilities
+
+- `sonarcloud-coverage-args`: The conditional coverage `-D` flag no longer produces an
+  empty-string argument when coverage is not configured (quoting fix).
+
+### Removed Capabilities
+
+_None._
+
+## Impact
+
+- **`reusable_sonarqube.yml`**: 2 new inputs, 2 new conditional `-D` flags, 1 quoting fix.
+  All changes are additive with empty defaults -- existing callers are unaffected.
+- **`specs/002-sonarqube-workflow/quickstart.md`**: New usage example showing the inputs.
+- **`specs/002-sonarqube-workflow/spec.md`**: Updated functional requirements.
+- **Downstream repos**: No impact unless they opt in to the new inputs. Existing callers
+  continue to work identically.
+- **Sync config**: No changes. This workflow is not in `sync-config.yml`.
+
+## Constitution Alignment
+
+Assessed against the Unbound Force org constitution.
+
+### I. Autonomous Collaboration
+
+**Assessment**: N/A -- No change to artifact-based communication or self-describing outputs.
+
+### II. Composability First
+
+**Assessment**: PASS -- New inputs are optional with empty defaults. No new mandatory
+dependencies introduced. Existing callers are unaffected.
+
+### III. Observable Quality
+
+**Assessment**: PASS -- The quoting fix eliminates a potential empty-string argument that could
+cause scanner warnings. New inputs improve scan accuracy by scoping analysis to actual source
+and test directories.
+
+### IV. Testability
+
+**Assessment**: N/A -- YAML workflow files have no unit test framework. Validation relies on
+`yamllint` (syntax) and code review. No behavioral changes to testable components.

--- a/openspec/changes/sonarcloud-source-test-inputs/tasks.md
+++ b/openspec/changes/sonarcloud-source-test-inputs/tasks.md
@@ -1,0 +1,25 @@
+## 1. Workflow Changes
+
+- [ ] 1.1 Add `sonar_sources` and `sonar_tests` inputs to the `workflow_call` section of
+  `.github/workflows/reusable_sonarqube.yml` (optional string inputs, empty default,
+  descriptive `description` fields)
+- [ ] 1.2 Add `SONAR_SOURCES` and `SONAR_TESTS` environment variables to the `SonarCloud Scan`
+  step's `env:` block, mapped from the new inputs
+- [ ] 1.3 Fix line 87: remove outer double quotes from the conditional coverage `-D` flag
+- [ ] 1.4 Append two conditional `-D` flags for `sonar.sources` and `sonar.tests` to the
+  `args` block, using the unquoted pattern and `env:` indirection
+
+## 2. Documentation Updates
+
+- [ ] 2.1 [P] Update `specs/002-sonarqube-workflow/quickstart.md`: add a usage example
+  showing `sonar_sources` and `sonar_tests` inputs (Python example with
+  `sonar_sources: complyscribe/` and `sonar_tests: tests/`); add the new inputs to the
+  Configuration Options section
+- [ ] 2.2 [P] Update `specs/002-sonarqube-workflow/spec.md`: add source/test path
+  configuration to functional requirements; note `sonar-project.properties` as an
+  alternative in scope boundaries
+
+## 3. Validation
+
+- [ ] 3.1 Run `make lint` and fix any issues in modified files
+- [ ] 3.2 Run `make test` to verify no regressions

--- a/specs/002-sonarqube-workflow/quickstart.md
+++ b/specs/002-sonarqube-workflow/quickstart.md
@@ -148,6 +148,62 @@ jobs:
       source_token: ${{ secrets.GITHUB_TOKEN }}
 ```
 
+**With source/test path scoping (Python example):**
+```yaml
+name: SonarQube Analysis
+
+on:
+  push:
+    branches:
+      - main
+
+permissions:
+  contents: none
+  issues: none
+  pull-requests: none
+
+jobs:
+  generate-coverage:
+    name: Generate Coverage Report
+    runs-on: ubuntu-latest
+    steps:
+      - name: Check out
+        uses: actions/checkout@de0fac2e4500dabe0009e67214ff5f5447ce83dd # v6.0.2
+      - name: Run test
+        run: pytest --cov --cov-report=xml
+      - name: Upload artifact
+        uses: actions/upload-artifact@bbbca2ddaa5d8feaa63e36b76fdaad77386f024f # v7.0.0
+        with:
+          name: coverage
+          path: coverage.xml
+
+  sonarqube:
+    name: SonarCloud Analysis
+    permissions:
+      contents: read
+      pull-requests: read
+    needs: generate-coverage
+    uses: complytime/org-infra/.github/workflows/reusable_sonarqube.yml@main
+    with:
+      sonar_organization: ${{ vars.SONAR_ORGANIZATION }}
+      sonar_project_key: ${{ vars.SONAR_PROJECT_KEY }}
+      coverage_artifact_name: coverage
+      coverage_file_path: coverage.xml
+      language_scanner_property: sonar.python.coverage.reportPaths
+      sonar_sources: complyscribe/
+      sonar_tests: tests/
+    secrets:
+      SONAR_TOKEN: ${{ secrets.SONAR_TOKEN }}
+      source_token: ${{ secrets.GITHUB_TOKEN }}
+```
+
+Without `sonar_sources` and `sonar_tests`, SonarCloud treats the entire repository as source
+code (including test files, scripts, and configs), which skews quality metrics. These inputs
+map directly to `sonar.sources` and `sonar.tests` scanner properties.
+
+Alternatively, repos can configure these properties via a `sonar-project.properties` file in
+the repository root. Workflow inputs take precedence (they are passed as `-D` CLI flags).
+
 **Language scanner properties:**
 - Go: `sonar.go.coverage.reportPaths`
 - Python: `sonar.python.coverage.reportPaths`
@@ -164,6 +220,11 @@ jobs:
 - `coverage_artifact_name`: Name of the coverage artifact uploaded by the previous job (default: `coverage`)
 - `coverage_file_path`: Path to coverage file within the artifact (e.g., `coverage.out`, `coverage.xml`)
 - `language_scanner_property`: SonarCloud scanner property for coverage (see language-specific properties above)
+
+### Optional Inputs (for source/test scoping)
+
+- `sonar_sources`: Comma-separated list of source directories (e.g., `complyscribe/`, `pkg/`). Maps to `sonar.sources`.
+- `sonar_tests`: Comma-separated list of test directories (e.g., `tests/`). Maps to `sonar.tests`.
 
 ### Required Secrets
 

--- a/specs/002-sonarqube-workflow/spec.md
+++ b/specs/002-sonarqube-workflow/spec.md
@@ -29,6 +29,12 @@ The workflow supports multiple language ecosystems with language-specific covera
 
 **Test Coverage:** Ensures language-specific scanner properties (Go and Python) can be configured, and the workflow correctly passes these to the SonarCloud scanner action.
 
+### Priority 2: Source and Test Path Scoping
+
+Callers can specify which directories SonarCloud treats as source code vs. test code via `sonar_sources` and `sonar_tests` inputs. Without these, SonarCloud scans the entire repository as source code, inflating code smell counts, duplication metrics, and skewing coverage percentages.
+
+**Test Coverage:** Validates that source and test path inputs are correctly passed as `-Dsonar.sources` and `-Dsonar.tests` scanner arguments, and that omitting them does not change default behavior.
+
 ## Edge Cases Addressed
 
 - **Missing coverage files**: Workflow proceeds with analysis when coverage files are not provided
@@ -43,7 +49,7 @@ The specification mandates that the sonarqube workflow must:
 2. **Enforce quality gates**: Configure SonarCloud scanner to wait for and enforce quality gate results
 3. **Handle coverage reports**: Optionally process test coverage files with language-specific scanner properties
 4. **Maintain security**: Follow least-privilege principles with minimal required permissions
-5. **Provide flexible configuration**: Accept inputs for organization, project key, coverage paths, and scanner properties
+5. **Provide flexible configuration**: Accept inputs for organization, project key, coverage paths, scanner properties, and source/test directory scoping
 6. **Use pinned actions**: Reference all GitHub actions by commit SHA for supply chain security
 
 ## Success Metrics
@@ -63,6 +69,7 @@ Adoption success requires:
 - Coverage file integration with language-specific scanner properties
 - Quality gate enforcement
 - Multi-language support via configurable scanner properties
+- Source and test directory scoping via `sonar_sources` and `sonar_tests` inputs
 
 **Excluded:**
 - SonarCloud project creation and configuration (handled in SonarCloud UI)
@@ -70,3 +77,4 @@ Adoption success requires:
 - Language-specific build steps (handled by consumer workflows or separate processes)
 - Organization-level SonarCloud administration
 - Custom quality gate definitions (managed in SonarCloud)
+- Language-version properties (e.g., `sonar.python.version`) -- repos can set these via `sonar-project.properties`


### PR DESCRIPTION
## Summary

Add `sonar_sources` and `sonar_tests` optional inputs to `reusable_sonarqube.yml`, allowing callers to scope SonarCloud analysis to specific source and test directories. Without these inputs, SonarCloud treats the entire repository as source code (including test files, scripts, and configs), which skews quality metrics.

Also fixes a pre-existing quoting defect on the conditional coverage `-D` flag (line 87): when `coverage_file_path` is empty, the outer double quotes produced an empty-string argument (`""`) that `string-argv` (used by sonarqube-scan-action v8.2.0) parsed as a positional argument to sonar-scanner.

### Changes

| File | Change |
|---|---|
| `reusable_sonarqube.yml` | 2 new inputs, 2 env vars, 2 conditional `-D` flags, 1 quoting fix |
| `quickstart.md` | New usage example with source/test path scoping, updated config options |
| `spec.md` | New user scenario, updated functional requirements and scope boundaries |
| `openspec/changes/sonarcloud-source-test-inputs/` | Proposal, design, and task artifacts |

### Design Decisions

- **Option B (dedicated inputs) over Option A (generic `extra_args`)**: All 15 reusable workflows in the org use strictly explicit inputs (60 total inputs, zero free-form catch-alls). A generic `extra_args` would be an anti-pattern.
- **Excluded `sonar_language_version`**: `sonar.python.version` is the only language-version property currently relevant. Adding it creates a Python-specific parameter on a language-agnostic workflow. Repos needing it can use `sonar-project.properties` instead.
- **Quoting fix included**: The coverage line quoting defect is in the same `args` block being modified, and the same unquoted pattern is applied to the new inputs.

Full rationale is documented in `openspec/changes/sonarcloud-source-test-inputs/design.md`.

## Related Issues

- Closes #146

## Review Hints

- The workflow change is best reviewed by looking at the final state of `reusable_sonarqube.yml` (101 lines) rather than the diff -- the `args` block at lines 95-101 shows the complete pattern.
- All new inputs have empty-string defaults, so existing callers are completely unaffected.
- The `env:` indirection pattern (inputs -> env vars -> `${{ env.* }}` in args) matches the existing convention in this workflow and across the org for injection safety.
- No sync-config changes -- this workflow is called cross-repo via `uses:` and is not synced.