### PR TITLE
fix: add tag event metadata to container image workflow

### DIFF
--- a/.github/workflows/reusable_publish_ghcr.yml
+++ b/.github/workflows/reusable_publish_ghcr.yml
@@ -224,6 +224,7 @@ jobs:
             type=sha,format=long,prefix=${{ env.TAG_PREFIX }}sha-,priority=1000
             type=ref,event=branch,prefix=${{ env.TAG_PREFIX }}
             type=ref,event=pr,prefix=${{ env.TAG_PREFIX }}
+            type=ref,event=tag,prefix=${{ env.TAG_PREFIX }}
           flavor: |
             latest=false
           labels: |


### PR DESCRIPTION
## Summary

The reusable container publish workflow (`reusable_publish_ghcr.yml`) builds images on tag pushes (when the tag is protected), but the `docker/metadata-action` only generates `sha-*`, branch, and PR tags. Version tags like `v0.0.4` don't produce a matching container image tag.

## Problem

When complypack pushes a `v0.0.4` git tag, the container image is built but only tagged as:
- `sha-<commit>`
- `main`

Users expect `ghcr.io/complytime/complypack:v0.0.4` to exist after a release.

## Fix

Add `type=ref,event=tag` to the metadata-action tags configuration. This produces a container image tag matching the git tag (e.g., `v0.0.4`) when triggered by a tag push.

## Impact

All repositories using this reusable workflow will get versioned container image tags on tag pushes. No change to branch or PR behavior.

Assisted-by: OpenCode (Claude Opus 4)