### PR TITLE
feat(vuln-scan): expose trivyignore file path input in reusable workflow

### DIFF
--- a/.github/workflows/ci_security.yml
+++ b/.github/workflows/ci_security.yml
@@ -26,6 +26,7 @@ jobs:
     with:
       # OSV focuses on known CVEs in dependencies; Trivy adds broader coverage
       enable_trivy_source: true
+      trivy_ignorefile: ''
 
   call_reusable_security:
     name: OpenSSF Scorecards

--- a/.github/workflows/reusable_vuln_scan.yml
+++ b/.github/workflows/reusable_vuln_scan.yml
@@ -24,6 +24,10 @@ on:
         description: 'Severity levels to report'
         type: string
         default: 'HIGH,CRITICAL'
+      trivy_ignorefile:
+        description: 'Path to .trivyignore or .trivyignore.yaml for scoped exclusions'
+        type: string
+        default: ''
 
 permissions:
   contents: none
@@ -71,6 +75,7 @@ jobs:
           scan-type: 'fs'
           scanners: 'secret,misconfig'
           severity: ${{ inputs.trivy_severity }}
+          trivyignores: ${{ inputs.trivy_ignorefile }}
           ignore-unfixed: true
           format: 'sarif'
           output: 'trivy-source-scan-${{ github.workflow_sha }}-${{ github.run_number }}.sarif'

--- a/sync-config.yml
+++ b/sync-config.yml
@@ -45,6 +45,10 @@ files_to_sync:
           complytime: "true"
           complytime-providers: "true"
           complytime-collector-components: "true"
+      trivy_ignorefile:
+        default: "''"
+        repos:
+          complytime-providers: "'.trivyignore.yaml'"
 
   - source: .github/workflows/ci_crapload.yml
     destination: .github/workflows/ci_crapload.yml


### PR DESCRIPTION
## Summary

Add an optional `trivy_ignorefile` input to `reusable_vuln_scan.yml` so consuming repositories can provide a `.trivyignore` or `.trivyignore.yaml` file for per-path scoped exclusions. This unblocks CI for repositories that encounter Trivy false positives in vendored or third-party code.

Changes:
- **`reusable_vuln_scan.yml`**: New `trivy_ignorefile` input (string, default `''`) wired to the `trivyignores` parameter of `aquasecurity/trivy-action`.
- **`ci_security.yml`**: Pass `trivy_ignorefile` through to the reusable workflow.
- **`sync-config.yml`**: Add `trivy_ignorefile` var with default `''` and per-repo override `'.trivyignore.yaml'` for `complytime-providers`.

The change is additive and backward-compatible -- the default is empty, so existing behavior is unchanged for all repos.

## Related Issues

- Closes #312

## Review Hints

- The `trivyignores` parameter on `aquasecurity/trivy-action` is guarded by `[ -n "${INPUT_TRIVYIGNORES:-}" ]` in the entrypoint script, so an empty string is functionally identical to not setting the input.
- `make sync-dry-run` was run to verify var substitution. `complytime-providers` correctly receives `trivy_ignorefile='.trivyignore.yaml'`; all other repos receive `trivy_ignorefile=''`.
- The `Warning: var 'trivy_ignorefile' not found in file content` warnings during dry-run are expected -- downstream repos don't have the line yet. The warnings resolve after the first sync pushes the updated `ci_security.yml`.
- The `complytime-providers` repo will still need a `.trivyignore.yaml` file created in its own repository to actually suppress the findings from [complytime-providers#42](https://github.com/complytime/complytime-providers/pull/42).
▣  Build · Claude Opus 4.6 · 5.8s