### PR TITLE
test(ci): council review workflow evidence

### DIFF
--- a/.github/workflows/ci_council_review.yml
+++ b/.github/workflows/ci_council_review.yml
@@ -1,0 +1,44 @@
+---
+name: Council Review
+
+# --------------------------------------------------------------------------
+# Thin consumer workflow for AI council review. Triggered by workflow_run
+# when the collect workflow completes (fork PR support), or manually via
+# workflow_dispatch. Delegates all review logic to reusable_council_review.yml.
+# --------------------------------------------------------------------------
+on:
+  workflow_dispatch:
+    inputs:
+      triggering_run_id:
+        description: >-
+          Run ID of the collect workflow (for artifact download).
+          Required for manual testing.
+        required: true
+        type: number
+  workflow_run:  # zizmor: ignore[dangerous-triggers]
+    workflows: ["Council Review - Collect"]
+    types: [completed]
+
+concurrency:
+  group: council-review-${{ github.event.workflow_run.head_sha || github.run_id }}
+  cancel-in-progress: true
+
+permissions: {}
+
+jobs:
+  council-review:
+    name: AI Council Review
+    if: >-
+      github.event_name == 'workflow_dispatch' ||
+      github.event.workflow_run.conclusion == 'success'
+    uses: complytime/org-infra/.github/workflows/reusable_council_review.yml@test/council-review-evidence-v2  # zizmor: ignore[unpinned-uses] — temporary: switch to @main after merge
+    permissions:
+      contents: read
+      id-token: write
+      pull-requests: write
+      actions: read
+    with:
+      triggering-run-id: ${{ github.event.inputs.triggering_run_id || github.event.workflow_run.id }}
+    secrets:
+      GCP_WORKLOAD_IDENTITY_PROVIDER: ${{ secrets.GCP_WORKLOAD_IDENTITY_PROVIDER }}
+      GCP_PROJECT_ID: ${{ secrets.GCP_PROJECT_ID }}

--- a/.github/workflows/ci_council_review_collect.yml
+++ b/.github/workflows/ci_council_review_collect.yml
@@ -1,0 +1,83 @@
+---
+name: Council Review - Collect
+
+# --------------------------------------------------------------------------
+# Fork-safe PR diff collection for AI council review. Runs on pull_request
+# (no secrets needed), collects the PR diff and metadata, then uploads as
+# an artifact for ci_council_review.yml to pick up via workflow_run.
+# --------------------------------------------------------------------------
+on:
+  pull_request:
+    types: [opened, synchronize, reopened, ready_for_review]
+    branches: [main]
+
+permissions: {}
+
+jobs:
+  gate-check:
+    name: Gate Check
+    runs-on: ubuntu-latest
+    permissions:
+      contents: read
+    outputs:
+      should_collect: ${{ steps.gate.outputs.should_collect }}
+    steps:
+      - name: Evaluate gate conditions
+        id: gate
+        env:
+          PR_AUTHOR: ${{ github.event.pull_request.user.login }}
+          PR_DRAFT: ${{ github.event.pull_request.draft }}
+        run: |
+          if [[ "${PR_DRAFT}" == "true" ]]; then
+            echo "::notice::Draft PR — skipping council review"
+            echo "should_collect=false" >> "$GITHUB_OUTPUT"
+            exit 0
+          fi
+          if [[ "${PR_AUTHOR}" == "dependabot[bot]" ]]; then
+            echo "::notice::Dependabot PR — skipping council review"
+            echo "should_collect=false" >> "$GITHUB_OUTPUT"
+            exit 0
+          fi
+          echo "should_collect=true" >> "$GITHUB_OUTPUT"
+
+  collect-diff:
+    name: Collect PR Diff
+    needs: gate-check
+    if: needs.gate-check.outputs.should_collect == 'true'
+    runs-on: ubuntu-latest
+    permissions:
+      contents: read
+      pull-requests: read
+    steps:
+      - name: Collect PR diff
+        env:
+          GH_TOKEN: ${{ github.token }}
+          PR_NUMBER: ${{ github.event.pull_request.number }}
+        run: |
+          gh pr diff "${PR_NUMBER}" \
+            --repo "${{ github.repository }}" > pr-diff.patch
+
+      - name: Write PR metadata
+        env:
+          PR_NUMBER: ${{ github.event.pull_request.number }}
+          PR_HEAD_SHA: ${{ github.event.pull_request.head.sha }}
+          PR_BASE_REF: ${{ github.event.pull_request.base.ref }}
+          PR_TITLE: ${{ github.event.pull_request.title }}
+        run: |
+          jq -n \
+            --arg number "${PR_NUMBER}" \
+            --arg head_sha "${PR_HEAD_SHA}" \
+            --arg base_ref "${PR_BASE_REF}" \
+            --arg title "${PR_TITLE}" \
+            --arg repo "${{ github.repository }}" \
+            '{number: $number, head_sha: $head_sha, base_ref: $base_ref, title: $title, repo: $repo}' \
+            > pr-meta.json
+
+      - name: Upload diff artifact
+        uses: actions/upload-artifact@043fb46d1a93c77aae656e7c1c64a875d1fc6a0a # v7.0.1
+        with:
+          name: council-review-diff
+          path: |
+            pr-diff.patch
+            pr-meta.json
+          retention-days: 1

