### PR TITLE
feat(ci): add org-level linter config fallback to reusable CI workflow

### DIFF
--- a/.github/workflows/reusable_ci.yml
+++ b/.github/workflows/reusable_ci.yml
@@ -2,7 +2,10 @@
 name: Reusable CI
 
 # --------------------------------------------------------------------------
-# This workflow only runs when explicitly called by another workflow.
+# Reusable CI workflow: runs MegaLinter and PR title validation.
+# If linter config files are missing locally, fetches org defaults
+# from org-infra as a fallback. See sync-config.yml for the canonical
+# list of org-managed configs.
 # --------------------------------------------------------------------------
 on:
   workflow_call:
@@ -22,11 +25,68 @@ jobs:
       contents: read
       issues: read
       pull-requests: read
+    # Org-managed linter configs — single source of truth for fallback.
+    # Keep in sync with sync-config.yml when adding new config files.
+    env:
+      LINTER_CONFIGS: >-
+        .mega-linter.yml .golangci.yml .yamllint.yml
+        commitlint.config.js ruff.toml
     steps:
       - name: Checkout Code
         uses: actions/checkout@9c091bb21b7c1c1d1991bb908d89e4e9dddfe3e0 # v7.0.0
         with:
           persist-credentials: false
+
+      - name: Check local linter configs
+        id: check_configs
+        run: |
+          missing=""
+          for file in $LINTER_CONFIGS; do
+            if [ ! -f "$file" ]; then
+              missing="$missing $file"
+            fi
+          done
+          if [ -n "$missing" ]; then
+            echo "needs_fallback=true" >> "$GITHUB_OUTPUT"
+            echo "missing_files=$missing" >> "$GITHUB_OUTPUT"
+            echo "Missing configs:$missing — will fetch from org-infra"
+          else
+            echo "needs_fallback=false" >> "$GITHUB_OUTPUT"
+            echo "All linter configs present locally"
+          fi
+
+      - name: Checkout org-infra fallback configs
+        if: steps.check_configs.outputs.needs_fallback == 'true'
+        uses: actions/checkout@9c091bb21b7c1c1d1991bb908d89e4e9dddfe3e0 # v7.0.0
+        with:
+          repository: ${{ job.workflow_repository }}
+          ref: ${{ job.workflow_sha }}
+          path: .org-infra-fallback
+          sparse-checkout: |
+            .mega-linter.yml
+            .golangci.yml
+            .yamllint.yml
+            commitlint.config.js
+            ruff.toml
+          persist-credentials: false
+
+      - name: Copy missing configs from org-infra
+        if: steps.check_configs.outputs.needs_fallback == 'true'
+        env:
+          MISSING_FILES: ${{ steps.check_configs.outputs.missing_files }}
+          WORKFLOW_SHA: ${{ job.workflow_sha }}
+        run: |
+          fallback_dir=".org-infra-fallback"
+          echo "org-infra fallback ref: $WORKFLOW_SHA"
+          for file in $MISSING_FILES; do
+            if [ -f "$fallback_dir/$file" ]; then
+              cp "$fallback_dir/$file" "$file"
+              echo "Copied fallback: $file"
+            else
+              echo "::warning::Fallback config not found in org-infra: $file"
+            fi
+          done
+          rm -rf "$fallback_dir"
 
       - name: Install Dependencies
         if: ${{ github.event_name == 'pull_request' && github.event.pull_request.user.login != 'dependabot[bot]' }}


### PR DESCRIPTION
## Summary

The reusable CI workflow (`reusable_ci.yml`) runs MegaLinter but relies on
linter config files being present in the calling repo. When a repo lacks its
own configs (e.g., new repos or repos where the sync PR hasn't been merged),
MegaLinter falls back to its built-in defaults, enabling all 100+ linters and
producing a flood of irrelevant errors.

This PR adds a fallback mechanism: the workflow checks for local config files
and, if any are missing, fetches org defaults from org-infra. Local configs
always take precedence.

### Changes

| File | Change |
|---|---|
| `reusable_ci.yml` | 3 new steps: check local configs, checkout org-infra fallback, copy missing files |

### Design Decisions

- **Fallback only, never overwrite**: repos with their own config files see
  zero change in behavior. The org-infra configs are only used when a file is
  missing locally.
- **`actions/checkout` over raw `git clone`**: follows the established pattern
  from `reusable_crapload_analysis.yml` — authenticated via the workflow token,
  version-pinned to `job.workflow_sha`, no hardcoded URLs.
- **Step output via `env:` not `${{ }}`**: the `missing_files` output is passed
  through an environment variable to avoid script injection in the `run:` block.
- **Job-level `LINTER_CONFIGS` env var**: single source of truth for the file
  list, referenced by the check step. The `sparse-checkout` list in the
  `actions/checkout` step must be literal YAML but is documented as needing to
  stay in sync.
- **Configs covered**: `.mega-linter.yml`, `.golangci.yml`, `.yamllint.yml`,
  `commitlint.config.js`, `ruff.toml`.

## Related Issues

- Closes #153

## Review Hints

- Best reviewed by looking at the final state of `reusable_ci.yml` (108 lines)
  rather than the diff — the three new steps (lines 40–86) form a
  self-contained block between "Checkout Code" and "Install Dependencies".
- The conditional checkout is skipped entirely when all configs exist locally,
  so repos that already have synced configs pay no performance cost.
- No sync-config changes — the existing file sync mechanism and this runtime
  fallback serve complementary purposes (proactive distribution vs. safety net).
- No new workflow inputs or permissions changes — fully backward compatible.