### PR TITLE
fix: replace BSD-incompatible paste with portable tr

### DIFF
--- a/.github/workflows/reusable_crapload_analysis.yml
+++ b/.github/workflows/reusable_crapload_analysis.yml
@@ -104,7 +104,7 @@ jobs:
             echo "No Go files changed in this PR."
             exit 0
           fi
-          PACKAGES=$(echo "$CHANGED_FILES" | xargs -I{} dirname {} | grep -v '/vendor/' | grep -v '^vendor' | sort -u | sed 's|^|./|' | paste -sd ' ')
+          PACKAGES=$(echo "$CHANGED_FILES" | xargs -I{} dirname {} | grep -v '/vendor/' | grep -v '^vendor' | sort -u | sed 's|^|./|' | tr '\n' ' ' | sed 's/ $//')
           echo "has_changes=true" >> "$GITHUB_OUTPUT"
           echo "packages=$PACKAGES" >> "$GITHUB_OUTPUT"
           echo "Changed packages: $PACKAGES"

--- a/scripts/resolve-go-packages.sh
+++ b/scripts/resolve-go-packages.sh
@@ -47,7 +47,7 @@ if [[ "$INPUT_PKGS" = "./..." ]]; then
 		MODULE_COUNT=$(echo "$DISCOVERED" | grep -c .)
 		echo "Found $MODULE_COUNT module(s)" >&2
 
-		DISCOVERED=$(echo "$DISCOVERED" | paste -sd ' ')
+		DISCOVERED=$(echo "$DISCOVERED" | tr '\n' ' ' | sed 's/ $//')
 		echo "$DISCOVERED"
 		echo "Auto-discovered packages: $DISCOVERED" >&2
 		echo "::notice::Analyzing all discovered modules. To analyze specific modules, set the 'packages' workflow input." >&2


### PR DESCRIPTION
## Summary

Fixes #403 — resolves 3 test failures on macOS caused by BSD `paste` incompatibility.

## Problem

`scripts/resolve-go-packages.sh` and `reusable_crapload_analysis.yml` use `paste -sd ' '` to join newline-separated output into a single space-delimited line. BSD `paste` (macOS) has different flag semantics than GNU `paste` (Linux), causing:

usage: paste -s -d delimiters file ...

This breaks 3 tests on macOS:
- `test_multi_module_repo`
- `test_go_workspace`
- `test_malformed_go_mod`

CI (ubuntu-latest) was unaffected since it uses GNU coreutils.

## Fix

Replaced `paste -sd ' '` with `tr '\n' ' ' | sed 's/ $//'` at both locations. `tr` and `sed` are POSIX-compliant and behave identically on GNU and BSD systems. The trailing `sed` strips the extra space that `tr` leaves at the end.

## Changes

| File | Line | Before | After |
|:-----|:-----|:-------|:------|
| `scripts/resolve-go-packages.sh` | 50 | `paste -sd ' '` | `tr '\n' ' ' \| sed 's/ $//'` |
| `.github/workflows/reusable_crapload_analysis.yml` | 107 | `paste -sd ' '` | `tr '\n' ' ' \| sed 's/ $//'` |

## Verification

- `make test` — 101/101 passed
- `make lint` — clean