--- a/.github/workflows/reusable_council_review.yml
+++ b/.github/workflows/reusable_council_review.yml
@@ -1,0 +1,206 @@
+---
+name: Reusable Council Review
+
+# --------------------------------------------------------------------------
+# Reusable workflow for AI council review using OpenCode on Vertex AI via
+# WIF authentication. Downloads the PR diff artifact, authenticates to GCP,
+# delegates review to the council-review-action composite action, and posts
+# inline review comments on the PR.
+#
+# Called by ci_council_review.yml (consumer workflow).
+# --------------------------------------------------------------------------
+on:
+  workflow_call:
+    inputs:
+      triggering-run-id:
+        description: Run ID of the collect workflow (for artifact download)
+        required: true
+        type: string
+      model:
+        description: Model ID for the AI review
+        required: false
+        type: string
+        default: "google-vertex-anthropic/claude-sonnet-4-6"
+    secrets:
+      GCP_WORKLOAD_IDENTITY_PROVIDER:
+        required: false
+      GCP_PROJECT_ID:
+        required: false
+
+permissions: {}
+
+jobs:
+  review:
+    name: Council Review
+    runs-on: ubuntu-latest
+    permissions:
+      contents: read
+      id-token: write
+      pull-requests: write
+      actions: read
+    env:
+      VERTEX_LOCATION: global
+    steps:
+      - name: Check WIF credentials
+        id: gate
+        env:
+          HAS_WIF: ${{ secrets.GCP_WORKLOAD_IDENTITY_PROVIDER != '' }}
+        run: |
+          if [[ "${HAS_WIF}" != "true" ]]; then
+            echo "::notice::No WIF credentials — skipping council review"
+            echo "should_review=false" >> "$GITHUB_OUTPUT"
+            exit 0
+          fi
+          echo "should_review=true" >> "$GITHUB_OUTPUT"
+
+      - name: Checkout
+        if: steps.gate.outputs.should_review == 'true'
+        uses: actions/checkout@df4cb1c069e1874edd31b4311f1884172cec0e10 # v6.0.3
+        with:
+          persist-credentials: false
+
+      - name: Download diff artifact
+        if: steps.gate.outputs.should_review == 'true'
+        uses: actions/download-artifact@3e5f45b2cfb9172054b4087a40e8e0b5a5461e7c # v8.0.1
+        with:
+          name: council-review-diff
+          run-id: ${{ inputs.triggering-run-id }}
+          github-token: ${{ github.token }}
+
+      - name: Extract PR metadata
+        if: steps.gate.outputs.should_review == 'true'
+        id: meta
+        run: |
+          PR_NUMBER=$(jq -r '.number' pr-meta.json)
+          PR_HEAD_SHA=$(jq -r '.head_sha' pr-meta.json)
+          {
+            echo "pr_number=${PR_NUMBER}"
+            echo "pr_head_sha=${PR_HEAD_SHA}"
+          } >> "$GITHUB_OUTPUT"
+
+      - name: Authenticate to Google Cloud (WIF)
+        if: steps.gate.outputs.should_review == 'true'
+        uses: google-github-actions/auth@7c6bc770dae815cd3e89ee6cdf493a5fab2cc093 # v3.0.0
+        with:
+          project_id: ${{ secrets.GCP_PROJECT_ID }}
+          workload_identity_provider: ${{ secrets.GCP_WORKLOAD_IDENTITY_PROVIDER }}
+
+      - name: Set up gcloud CLI
+        if: steps.gate.outputs.should_review == 'true'
+        uses: google-github-actions/setup-gcloud@aa5489c8933f4cc7a4f7d45035b3b1440c9c10db # v3.0.1
+
+      # TODO: remove continue-on-error once council review is stable
+      - name: Run council review
+        if: steps.gate.outputs.should_review == 'true'
+        id: review
+        continue-on-error: true
+        uses: unbound-force/unbound-force/council-review-action@ce19a177e2bf0a4db06008c34db37e3704df3fbd  # feat/council-review-action
+        with:
+          model: ${{ inputs.model }}
+          diff-path: pr-diff.patch
+          meta-path: pr-meta.json
+          github-token: ${{ github.token }}
+
+      - name: Clean up previous bot comments
+        if: steps.gate.outputs.should_review == 'true'
+        env:
+          GH_TOKEN: ${{ github.token }}
+          PR_NUMBER: ${{ steps.meta.outputs.pr_number }}
+          REPO: ${{ github.repository }}
+        run: |
+          gh api "repos/${REPO}/issues/${PR_NUMBER}/comments" \
+            --paginate --jq '.[] | select(.body | contains("<!-- council-review-bot -->")) | .id' | \
+          while read -r cid; do
+            [[ -n "${cid}" ]] && gh api "repos/${REPO}/issues/comments/${cid}" --method DELETE || true
+          done
+
+          gh api "repos/${REPO}/pulls/${PR_NUMBER}/comments" \
+            --paginate --jq '.[] | select(.body | contains("<!-- council-review-bot -->")) | .id' | \
+          while read -r cid; do
+            [[ -n "${cid}" ]] && gh api "repos/${REPO}/pulls/comments/${cid}" --method DELETE || true
+          done
+
+          gh api "repos/${REPO}/pulls/${PR_NUMBER}/reviews" \
+            --paginate --jq '.[] | select(.user.login == "github-actions[bot]" and ((.body | contains("council-review-bot")) or (.body | contains("council-review-bot-inline")))) | .node_id' | \
+          while read -r nid; do
+            [[ -n "${nid}" ]] && gh api graphql -f query="mutation { minimizeComment(input: {subjectId: \"${nid}\", classifier: OUTDATED}) { minimizedComment { isMinimized } } }" || true
+          done
+
+      - name: Post review summary
+        if: >-
+          steps.gate.outputs.should_review == 'true' &&
+          steps.review.outcome == 'success'
+        env:
+          GH_TOKEN: ${{ github.token }}
+          PR_NUMBER: ${{ steps.meta.outputs.pr_number }}
+          PR_HEAD_SHA: ${{ steps.meta.outputs.pr_head_sha }}
+          MODEL: ${{ inputs.model }}
+          REPO: ${{ github.repository }}
+          REVIEW_JSON: ${{ steps.review.outputs.review-json }}
+          REVIEW_MODE: ${{ steps.review.outputs.review-mode }}
+        run: |
+          COMMENT_COUNT=0
+          if [[ "${REVIEW_MODE}" == "inline" ]]; then
+            COMMENT_COUNT=$(jq '.inline_comments | length' "${REVIEW_JSON}")
+          fi
+
+          {
+            echo "<!-- council-review-bot -->"
+            echo "## AI Council Review"
+            echo ""
+            if [[ -s "${REVIEW_JSON}" ]]; then
+              jq -r '.summary' "${REVIEW_JSON}"
+            else
+              echo "_Council review produced no output._"
+            fi
+            echo ""
+            echo "---"
+            if [[ "${COMMENT_COUNT}" -gt 0 ]]; then
+              echo "_Model: \`${MODEL}\` | Commit: \`${PR_HEAD_SHA:0:7}\` | Inline comments: ${COMMENT_COUNT}_"
+            else
+              echo "_Model: \`${MODEL}\` | Commit: \`${PR_HEAD_SHA:0:7}\`_"
+            fi
+          } > review_summary.txt
+          gh pr comment "${PR_NUMBER}" --repo "${REPO}" --body-file review_summary.txt
+
+      - name: Post inline comments
+        if: >-
+          steps.gate.outputs.should_review == 'true' &&
+          steps.review.outcome == 'success' &&
+          steps.review.outputs.review-mode == 'inline'
+        env:
+          GH_TOKEN: ${{ github.token }}
+          PR_NUMBER: ${{ steps.meta.outputs.pr_number }}
+          PR_HEAD_SHA: ${{ steps.meta.outputs.pr_head_sha }}
+          REPO: ${{ github.repository }}
+          REVIEW_JSON: ${{ steps.review.outputs.review-json }}
+        run: |
+          COMMENT_COUNT=$(jq '.inline_comments | length' "${REVIEW_JSON}")
+          if [[ "${COMMENT_COUNT}" -eq 0 ]]; then
+            echo "::notice::No inline comments to post"
+            exit 0
+          fi
+
+          POSTED=0
+          FAILED=0
+          while IFS= read -r comment; do
+            path=$(echo "${comment}" | jq -r '.path')
+            line=$(echo "${comment}" | jq -r '.line')
+            body=$(echo "${comment}" | jq -r '.body')
+            tagged_body="<!-- council-review-bot -->${body}"
+
+            if jq -n \
+              --arg commit_id "${PR_HEAD_SHA}" \
+              --arg path "${path}" \
+              --argjson line "${line}" \
+              --arg side "RIGHT" \
+              --arg body "${tagged_body}" \
+              '{commit_id: $commit_id, path: $path, line: $line, side: $side, body: $body}' | \
+            gh api "repos/${REPO}/pulls/${PR_NUMBER}/comments" \
+              --method POST --input - > /dev/null 2>&1; then
+              POSTED=$((POSTED + 1))
+            else
+              FAILED=$((FAILED + 1))
+            fi
+          done < <(jq -c '.inline_comments[]' "${REVIEW_JSON}")
+          echo "::notice::Posted ${POSTED} inline comments (${FAILED} failed)"

