### PR TITLE
chore: improve Renovate config with autodiscover and job summary

### DIFF
--- a/.github/workflows/ci_renovate.yml
+++ b/.github/workflows/ci_renovate.yml
@@ -67,6 +67,72 @@ jobs:
           RENOVATE_REPORT_TYPE: file
           RENOVATE_REPORT_PATH: /tmp/renovate-report.json
 
+      - name: Generate job summary
+        if: always() && hashFiles('/tmp/renovate-report.json') != ''
+        shell: bash
+        run: |
+          REPORT="/tmp/renovate-report.json"
+          DRY_RUN="${{ inputs.dry_run }}"
+
+          {
+            echo "## Renovate Run Summary"
+            echo ""
+            if [ -n "$DRY_RUN" ] && [ "$DRY_RUN" != "none" ]; then
+              echo "> **Mode:** dry-run (\`${DRY_RUN}\`) — no changes were made"
+              echo ""
+            fi
+
+            # --- Repository overview table ---
+            echo "### Repositories"
+            echo ""
+            echo "| Repository | Go Version | Deps | PRs | Status |"
+            echo "|:-----------|:-----------|-----:|----:|:-------|"
+
+            jq -r '
+              .repositories | to_entries[] |
+              (.value.packageFiles.gomod // []) as $gomod |
+              ([($gomod[]?.deps // [])[] | select(.depName == "go" and .depType == "golang") | .currentValue] | unique | join(", ")) as $versions |
+              ([($gomod[]?.deps // []) | length] | add // 0) as $deps |
+              (.value.branches | length) as $prs |
+              (if $prs > 0 then "\u26a0\ufe0f Updates"
+               elif ($gomod | length) == 0 then "Skipped (no go.mod)"
+               else "\u2705 Up to date"
+               end) as $status |
+              "| \(.key) | \(if $versions == "" then "-" else $versions end) | \($deps) | \($prs) | \($status) |"
+            ' "$REPORT"
+
+            # --- PRs created/updated ---
+            PR_COUNT=$(jq '[.repositories[].branches[]] | length' "$REPORT")
+            if [ "$PR_COUNT" -gt 0 ]; then
+              echo ""
+              echo "### Pull Requests"
+              echo ""
+              echo "| Repository | Branch | Update | From | To |"
+              echo "|:-----------|:-------|:-------|:-----|:---|"
+
+              jq -r '
+                .repositories | to_entries[] |
+                .key as $repo |
+                .value.branches[]? |
+                .branchName as $branch |
+                (.upgrades // [])[] |
+                "| \($repo) | \($branch) | \(.depName // .packageName // "-") | \(.currentVersion // .currentValue // "-") | \(.newVersion // .newValue // "-") |"
+              ' "$REPORT"
+            fi
+
+            # --- Problems ---
+            PROBLEM_COUNT=$(jq '[.problems[], .repositories[].problems[]] | length' "$REPORT")
+            if [ "$PROBLEM_COUNT" -gt 0 ]; then
+              echo ""
+              echo "### Warnings"
+              echo ""
+              jq -r '
+                [.repositories | to_entries[] | .key as $repo | .value.problems[] | "\($repo): \(.msg)"] |
+                unique[] | "- \(.)"
+              ' "$REPORT"
+            fi
+          } >> "$GITHUB_STEP_SUMMARY"
+
       - name: Upload Renovate report
         if: always()
         uses: actions/upload-artifact@043fb46d1a93c77aae656e7c1c64a875d1fc6a0a # v7.0.1

--- a/.github/workflows/ci_renovate.yml
+++ b/.github/workflows/ci_renovate.yml
@@ -68,10 +68,14 @@ jobs:
           RENOVATE_REPORT_PATH: /tmp/renovate-report.json
 
       - name: Generate job summary
-        if: always() && hashFiles('/tmp/renovate-report.json') != ''
+        if: always()
         shell: bash
         run: |
           REPORT="/tmp/renovate-report.json"
+          if [ ! -f "$REPORT" ]; then
+            echo "No Renovate report found; skipping summary."
+            exit 0
+          fi
           DRY_RUN="${{ inputs.dry_run }}"
 
           {

--- a/renovate-config.js
+++ b/renovate-config.js
@@ -6,12 +6,8 @@ module.exports = {
   platform: 'github',
   onboarding: false,
   requireConfig: 'optional',
-  repositories: [
-    'complytime/complyctl',
-    'complytime/complytime',
-    'complytime/complytime-providers',
-    'complytime/complytime-collector-components',
-  ],
+  autodiscover: true,
+  autodiscoverFilter: ['complytime/*'],
   globalExtends: [
     'github>complytime/org-infra:go-toolchain-patches',
   ],


### PR DESCRIPTION
## Summary

Two improvements to the centralized Renovate workflow:

1. **Replace static repo list with autodiscover** — new Go repos are
   automatically picked up when `complytime-renovate[bot]` is installed
   on them, removing the need for maintainers to update the config file.
2. **Add a job summary** — parse the Renovate JSON report to generate a
   readable summary in the Actions UI showing repos, Go versions,
   dependency counts, PRs created, and warnings.

## Changes

### `renovate-config.js`
- Remove the static `repositories` array (which also referenced the
  doc-only `complytime/complytime` repo with no Go deps).
- Add `autodiscover: true` with `autodiscoverFilter: ['complytime/*']`.
- Scope is controlled by the GitHub App installation — Renovate can only
  access repos where `complytime-renovate[bot]` is installed.

### `.github/workflows/ci_renovate.yml`
- Add a "Generate job summary" step that parses `/tmp/renovate-report.json`
  and writes a markdown summary to `$GITHUB_STEP_SUMMARY` with:
  - Per-repo table (Go version, dep count, PR count, status)
  - PR details table when updates exist (branch, dep, old/new version)
  - Deduplicated warnings section

## Example summary output

| Repository | Go Version | Deps | PRs | Status |
|:-----------|:-----------|-----:|----:|:-------|
| complytime/complyctl | 1.25.11 | 121 | 0 | Up to date |
| complytime/complytime-providers | 1.25.11 | 29 | 0 | Up to date |
| complytime/complytime-collector-components | 1.26.4 | 145 | 0 | Up to date |

## Checklist

- [ ] Install `complytime-renovate[bot]` on `.github` and `website` repos
- [ ] Verify with a `workflow_dispatch` dry-run after merge