### PR TITLE
chore: remove stale truthbeam references after collector-components#328

### DIFF
--- a/.github/workflows/reusable_publish_ghcr.yml
+++ b/.github/workflows/reusable_publish_ghcr.yml
@@ -36,7 +36,7 @@ on:
   workflow_call:
     inputs:
       component_name:
-        description: "Component name (e.g., compass, beacon-distro)"
+        description: "Component name (e.g., proofwatch, beacon-distro)"
         required: true
         type: string
       containerfile_path:

--- a/openspec/changes/go-toolchain-patch-automation/tasks.md
+++ b/openspec/changes/go-toolchain-patch-automation/tasks.md
@@ -76,11 +76,9 @@
     patch-only filtering).
   - PR metadata shows conventional commit prefix and
     `dependencies` label (covers: PR metadata scenario).
-- [ ] 5.5 Verify multi-module support: confirm the dry-run output
-  from task 5.4 shows Renovate discovering `go.mod` files in
-  `complytime-collector-components/proofwatch/` and
-  `complytime-collector-components/truthbeam/` subdirectories
-  independently.
+- [ ] 5.5 Verify single-module discovery: confirm the dry-run output
+  from task 5.4 shows Renovate discovering the `go.mod` file in
+  `complytime-collector-components/proofwatch/` subdirectory.
 - [ ] 5.6 Create a test fixture for live validation: a minimal
   repo (or fork) with an outdated `toolchain` directive in
   `go.mod`. Create two variants:

--- a/sync-config.yml
+++ b/sync-config.yml
@@ -171,7 +171,6 @@ dependabot:
       - package-ecosystem: "gomod"
         directories:
           - "/proofwatch"
-          - "/truthbeam"
         schedule:
           interval: "weekly"
         open-pull-requests-limit: 10


### PR DESCRIPTION
The TruthBeam enrichment processor was removed from
complytime-collector-components in PR #328. Remove stale references:

- sync-config.yml: drop /truthbeam from dependabot overrides to prevent
  the next sync cycle from re-introducing the entry downstream
- tasks.md: update go-toolchain validation task 5.5 to reflect
  single-module (proofwatch-only) workspace
- reusable_publish_ghcr.yml: replace stale compass example with
  proofwatch in component_name input description

Closes #393

Assisted-by: Claude Code (claude-opus-4-6)
Signed-off-by: Trevor Vaughan <tvaughan@redhat.com>