--- a/scripts/generate-crapload-comment.sh
+++ b/scripts/generate-crapload-comment.sh
@@ -28,6 +28,7 @@ set -euo pipefail
 CRAP_JSON="${1:-/tmp/crapload-current.json}"
 REPORT_JSON="${2:-/tmp/gaze-report.json}"
 COMMENT_FILE="/tmp/crapload-comment-body.md"
+MAX_COMMENT_SIZE="${MAX_COMMENT_SIZE:-65536}"
 
 # Extract summary metrics from gaze crap JSON.
 TOTAL_FUNCS=$(jq -r '.summary.total_functions // 0' "$CRAP_JSON")
@@ -196,3 +197,16 @@ fi
 # Add footer.
 printf '\n[View full analysis logs](%s/%s/actions/runs/%s)\n' \
 	"$GITHUB_SERVER_URL" "$GITHUB_REPOSITORY" "$GITHUB_RUN_ID" >>"$COMMENT_FILE"
+
+# Truncate if comment exceeds GitHub's character limit.
+# Reserve space for the trailer so the final file stays within the limit.
+TRAILER_RESERVE=120
+TRUNCATE_AT=$((MAX_COMMENT_SIZE - TRAILER_RESERVE))
+
+COMMENT_SIZE=$(wc -c < "$COMMENT_FILE")
+if [ "$COMMENT_SIZE" -gt "$MAX_COMMENT_SIZE" ]; then
+	head -c "$TRUNCATE_AT" "$COMMENT_FILE" > "${COMMENT_FILE}.tmp"
+	printf '\n\n---\n_Comment truncated (%s bytes, limit %s). See full logs above._\n' \
+		"$COMMENT_SIZE" "$MAX_COMMENT_SIZE" >> "${COMMENT_FILE}.tmp"
+	mv "${COMMENT_FILE}.tmp" "$COMMENT_FILE"
+fi

