### PR TITLE
fix(workflows): rename compliance artifact names for clarity

### DIFF
--- a/.github/workflows/reusable_compliance.yml
+++ b/.github/workflows/reusable_compliance.yml
@@ -193,7 +193,7 @@ jobs:
                       print(f"| {name} | {STATUS.get(r, '❓')} {r} | {msg} |")
                   print()
 
-              print("> Full details in the `gemara-evaluation-log` artifact.")
+              print("> Full details in the `gemara-evaluation-logs` artifact.")
               print()
           PYEOF
 
@@ -253,7 +253,7 @@ jobs:
         if: always()
         uses: actions/upload-artifact@043fb46d1a93c77aae656e7c1c64a875d1fc6a0a # v7.0.1
         with:
-          name: report-policies-ampel-branch-protection.md
+          name: compliance-scan-reports
           path: report-*.md
           if-no-files-found: warn
 
@@ -261,7 +261,7 @@ jobs:
         if: always()
         uses: actions/upload-artifact@043fb46d1a93c77aae656e7c1c64a875d1fc6a0a # v7.0.1
         with:
-          name: ampel.intoto.json
+          name: ampel-intoto-attestations
           path: .complytime/ampel/results/*-ampel.intoto.json
           if-no-files-found: warn
 
@@ -269,7 +269,7 @@ jobs:
         if: always()
         uses: actions/upload-artifact@043fb46d1a93c77aae656e7c1c64a875d1fc6a0a # v7.0.1
         with:
-          name: snappy.intoto.json
+          name: snappy-intoto-attestations
           path: .complytime/ampel/results/*-snappy.intoto.json
           if-no-files-found: warn
 
@@ -277,7 +277,7 @@ jobs:
         if: always()
         uses: actions/upload-artifact@043fb46d1a93c77aae656e7c1c64a875d1fc6a0a # v7.0.1
         with:
-          name: gemara-evaluation-log
+          name: gemara-evaluation-logs
           path: .complytime/scan/evaluation-log-*.yaml
           if-no-files-found: warn
 


### PR DESCRIPTION
## Summary

Artifact names in `reusable_compliance.yml` used single-file conventions (`.json`, `.md` extensions or singular nouns) but each artifact bundles multiple files via glob patterns. This is misleading when downloading and unzipping the artifacts.

## Changes

Renamed to plural, descriptive names without file extensions:

| Old name | New name |
|---|---|
| `report-policies-ampel-branch-protection.md` | `compliance-scan-reports` |
| `ampel.intoto.json` | `ampel-intoto-attestations` |
| `snappy.intoto.json` | `snappy-intoto-attestations` |
| `gemara-evaluation-log` | `gemara-evaluation-logs` |

Updated the Step Summary reference to match the new `gemara-evaluation-logs` artifact name.

## Validation

- `make lint` passes (yamllint + ruff)
- No sync-config.yml impact (reusable workflow is not synced to other repos)

## Related

- complytime/complyctl#697 — upstream issue to make the Markdown report suitable for direct use as CI Step Summary