--- a/sync-config.yml
+++ b/sync-config.yml
@@ -50,6 +50,22 @@ files_to_sync:
         repos:
           complytime-providers: "'.trivyignore.yaml'"
 
+  - source: .github/workflows/ci_council_review_collect.yml
+    destination: .github/workflows/ci_council_review_collect.yml
+    exclude_repos:
+      - .github
+      - community
+
+  - source: .github/workflows/ci_council_review.yml
+    destination: .github/workflows/ci_council_review.yml
+    exclude_repos:
+      - .github
+      - community
+
+  # NOTE: reusable_council_review.yml is intentionally NOT synced.
+  # It stays in org-infra and is called cross-repo by downstream
+  # consumers via: complytime/org-infra/.github/workflows/reusable_council_review.yml@SHA
+
   - source: .github/workflows/ci_crapload.yml
     destination: .github/workflows/ci_crapload.yml
     exclude_repos:


### PR DESCRIPTION
## Summary

- Evidence PR for the AI council review workflow chain (collect → consumer → reusable)
- Validates end-to-end: WIF auth, diff collection, inline comments, and cleanup
- Also includes the crapload comment truncation fix (off-by-one)

## Related PRs

- complytime/org-infra#424 — production council review workflow
- unbound-force/unbound-force#329 — council-review-action composite action

## Test plan

- [ ] Collect workflow triggers on PR open
- [ ] Consumer workflow runs successfully
- [ ] Council review posts summary as deletable issue comment
- [ ] Inline comments appear on diff lines (deletable on re-run)
- [ ] Close after evidence is captured