### PR TITLE
feat(ci): add production council review workflow chain

### DIFF
--- a/.github/workflows/ci_council_review.yml
+++ b/.github/workflows/ci_council_review.yml
@@ -1,0 +1,44 @@
+---
+name: Council Review
+
+# --------------------------------------------------------------------------
+# Thin consumer workflow for AI council review. Triggered by workflow_run
+# when the collect workflow completes (fork PR support), or manually via
+# workflow_dispatch. Delegates all review logic to reusable_council_review.yml.
+# --------------------------------------------------------------------------
+on:
+  workflow_dispatch:
+    inputs:
+      triggering_run_id:
+        description: >-
+          Run ID of the collect workflow (for artifact download).
+          Required for manual testing.
+        required: true
+        type: number
+  workflow_run:  # zizmor: ignore[dangerous-triggers]
+    workflows: ["Council Review - Collect"]
+    types: [completed]
+
+concurrency:
+  group: council-review-${{ github.event.workflow_run.head_sha || github.run_id }}
+  cancel-in-progress: true
+
+permissions: {}
+
+jobs:
+  council-review:
+    name: AI Council Review
+    if: >-
+      github.event_name == 'workflow_dispatch' ||
+      github.event.workflow_run.conclusion == 'success'
+    uses: complytime/org-infra/.github/workflows/reusable_council_review.yml@main  # zizmor: ignore[unpinned-uses] — internal org workflow, @main is intentional
+    permissions:
+      contents: read
+      id-token: write
+      pull-requests: write
+      actions: read
+    with:
+      triggering-run-id: ${{ github.event.inputs.triggering_run_id || github.event.workflow_run.id }}
+    secrets:
+      GCP_WORKLOAD_IDENTITY_PROVIDER: ${{ secrets.GCP_WORKLOAD_IDENTITY_PROVIDER }}
+      GCP_PROJECT_ID: ${{ secrets.GCP_PROJECT_ID }}

--- a/.github/workflows/ci_council_review.yml
+++ b/.github/workflows/ci_council_review.yml
@@ -1,4 +1,9 @@
 ---
+# !! DO NOT EDIT — managed by complytime/org-infra !!
+# Source: .github/workflows/ci_council_review.yml
+# Changes here will be overwritten on the next org-infra sync.
+# To modify, open a PR against complytime/org-infra instead.
+
 name: Council Review
 
 # --------------------------------------------------------------------------

--- a/.github/workflows/ci_council_review_collect.yml
+++ b/.github/workflows/ci_council_review_collect.yml
@@ -2,9 +2,12 @@
 name: Council Review - Collect
 
 # --------------------------------------------------------------------------
-# Fork-safe PR diff collection for AI council review. Runs on pull_request
-# (no secrets needed), collects the PR diff and metadata, then uploads as
-# an artifact for ci_council_review.yml to pick up via workflow_run.
+# Fork-safe PR diff collection for AI council review. Runs on pull_request,
+# collects the PR diff and metadata, then uploads as an artifact for
+# ci_council_review.yml to pick up via workflow_run.
+#
+# Org membership check uses ORG_CHECK_TOKEN (PAT with org:read scope) if
+# available, falling back to GITHUB_TOKEN (public membership only).
 # --------------------------------------------------------------------------
 on:
   pull_request:
@@ -44,7 +47,7 @@ jobs:
         if: steps.gate.outputs.should_collect == 'true'
         id: org-check
         env:
-          GH_TOKEN: ${{ github.token }}
+          GH_TOKEN: ${{ secrets.ORG_CHECK_TOKEN != '' && secrets.ORG_CHECK_TOKEN || github.token }}
           ACTOR: ${{ github.event.pull_request.user.login }}
           ORG: ${{ github.repository_owner }}
         run: |

--- a/.github/workflows/ci_council_review_collect.yml
+++ b/.github/workflows/ci_council_review_collect.yml
@@ -20,7 +20,7 @@ jobs:
     permissions:
       contents: read
     outputs:
-      should_collect: ${{ steps.gate.outputs.should_collect }}
+      should_collect: ${{ steps.org-check.outputs.should_collect != '' && steps.org-check.outputs.should_collect || steps.gate.outputs.should_collect }}
     steps:
       - name: Evaluate gate conditions
         id: gate
@@ -39,6 +39,26 @@ jobs:
             exit 0
           fi
           echo "should_collect=true" >> "$GITHUB_OUTPUT"
+
+      - name: Verify org membership
+        if: steps.gate.outputs.should_collect == 'true'
+        id: org-check
+        env:
+          GH_TOKEN: ${{ github.token }}
+          ACTOR: ${{ github.event.pull_request.user.login }}
+          ORG: ${{ github.repository_owner }}
+        run: |
+          HTTP_STATUS=$(curl -s -L -o /dev/null -w "%{http_code}" \
+            -H "Authorization: token $GH_TOKEN" \
+            -H "Accept: application/vnd.github+json" \
+            "https://api.github.com/orgs/$ORG/members/$ACTOR")
+          if [[ "$HTTP_STATUS" != "204" ]]; then
+            echo "::notice::PR author ${ACTOR} is not a member of ${ORG} (HTTP ${HTTP_STATUS}) — skipping council review"
+            echo "should_collect=false" >> "$GITHUB_OUTPUT"
+          else
+            echo "::notice::✓ ${ACTOR} is a member of ${ORG}"
+            echo "should_collect=true" >> "$GITHUB_OUTPUT"
+          fi
 
   collect-diff:
     name: Collect PR Diff

--- a/.github/workflows/ci_council_review_collect.yml
+++ b/.github/workflows/ci_council_review_collect.yml
@@ -1,4 +1,9 @@
 ---
+# !! DO NOT EDIT — managed by complytime/org-infra !!
+# Source: .github/workflows/ci_council_review_collect.yml
+# Changes here will be overwritten on the next org-infra sync.
+# To modify, open a PR against complytime/org-infra instead.
+
 name: Council Review - Collect
 
 # --------------------------------------------------------------------------

--- a/.github/workflows/ci_council_review_collect.yml
+++ b/.github/workflows/ci_council_review_collect.yml
@@ -1,0 +1,83 @@
+---
+name: Council Review - Collect
+
+# --------------------------------------------------------------------------
+# Fork-safe PR diff collection for AI council review. Runs on pull_request
+# (no secrets needed), collects the PR diff and metadata, then uploads as
+# an artifact for ci_council_review.yml to pick up via workflow_run.
+# --------------------------------------------------------------------------
+on:
+  pull_request:
+    types: [opened, synchronize, reopened, ready_for_review]
+    branches: [main]
+
+permissions: {}
+
+jobs:
+  gate-check:
+    name: Gate Check
+    runs-on: ubuntu-latest
+    permissions:
+      contents: read
+    outputs:
+      should_collect: ${{ steps.gate.outputs.should_collect }}
+    steps:
+      - name: Evaluate gate conditions
+        id: gate
+        env:
+          PR_AUTHOR: ${{ github.event.pull_request.user.login }}
+          PR_DRAFT: ${{ github.event.pull_request.draft }}
+        run: |
+          if [[ "${PR_DRAFT}" == "true" ]]; then
+            echo "::notice::Draft PR — skipping council review"
+            echo "should_collect=false" >> "$GITHUB_OUTPUT"
+            exit 0
+          fi
+          if [[ "${PR_AUTHOR}" == "dependabot[bot]" ]]; then
+            echo "::notice::Dependabot PR — skipping council review"
+            echo "should_collect=false" >> "$GITHUB_OUTPUT"
+            exit 0
+          fi
+          echo "should_collect=true" >> "$GITHUB_OUTPUT"
+
+  collect-diff:
+    name: Collect PR Diff
+    needs: gate-check
+    if: needs.gate-check.outputs.should_collect == 'true'
+    runs-on: ubuntu-latest
+    permissions:
+      contents: read
+      pull-requests: read
+    steps:
+      - name: Collect PR diff
+        env:
+          GH_TOKEN: ${{ github.token }}
+          PR_NUMBER: ${{ github.event.pull_request.number }}
+        run: |
+          gh pr diff "${PR_NUMBER}" \
+            --repo "${{ github.repository }}" > pr-diff.patch
+
+      - name: Write PR metadata
+        env:
+          PR_NUMBER: ${{ github.event.pull_request.number }}
+          PR_HEAD_SHA: ${{ github.event.pull_request.head.sha }}
+          PR_BASE_REF: ${{ github.event.pull_request.base.ref }}
+          PR_TITLE: ${{ github.event.pull_request.title }}
+        run: |
+          jq -n \
+            --arg number "${PR_NUMBER}" \
+            --arg head_sha "${PR_HEAD_SHA}" \
+            --arg base_ref "${PR_BASE_REF}" \
+            --arg title "${PR_TITLE}" \
+            --arg repo "${{ github.repository }}" \
+            '{number: $number, head_sha: $head_sha, base_ref: $base_ref, title: $title, repo: $repo}' \
+            > pr-meta.json
+
+      - name: Upload diff artifact
+        uses: actions/upload-artifact@043fb46d1a93c77aae656e7c1c64a875d1fc6a0a # v7.0.1
+        with:
+          name: council-review-diff
+          path: |
+            pr-diff.patch
+            pr-meta.json
+          retention-days: 1

--- a/.github/workflows/reusable_council_review.yml
+++ b/.github/workflows/reusable_council_review.yml
@@ -188,7 +188,7 @@ jobs:
             path=$(echo "${comment}" | jq -r '.path')
             line=$(echo "${comment}" | jq -r '.line')
             body=$(echo "${comment}" | jq -r '.body')
-            tagged_body="<!-- council-review-bot -->${body}"
+            tagged_body=$(printf '<!-- council-review-bot -->\n\n%s' "${body}")
 
             if jq -n \
               --arg commit_id "${PR_HEAD_SHA}" \

--- a/.github/workflows/reusable_council_review.yml
+++ b/.github/workflows/reusable_council_review.yml
@@ -95,7 +95,7 @@ jobs:
         if: steps.gate.outputs.should_review == 'true'
         id: review
         continue-on-error: true
-        uses: unbound-force/unbound-force/council-review-action@eece8d4cda2482fd72efa751fa173fa87ef296e7  # feat/council-review-action-v2
+        uses: unbound-force/unbound-force/council-review-action@26db3b791cafafa40969e53e22b1a1b0295ef1f0  # feat/council-review-action-v2
         with:
           model: ${{ inputs.model }}
           diff-path: pr-diff.patch

--- a/.github/workflows/reusable_council_review.yml
+++ b/.github/workflows/reusable_council_review.yml
@@ -90,7 +90,7 @@ jobs:
         if: steps.gate.outputs.should_review == 'true'
         uses: google-github-actions/setup-gcloud@aa5489c8933f4cc7a4f7d45035b3b1440c9c10db # v3.0.1
 
-      # TODO: remove continue-on-error once council review is stable
+      # TODO(#440): remove continue-on-error once council review is stable
       - name: Run council review
         if: steps.gate.outputs.should_review == 'true'
         id: review
@@ -103,7 +103,9 @@ jobs:
           github-token: ${{ github.token }}
 
       - name: Clean up previous bot comments
-        if: steps.gate.outputs.should_review == 'true'
+        if: >-
+          steps.gate.outputs.should_review == 'true' &&
+          steps.review.outcome == 'success'
         env:
           GH_TOKEN: ${{ github.token }}
           PR_NUMBER: ${{ steps.meta.outputs.pr_number }}
@@ -124,7 +126,9 @@ jobs:
           gh api "repos/${REPO}/pulls/${PR_NUMBER}/reviews" \
             --paginate --jq '.[] | select(.user.login == "github-actions[bot]" and (.body | contains("council-review-bot"))) | .node_id' | \
           while read -r nid; do
-            [[ -n "${nid}" ]] && gh api graphql -f query="mutation { minimizeComment(input: {subjectId: \"${nid}\", classifier: OUTDATED}) { minimizedComment { isMinimized } } }" || true
+            [[ -n "${nid}" ]] && gh api graphql \
+              -f query='mutation($id: ID!) { minimizeComment(input: {subjectId: $id, classifier: OUTDATED}) { minimizedComment { isMinimized } } }' \
+              -f id="${nid}" || true
           done
 
       - name: Post review summary
@@ -190,6 +194,7 @@ jobs:
             body=$(echo "${comment}" | jq -r '.body')
             tagged_body=$(printf '<!-- council-review-bot -->\n\n%s' "${body}")
 
+            ERROR_FILE=$(mktemp)
             if jq -n \
               --arg commit_id "${PR_HEAD_SHA}" \
               --arg path "${path}" \
@@ -198,10 +203,12 @@ jobs:
               --arg body "${tagged_body}" \
               '{commit_id: $commit_id, path: $path, line: $line, side: $side, body: $body}' | \
             gh api "repos/${REPO}/pulls/${PR_NUMBER}/comments" \
-              --method POST --input - > /dev/null 2>&1; then
+              --method POST --input - > /dev/null 2>"${ERROR_FILE}"; then
               POSTED=$((POSTED + 1))
             else
               FAILED=$((FAILED + 1))
+              echo "::warning::Failed to post comment on ${path}:${line}: $(cat "${ERROR_FILE}")"
             fi
+            rm -f "${ERROR_FILE}"
           done < <(jq -c '.inline_comments[]' "${REVIEW_JSON}")
           echo "::notice::Posted ${POSTED} inline comments (${FAILED} failed)"

--- a/.github/workflows/reusable_council_review.yml
+++ b/.github/workflows/reusable_council_review.yml
@@ -111,6 +111,7 @@ jobs:
           PR_NUMBER: ${{ steps.meta.outputs.pr_number }}
           REPO: ${{ github.repository }}
         run: |
+          # shellcheck disable=SC2016
           gh api "repos/${REPO}/issues/${PR_NUMBER}/comments" \
             --paginate --jq '.[] | select(.body | contains("<!-- council-review-bot -->")) | .id' | \
           while read -r cid; do

--- a/.github/workflows/reusable_council_review.yml
+++ b/.github/workflows/reusable_council_review.yml
@@ -111,7 +111,6 @@ jobs:
           PR_NUMBER: ${{ steps.meta.outputs.pr_number }}
           REPO: ${{ github.repository }}
         run: |
-          # shellcheck disable=SC2016
           gh api "repos/${REPO}/issues/${PR_NUMBER}/comments" \
             --paginate --jq '.[] | select(.body | contains("<!-- council-review-bot -->")) | .id' | \
           while read -r cid; do
@@ -127,6 +126,7 @@ jobs:
           gh api "repos/${REPO}/pulls/${PR_NUMBER}/reviews" \
             --paginate --jq '.[] | select(.user.login == "github-actions[bot]" and (.body | contains("council-review-bot"))) | .node_id' | \
           while read -r nid; do
+            # shellcheck disable=SC2016
             [[ -n "${nid}" ]] && gh api graphql \
               -f query='mutation($id: ID!) { minimizeComment(input: {subjectId: $id, classifier: OUTDATED}) { minimizedComment { isMinimized } } }' \
               -f id="${nid}" || true

--- a/.github/workflows/reusable_council_review.yml
+++ b/.github/workflows/reusable_council_review.yml
@@ -95,7 +95,7 @@ jobs:
         if: steps.gate.outputs.should_review == 'true'
         id: review
         continue-on-error: true
-        uses: unbound-force/unbound-force/council-review-action@7e731c17927e59566faed0fd2aace4448a6243e2  # feat/council-review-action
+        uses: unbound-force/unbound-force/council-review-action@78c8a65ffbc245547ccab3a8f566282ef0a2c843  # feat/council-review-action
         with:
           model: ${{ inputs.model }}
           diff-path: pr-diff.patch

--- a/.github/workflows/reusable_council_review.yml
+++ b/.github/workflows/reusable_council_review.yml
@@ -95,7 +95,7 @@ jobs:
         if: steps.gate.outputs.should_review == 'true'
         id: review
         continue-on-error: true
-        uses: unbound-force/unbound-force/council-review-action@78c8a65ffbc245547ccab3a8f566282ef0a2c843  # feat/council-review-action
+        uses: unbound-force/unbound-force/council-review-action@eece8d4cda2482fd72efa751fa173fa87ef296e7  # feat/council-review-action-v2
         with:
           model: ${{ inputs.model }}
           diff-path: pr-diff.patch

--- a/.github/workflows/reusable_council_review.yml
+++ b/.github/workflows/reusable_council_review.yml
@@ -95,7 +95,7 @@ jobs:
         if: steps.gate.outputs.should_review == 'true'
         id: review
         continue-on-error: true
-        uses: unbound-force/unbound-force/council-review-action@28b8b438390652909463cacd1a95f189571ac188  # feat/council-review-action-v2
+        uses: unbound-force/unbound-force/council-review-action@dc82f77d590a0fa68dd6e2344f6a9569087dedf5  # opsx/council-review-sandbox (PR #425)
         with:
           model: ${{ inputs.model }}
           diff-path: pr-diff.patch

--- a/.github/workflows/reusable_council_review.yml
+++ b/.github/workflows/reusable_council_review.yml
@@ -1,0 +1,207 @@
+---
+# Reusable workflow — NOT synced to downstream repos (see sync-config.yml)
+name: Reusable Council Review
+
+# --------------------------------------------------------------------------
+# Reusable workflow for AI council review using OpenCode on Vertex AI via
+# WIF authentication. Downloads the PR diff artifact, authenticates to GCP,
+# delegates review to the council-review-action composite action, and posts
+# inline review comments on the PR.
+#
+# Called by ci_council_review.yml (consumer workflow).
+# --------------------------------------------------------------------------
+on:
+  workflow_call:
+    inputs:
+      triggering-run-id:
+        description: Run ID of the collect workflow (for artifact download)
+        required: true
+        type: string
+      model:
+        description: Model ID for the AI review
+        required: false
+        type: string
+        default: "google-vertex-anthropic/claude-sonnet-4-6"
+    secrets:
+      GCP_WORKLOAD_IDENTITY_PROVIDER:
+        required: false
+      GCP_PROJECT_ID:
+        required: false
+
+permissions: {}
+
+jobs:
+  review:
+    name: Council Review
+    runs-on: ubuntu-latest
+    permissions:
+      contents: read
+      id-token: write
+      pull-requests: write
+      actions: read
+    env:
+      VERTEX_LOCATION: global
+    steps:
+      - name: Check WIF credentials
+        id: gate
+        env:
+          HAS_WIF: ${{ secrets.GCP_WORKLOAD_IDENTITY_PROVIDER != '' }}
+        run: |
+          if [[ "${HAS_WIF}" != "true" ]]; then
+            echo "::notice::No WIF credentials — skipping council review"
+            echo "should_review=false" >> "$GITHUB_OUTPUT"
+            exit 0
+          fi
+          echo "should_review=true" >> "$GITHUB_OUTPUT"
+
+      - name: Checkout
+        if: steps.gate.outputs.should_review == 'true'
+        uses: actions/checkout@df4cb1c069e1874edd31b4311f1884172cec0e10 # v6.0.3
+        with:
+          persist-credentials: false
+
+      - name: Download diff artifact
+        if: steps.gate.outputs.should_review == 'true'
+        uses: actions/download-artifact@3e5f45b2cfb9172054b4087a40e8e0b5a5461e7c # v8.0.1
+        with:
+          name: council-review-diff
+          run-id: ${{ inputs.triggering-run-id }}
+          github-token: ${{ github.token }}
+
+      - name: Extract PR metadata
+        if: steps.gate.outputs.should_review == 'true'
+        id: meta
+        run: |
+          PR_NUMBER=$(jq -r '.number' pr-meta.json)
+          PR_HEAD_SHA=$(jq -r '.head_sha' pr-meta.json)
+          {
+            echo "pr_number=${PR_NUMBER}"
+            echo "pr_head_sha=${PR_HEAD_SHA}"
+          } >> "$GITHUB_OUTPUT"
+
+      - name: Authenticate to Google Cloud (WIF)
+        if: steps.gate.outputs.should_review == 'true'
+        uses: google-github-actions/auth@7c6bc770dae815cd3e89ee6cdf493a5fab2cc093 # v3.0.0
+        with:
+          project_id: ${{ secrets.GCP_PROJECT_ID }}
+          workload_identity_provider: ${{ secrets.GCP_WORKLOAD_IDENTITY_PROVIDER }}
+
+      - name: Set up gcloud CLI
+        if: steps.gate.outputs.should_review == 'true'
+        uses: google-github-actions/setup-gcloud@aa5489c8933f4cc7a4f7d45035b3b1440c9c10db # v3.0.1
+
+      # TODO: remove continue-on-error once council review is stable
+      - name: Run council review
+        if: steps.gate.outputs.should_review == 'true'
+        id: review
+        continue-on-error: true
+        uses: unbound-force/unbound-force/council-review-action@7e731c17927e59566faed0fd2aace4448a6243e2  # feat/council-review-action
+        with:
+          model: ${{ inputs.model }}
+          diff-path: pr-diff.patch
+          meta-path: pr-meta.json
+          github-token: ${{ github.token }}
+
+      - name: Clean up previous bot comments
+        if: steps.gate.outputs.should_review == 'true'
+        env:
+          GH_TOKEN: ${{ github.token }}
+          PR_NUMBER: ${{ steps.meta.outputs.pr_number }}
+          REPO: ${{ github.repository }}
+        run: |
+          gh api "repos/${REPO}/issues/${PR_NUMBER}/comments" \
+            --paginate --jq '.[] | select(.body | contains("<!-- council-review-bot -->")) | .id' | \
+          while read -r cid; do
+            [[ -n "${cid}" ]] && gh api "repos/${REPO}/issues/comments/${cid}" --method DELETE || true
+          done
+
+          gh api "repos/${REPO}/pulls/${PR_NUMBER}/comments" \
+            --paginate --jq '.[] | select(.body | contains("<!-- council-review-bot -->")) | .id' | \
+          while read -r cid; do
+            [[ -n "${cid}" ]] && gh api "repos/${REPO}/pulls/comments/${cid}" --method DELETE || true
+          done
+
+          gh api "repos/${REPO}/pulls/${PR_NUMBER}/reviews" \
+            --paginate --jq '.[] | select(.user.login == "github-actions[bot]" and (.body | contains("council-review-bot"))) | .node_id' | \
+          while read -r nid; do
+            [[ -n "${nid}" ]] && gh api graphql -f query="mutation { minimizeComment(input: {subjectId: \"${nid}\", classifier: OUTDATED}) { minimizedComment { isMinimized } } }" || true
+          done
+
+      - name: Post review summary
+        if: >-
+          steps.gate.outputs.should_review == 'true' &&
+          steps.review.outcome == 'success'
+        env:
+          GH_TOKEN: ${{ github.token }}
+          PR_NUMBER: ${{ steps.meta.outputs.pr_number }}
+          PR_HEAD_SHA: ${{ steps.meta.outputs.pr_head_sha }}
+          MODEL: ${{ inputs.model }}
+          REPO: ${{ github.repository }}
+          REVIEW_JSON: ${{ steps.review.outputs.review-json }}
+          REVIEW_MODE: ${{ steps.review.outputs.review-mode }}
+        run: |
+          COMMENT_COUNT=0
+          if [[ "${REVIEW_MODE}" == "inline" ]]; then
+            COMMENT_COUNT=$(jq '.inline_comments | length' "${REVIEW_JSON}")
+          fi
+
+          {
+            echo "<!-- council-review-bot -->"
+            echo "## AI Council Review"
+            echo ""
+            if [[ -s "${REVIEW_JSON}" ]]; then
+              jq -r '.summary' "${REVIEW_JSON}"
+            else
+              echo "_Council review produced no output._"
+            fi
+            echo ""
+            echo "---"
+            if [[ "${COMMENT_COUNT}" -gt 0 ]]; then
+              echo "_Model: \`${MODEL}\` | Commit: \`${PR_HEAD_SHA:0:7}\` | Inline comments: ${COMMENT_COUNT}_"
+            else
+              echo "_Model: \`${MODEL}\` | Commit: \`${PR_HEAD_SHA:0:7}\`_"
+            fi
+          } > review_summary.txt
+          gh pr comment "${PR_NUMBER}" --repo "${REPO}" --body-file review_summary.txt
+
+      - name: Post inline comments
+        if: >-
+          steps.gate.outputs.should_review == 'true' &&
+          steps.review.outcome == 'success' &&
+          steps.review.outputs.review-mode == 'inline'
+        env:
+          GH_TOKEN: ${{ github.token }}
+          PR_NUMBER: ${{ steps.meta.outputs.pr_number }}
+          PR_HEAD_SHA: ${{ steps.meta.outputs.pr_head_sha }}
+          REPO: ${{ github.repository }}
+          REVIEW_JSON: ${{ steps.review.outputs.review-json }}
+        run: |
+          COMMENT_COUNT=$(jq '.inline_comments | length' "${REVIEW_JSON}")
+          if [[ "${COMMENT_COUNT}" -eq 0 ]]; then
+            echo "::notice::No inline comments to post"
+            exit 0
+          fi
+
+          POSTED=0
+          FAILED=0
+          while IFS= read -r comment; do
+            path=$(echo "${comment}" | jq -r '.path')
+            line=$(echo "${comment}" | jq -r '.line')
+            body=$(echo "${comment}" | jq -r '.body')
+            tagged_body="<!-- council-review-bot -->${body}"
+
+            if jq -n \
+              --arg commit_id "${PR_HEAD_SHA}" \
+              --arg path "${path}" \
+              --argjson line "${line}" \
+              --arg side "RIGHT" \
+              --arg body "${tagged_body}" \
+              '{commit_id: $commit_id, path: $path, line: $line, side: $side, body: $body}' | \
+            gh api "repos/${REPO}/pulls/${PR_NUMBER}/comments" \
+              --method POST --input - > /dev/null 2>&1; then
+              POSTED=$((POSTED + 1))
+            else
+              FAILED=$((FAILED + 1))
+            fi
+          done < <(jq -c '.inline_comments[]' "${REVIEW_JSON}")
+          echo "::notice::Posted ${POSTED} inline comments (${FAILED} failed)"

--- a/.github/workflows/reusable_council_review.yml
+++ b/.github/workflows/reusable_council_review.yml
@@ -95,7 +95,7 @@ jobs:
         if: steps.gate.outputs.should_review == 'true'
         id: review
         continue-on-error: true
-        uses: unbound-force/unbound-force/council-review-action@dc82f77d590a0fa68dd6e2344f6a9569087dedf5  # opsx/council-review-sandbox (PR #425)
+        uses: unbound-force/unbound-force/council-review-action@7836c070a63f3eeeab78ebd48c5dd5921ae486e2  # main (merged #336)
         with:
           model: ${{ inputs.model }}
           diff-path: pr-diff.patch

--- a/.github/workflows/reusable_council_review.yml
+++ b/.github/workflows/reusable_council_review.yml
@@ -95,7 +95,7 @@ jobs:
         if: steps.gate.outputs.should_review == 'true'
         id: review
         continue-on-error: true
-        uses: unbound-force/unbound-force/council-review-action@26db3b791cafafa40969e53e22b1a1b0295ef1f0  # feat/council-review-action-v2
+        uses: unbound-force/unbound-force/council-review-action@28b8b438390652909463cacd1a95f189571ac188  # feat/council-review-action-v2
         with:
           model: ${{ inputs.model }}
           diff-path: pr-diff.patch

--- a/AGENTS.md
+++ b/AGENTS.md
@@ -28,6 +28,60 @@ make sync-dry-run    # Preview file sync to org repos
 make clean           # Remove __pycache__ and .pyc
 ```
 
+## Council Review (AI-assisted PR review)
+
+Three-workflow chain for automated AI code review using OpenCode on Vertex AI,
+with Divisor persona discovery from the reviewed repo.
+
+### Workflow chain
+
+```text
+ci_council_review_collect.yml  (pull_request)  [synced to downstream repos]
+  ├── Gate: skip drafts, dependabot, non-org-members
+  ├── Collect diff: gh pr diff → pr-diff.patch
+  ├── Build metadata: pr-meta.json
+  └── Upload artifact (1-day retention)
+         │
+         ▼  workflow_run / workflow_dispatch
+ci_council_review.yml  (consumer)  [synced to downstream repos]
+  └── Calls reusable_council_review.yml@main (org-infra only)
+         │
+         ▼  workflow_call
+reusable_council_review.yml  [NOT synced — org-infra only]
+  ├── WIF auth → Vertex AI
+  ├── council-review-action (composite, SHA-pinned, from unbound-force)
+  ├── Clean up previous bot comments
+  ├── Post review summary
+  └── Post inline comments on diff lines
+```
+
+### Required secrets
+
+| Secret | Scope | Purpose |
+|--------|-------|---------|
+| `GCP_WORKLOAD_IDENTITY_PROVIDER` | Org-level | WIF provider for Vertex AI auth |
+| `GCP_PROJECT_ID` | Org-level | GCP project containing Vertex AI |
+| `ORG_CHECK_TOKEN` | Optional | PAT with `org:read` for private membership checks (falls back to `GITHUB_TOKEN` for public-only) |
+
+### Sync and rollout
+
+Consumer workflows (`ci_council_review_collect.yml`, `ci_council_review.yml`) sync
+to downstream repos via `sync-config.yml`. The reusable workflow stays in org-infra
+and is called cross-repo. See `sync-config.yml` for current `exclude_repos` list.
+
+Rollout is staged: all downstream repos are excluded until the composite action SHA
+points to a merged `main` commit and security hardening (#429) / cost controls (#430)
+are in place.
+
+### Related issues
+
+- Security hardening: #429
+- Token consumption controls: #430
+- `continue-on-error` removal: #440
+- Composite action: `unbound-force/unbound-force` → `council-review-action/`
+
+See `docs/COUNCIL_REVIEW.md` for the full operational guide.
+
 ## Constraints
 
 - **Sync impact**: Config files (`.golangci.yml`, `.yamllint.yml`, `ruff.toml`, `.mega-linter.yml`, `commitlint.config.js`) and workflows (`ci_*`, `reusable_*`) sync to all org repos. Check `sync-config.yml` before modifying to understand downstream impact.

--- a/docs/COUNCIL_REVIEW.md
+++ b/docs/COUNCIL_REVIEW.md
@@ -1,0 +1,167 @@
+# Council Review — Operational Guide
+
+AI-assisted PR review using OpenCode on Vertex AI with Divisor persona
+discovery. Reviews are posted as inline comments on PR diff lines.
+
+## Architecture
+
+```text
+┌─────────────────────────────────────────────────────────┐
+│  Downstream Repo (e.g., complytime, gaze)               │
+│                                                         │
+│  ci_council_review_collect.yml  (pull_request trigger)  │
+│  ├── Gate: skip bots, drafts, non-org-members           │
+│  ├── Capture diff: gh pr diff → pr-diff.patch           │
+│  ├── Build metadata: pr-meta.json                       │
+│  └── Upload artifact: council-review-diff               │
+│                                                         │
+│  ci_council_review.yml  (workflow_run / workflow_dispatch)│
+│  └── calls → reusable_council_review.yml (org-infra)    │
+└────────────────────────┬────────────────────────────────┘
+                         │
+┌────────────────────────▼────────────────────────────────┐
+│  org-infra: reusable_council_review.yml                 │
+│                                                         │
+│  ├── Download artifact (pr-diff.patch, pr-meta.json)    │
+│  ├── WIF auth → Google Cloud (Vertex AI)                │
+│  ├── council-review-action (SHA-pinned composite)       │
+│  │   ├── Filter noise → pr-diff-filtered.patch          │
+│  │   ├── Annotate lines → pr-diff-annotated.patch       │
+│  │   ├── Pre-fetch PR context (CI, reviews, issues)     │
+│  │   ├── Discover Divisor personas                      │
+│  │   ├── Build prompt + opencode run                    │
+│  │   └── Parse + validate → review_output.json          │
+│  ├── Clean up previous bot comments                     │
+│  ├── Post review summary (issue comment)                │
+│  └── Post inline comments (PR review comments)          │
+└─────────────────────────────────────────────────────────┘
+```
+
+## Workflow files
+
+| File | Synced? | Trigger | Purpose |
+|------|---------|---------|---------|
+| `ci_council_review_collect.yml` | Yes | `pull_request` | Fork-safe diff collection, no secrets needed |
+| `ci_council_review.yml` | Yes | `workflow_run` / `workflow_dispatch` | Thin consumer, passes secrets to the reusable |
+| `reusable_council_review.yml` | **No** | `workflow_call` | Core logic: WIF auth, action invocation, comment posting |
+
+Consumer workflows have `DO NOT EDIT` provenance headers indicating they
+are managed by org-infra. Downstream repos should not modify them directly.
+
+## Required secrets
+
+| Secret | Required | Scope | Purpose |
+|--------|----------|-------|---------|
+| `GCP_WORKLOAD_IDENTITY_PROVIDER` | Yes | Org-level | WIF provider for Vertex AI authentication |
+| `GCP_PROJECT_ID` | Yes | Org-level | GCP project containing Vertex AI |
+| `ORG_CHECK_TOKEN` | No | Org-level | PAT with `org:read` for private org membership checks |
+
+If `GCP_WORKLOAD_IDENTITY_PROVIDER` is not set, the review is skipped with a
+`::notice::` annotation. No tokens are consumed.
+
+If `ORG_CHECK_TOKEN` is not set, the collect workflow falls back to
+`GITHUB_TOKEN` which can only check **public** org membership. Private org
+members (the GitHub default) will be treated as non-members and skipped.
+
+## Gate conditions
+
+The collect workflow skips council review when:
+
+- PR is a draft
+- PR author is `dependabot[bot]`
+- PR author is not a member of the repository's org
+
+## Composite action
+
+The review logic lives in
+[`unbound-force/unbound-force/council-review-action/`](https://github.com/unbound-force/unbound-force/tree/main/council-review-action).
+It is pinned by full SHA in `reusable_council_review.yml`.
+
+The action:
+
+1. Installs `opencode-ai@1.2.26` via npm
+2. Filters noise files from the diff (lock files, vendor, generated code)
+3. Annotates the diff with `[L<N>]` source-file line numbers
+4. Pre-fetches PR context (CI status, existing reviews, linked issues)
+5. Discovers Divisor personas from `.opencode/agents/divisor-*.md`
+6. Builds a constrained review prompt with injection defense
+7. Runs `opencode run` on Vertex AI
+8. Parses structured JSON output and validates line numbers against the diff
+
+## Rollout
+
+Rollout is staged via `sync-config.yml` `exclude_repos`:
+
+1. **Current**: Only org-infra receives the consumer workflows
+2. **Phase 2**: Remove repos from `exclude_repos` after:
+   - Composite action SHA points to a merged `main` commit
+   - Security hardening (#429) is in place
+   - Token consumption controls (#430) are in place
+   - End-to-end chain validated on org-infra
+
+## Manual trigger
+
+To manually trigger a council review on an existing PR:
+
+1. Find the collect workflow run ID from the PR's "Checks" tab
+   (the "Council Review - Collect" run)
+2. Go to Actions → "Council Review" → "Run workflow"
+3. Select the PR's branch, enter the collect run ID
+
+Or via CLI:
+
+```bash
+gh workflow run ci_council_review.yml \
+  --repo complytime/org-infra \
+  --ref <branch> \
+  -f triggering_run_id=<collect-run-id>
+```
+
+## Bot comment lifecycle
+
+All bot comments are tagged with `<!-- council-review-bot -->`.
+
+On each new review:
+1. Previous issue comments (summary) are **deleted**
+2. Previous PR review comments (inline) are **deleted**
+3. Previous Reviews API objects are **minimized** (collapsed as "outdated")
+4. New summary and inline comments are posted
+
+## Troubleshooting
+
+### Review skipped — "No WIF credentials"
+
+The `GCP_WORKLOAD_IDENTITY_PROVIDER` secret is not configured for this repo.
+Set it at the org level or add a repo-level secret.
+
+### Review skipped — "PR author is not a member"
+
+Either the author is not an org member, or `ORG_CHECK_TOKEN` is not set and
+the author's membership is private. Configure `ORG_CHECK_TOKEN` with a PAT
+that has `org:read` scope.
+
+### Review produced no inline comments
+
+The model may have returned a summary-only review, or the diff was too small
+to warrant inline findings. Check the review summary comment on the PR.
+
+### Inline comments on wrong lines
+
+The `[L<N>]` annotation in the diff helps the model identify correct line
+numbers. If comments land on wrong lines, check:
+- `filter-diff-lines.py` validation logic in the composite action
+- Whether the diff has since been invalidated by new commits
+
+### Credentials error — "Could not load the default credentials"
+
+The WIF authentication succeeded but the credentials were not passed to
+OpenCode. Check that `GOOGLE_APPLICATION_CREDENTIALS` is set in the
+environment when `opencode run` executes.
+
+## Related issues
+
+- Security hardening: [#429](https://github.com/complytime/org-infra/issues/429)
+- Token consumption controls: [#430](https://github.com/complytime/org-infra/issues/430)
+- `continue-on-error` removal: [#440](https://github.com/complytime/org-infra/issues/440)
+- Error handling hardening: [#454](https://github.com/complytime/org-infra/issues/454)
+- Composite action tracking: [unbound-force#253](https://github.com/unbound-force/unbound-force/issues/253)

--- a/scripts/generate-crapload-comment.sh
+++ b/scripts/generate-crapload-comment.sh
@@ -27,7 +27,7 @@ set -euo pipefail
 
 CRAP_JSON="${1:-/tmp/crapload-current.json}"
 REPORT_JSON="${2:-/tmp/gaze-report.json}"
-COMMENT_FILE="/tmp/crapload-comment-body.md"
+COMMENT_FILE="${COMMENT_FILE:-/tmp/crapload-comment-body.md}"
 MAX_COMMENT_SIZE="${MAX_COMMENT_SIZE:-65536}"
 
 # Extract summary metrics from gaze crap JSON.

--- a/scripts/generate-crapload-comment.sh
+++ b/scripts/generate-crapload-comment.sh
@@ -28,6 +28,7 @@ set -euo pipefail
 CRAP_JSON="${1:-/tmp/crapload-current.json}"
 REPORT_JSON="${2:-/tmp/gaze-report.json}"
 COMMENT_FILE="/tmp/crapload-comment-body.md"
+MAX_COMMENT_SIZE="${MAX_COMMENT_SIZE:-65536}"
 
 # Extract summary metrics from gaze crap JSON.
 TOTAL_FUNCS=$(jq -r '.summary.total_functions // 0' "$CRAP_JSON")
@@ -196,3 +197,16 @@ fi
 # Add footer.
 printf '\n[View full analysis logs](%s/%s/actions/runs/%s)\n' \
 	"$GITHUB_SERVER_URL" "$GITHUB_REPOSITORY" "$GITHUB_RUN_ID" >>"$COMMENT_FILE"
+
+# Truncate if comment exceeds GitHub's character limit.
+# Reserve space for the trailer so the final file stays within the limit.
+TRAILER_RESERVE=120
+TRUNCATE_AT=$((MAX_COMMENT_SIZE - TRAILER_RESERVE))
+
+COMMENT_SIZE=$(wc -c < "$COMMENT_FILE")
+if [ "$COMMENT_SIZE" -gt "$MAX_COMMENT_SIZE" ]; then
+	head -c "$TRUNCATE_AT" "$COMMENT_FILE" > "${COMMENT_FILE}.tmp"
+	printf '\n\n---\n_Comment truncated (%s bytes, limit %s). See full logs above._\n' \
+		"$COMMENT_SIZE" "$MAX_COMMENT_SIZE" >> "${COMMENT_FILE}.tmp"
+	mv "${COMMENT_FILE}.tmp" "$COMMENT_FILE"
+fi

--- a/sync-config.yml
+++ b/sync-config.yml
@@ -50,6 +50,22 @@ files_to_sync:
         repos:
           complytime-providers: "'.trivyignore.yaml'"
 
+  - source: .github/workflows/ci_council_review_collect.yml
+    destination: .github/workflows/ci_council_review_collect.yml
+    exclude_repos:
+      - .github
+      - community
+
+  - source: .github/workflows/ci_council_review.yml
+    destination: .github/workflows/ci_council_review.yml
+    exclude_repos:
+      - .github
+      - community
+
+  # NOTE: reusable_council_review.yml is intentionally NOT synced.
+  # It stays in org-infra and is called cross-repo by downstream
+  # consumers via: complytime/org-infra/.github/workflows/reusable_council_review.yml@SHA
+
   - source: .github/workflows/ci_crapload.yml
     destination: .github/workflows/ci_crapload.yml
     exclude_repos:

--- a/sync-config.yml
+++ b/sync-config.yml
@@ -55,12 +55,38 @@ files_to_sync:
     exclude_repos:
       - .github
       - community
+      # Staged rollout: validate on org-infra first, then widen once:
+      #   - composite action SHA points to merged main (unbound-force#336)
+      #   - security hardening (#429) and cost controls (#430) are in place
+      - complyapi
+      - complyctl
+      - complypack
+      - complytime
+      - complytime-collector-components
+      - complytime-demos
+      - complytime-policies
+      - complytime-providers
+      - homebrew-tap
+      - website
 
   - source: .github/workflows/ci_council_review.yml
     destination: .github/workflows/ci_council_review.yml
     exclude_repos:
       - .github
       - community
+      # Staged rollout: validate on org-infra first, then widen once:
+      #   - composite action SHA points to merged main (unbound-force#336)
+      #   - security hardening (#429) and cost controls (#430) are in place
+      - complyapi
+      - complyctl
+      - complypack
+      - complytime
+      - complytime-collector-components
+      - complytime-demos
+      - complytime-policies
+      - complytime-providers
+      - homebrew-tap
+      - website
 
   # NOTE: reusable_council_review.yml is intentionally NOT synced.
   # It stays in org-infra and is called cross-repo by downstream

--- a/tests/test_crapload_comment_truncation.py
+++ b/tests/test_crapload_comment_truncation.py
@@ -66,8 +66,17 @@ def _run_script(
     report_json: str,
     baseline: str,
     max_comment_size: str = "65536",
+    comment_file: str | None = None,
 ) -> tuple[int, str]:
-    """Run generate-crapload-comment.sh and return (returncode, comment_body)."""
+    """Run generate-crapload-comment.sh and return (returncode, comment_body).
+
+    Uses an isolated COMMENT_FILE path per invocation to avoid
+    cross-test interference via the shared /tmp default.
+    """
+    if comment_file is None:
+        fd, comment_file = tempfile.mkstemp(suffix=".md", prefix="crapload-test-")
+        os.close(fd)
+
     env = {
         **os.environ,
         "BASELINE": baseline,
@@ -77,6 +86,7 @@ def _run_script(
         "GITHUB_REPOSITORY": "test/repo",
         "GITHUB_RUN_ID": "12345",
         "MAX_COMMENT_SIZE": max_comment_size,
+        "COMMENT_FILE": comment_file,
     }
     result = subprocess.run(
         ["bash", str(SCRIPT_PATH), crap_json, report_json],
@@ -85,10 +95,10 @@ def _run_script(
         text=True,
     )
     comment = ""
-    comment_file = "/tmp/crapload-comment-body.md"
     if os.path.exists(comment_file):
         with open(comment_file) as f:
             comment = f.read()
+        os.unlink(comment_file)
     return result.returncode, comment
 
 

--- a/tests/test_crapload_comment_truncation.py
+++ b/tests/test_crapload_comment_truncation.py
@@ -1,0 +1,159 @@
+# SPDX-License-Identifier: Apache-2.0
+
+"""Regression tests for generate-crapload-comment.sh truncation logic.
+
+Covers the truncation fix that ensures comments exceeding GitHub's
+character limit are truncated with a trailer that fits within the limit.
+See: TC-006 (bug fixes require regression tests).
+"""
+
+import json
+import os
+import subprocess
+import tempfile
+from pathlib import Path
+
+PROJECT_ROOT = Path(__file__).parent.parent
+SCRIPT_PATH = PROJECT_ROOT / "scripts" / "generate-crapload-comment.sh"
+
+
+def _make_crap_json(tmp: str, total_functions: int = 5) -> str:
+    """Write a minimal gaze crap JSON fixture and return its path."""
+    path = os.path.join(tmp, "crapload-current.json")
+    data = {
+        "summary": {
+            "total_functions": total_functions,
+            "avg_complexity": 2,
+            "avg_line_coverage": 80,
+            "avg_crap": 5,
+            "crap_threshold": 15,
+            "crapload": 0,
+            "avg_contract_coverage": 70,
+            "avg_gaze_crap": 4,
+            "gaze_crap_threshold": 15,
+            "gaze_crapload": 0,
+        },
+        "comparison": {
+            "regressions": 0,
+            "improvements": 0,
+            "new_functions": 0,
+        },
+        "scores": [],
+    }
+    with open(path, "w") as f:
+        json.dump(data, f)
+    return path
+
+
+def _make_report_json(tmp: str) -> str:
+    """Write a minimal gaze report JSON fixture and return its path."""
+    path = os.path.join(tmp, "gaze-report.json")
+    with open(path, "w") as f:
+        json.dump({"errors": {}}, f)
+    return path
+
+
+def _make_baseline(tmp: str) -> str:
+    """Write a minimal baseline file and return its path."""
+    path = os.path.join(tmp, "baseline.json")
+    with open(path, "w") as f:
+        json.dump({"summary": {"crapload": 0}, "scores": []}, f)
+    return path
+
+
+def _run_script(
+    crap_json: str,
+    report_json: str,
+    baseline: str,
+    max_comment_size: str = "65536",
+) -> tuple[int, str]:
+    """Run generate-crapload-comment.sh and return (returncode, comment_body)."""
+    env = {
+        **os.environ,
+        "BASELINE": baseline,
+        "GAZE_VERSION": "v0.0.0-test",
+        "STATUS": "pass",
+        "GITHUB_SERVER_URL": "https://github.com",
+        "GITHUB_REPOSITORY": "test/repo",
+        "GITHUB_RUN_ID": "12345",
+        "MAX_COMMENT_SIZE": max_comment_size,
+    }
+    result = subprocess.run(
+        ["bash", str(SCRIPT_PATH), crap_json, report_json],
+        env=env,
+        capture_output=True,
+        text=True,
+    )
+    comment = ""
+    comment_file = "/tmp/crapload-comment-body.md"
+    if os.path.exists(comment_file):
+        with open(comment_file) as f:
+            comment = f.read()
+    return result.returncode, comment
+
+
+class TestCraploadCommentTruncation:
+    """Regression tests for comment truncation (off-by-one fix)."""
+
+    def test_small_comment_not_truncated(self):
+        """Comments under the limit are left unchanged."""
+        with tempfile.TemporaryDirectory() as tmp:
+            crap = _make_crap_json(tmp)
+            report = _make_report_json(tmp)
+            baseline = _make_baseline(tmp)
+
+            rc, comment = _run_script(crap, report, baseline)
+
+            assert rc == 0
+            assert "Comment truncated" not in comment
+            # Verify the comment has expected content
+            assert "CRAP Load Analysis" in comment
+
+    def test_oversized_comment_is_truncated(self):
+        """Comments over the limit are truncated with a trailer."""
+        with tempfile.TemporaryDirectory() as tmp:
+            crap = _make_crap_json(tmp)
+            report = _make_report_json(tmp)
+            baseline = _make_baseline(tmp)
+
+            # Use a very small limit to force truncation
+            rc, comment = _run_script(
+                crap, report, baseline, max_comment_size="200"
+            )
+
+            assert rc == 0
+            assert "Comment truncated" in comment
+
+    def test_truncated_comment_within_limit(self):
+        """The final truncated file must not exceed MAX_COMMENT_SIZE."""
+        with tempfile.TemporaryDirectory() as tmp:
+            crap = _make_crap_json(tmp)
+            report = _make_report_json(tmp)
+            baseline = _make_baseline(tmp)
+
+            limit = 300
+            rc, comment = _run_script(
+                crap, report, baseline, max_comment_size=str(limit)
+            )
+
+            assert rc == 0
+            comment_bytes = len(comment.encode("utf-8"))
+            assert comment_bytes <= limit, (
+                f"Truncated comment is {comment_bytes} bytes, "
+                f"exceeds limit of {limit}"
+            )
+
+    def test_trailer_present_after_truncation(self):
+        """Truncation trailer includes byte counts for diagnostics."""
+        with tempfile.TemporaryDirectory() as tmp:
+            crap = _make_crap_json(tmp)
+            report = _make_report_json(tmp)
+            baseline = _make_baseline(tmp)
+
+            rc, comment = _run_script(
+                crap, report, baseline, max_comment_size="200"
+            )
+
+            assert rc == 0
+            assert "limit 200" in comment
+            assert "See full logs above" in comment


### PR DESCRIPTION
## Summary

Three-file workflow chain for AI council review using OpenCode on Vertex AI
via ITPC WIF authentication, matching the org's reusable workflow convention:

- `ci_council_review_collect.yml` (synced): fork-safe diff collection on
  `pull_request`, uploads PR diff and metadata as artifact
- `ci_council_review.yml` (synced): thin consumer on `workflow_run` /
  `workflow_dispatch`, calls `reusable_council_review.yml` with secrets
- `reusable_council_review.yml` (NOT synced): shared review logic — WIF auth,
  council-review-action composite action, cleanup of previous bot comments,
  inline comment posting via GitHub API

Downstream repos receive consumer workflows via `sync-config.yml` and call
the reusable cross-repo (`complytime/org-infra/.github/workflows/reusable_council_review.yml@main`).

## Note
This PR should not merge before unbound-force#336

The merge order is:
1. Merge unbound-force#336 first — gets the composite action onto main
2. Update the SHA in #428 to the merged main commit (this is already the first item in the post-merge checklist)
3. Then merge #428

## Architecture

```
ci_council_review_collect.yml (pull_request) [synced]
  ├─ Gate check (skip drafts, dependabot)
  ├─ Collect PR diff via gh pr diff
  ├─ Write pr-meta.json
  └─ Upload artifact (1-day retention)
         │
         ▼  workflow_run
ci_council_review.yml (workflow_run / workflow_dispatch) [synced]
  └─ Calls reusable_council_review.yml
         │
         ▼  workflow_call
reusable_council_review.yml [org-infra only]
  ├─ WIF gate, artifact download, WIF auth
  ├─ council-review-action (composite, SHA-pinned)
  │   ├─ Filter noise from diff → pr-diff-filtered.patch
  │   ├─ Annotate with source line numbers → pr-diff-annotated.patch
  │   ├─ Pre-fetch PR context (CI, reviews, issues)
  │   ├─ Discover Divisor personas
  │   ├─ Build prompt + opencode run
  │   └─ Parse + validate line numbers → review_output.json
  ├─ Clean up previous bot comments (delete + minimize)
  ├─ Post review summary (issue comment)
  └─ Post inline comments (individual PR comments)
```

## Prior review

Replaces #424 (closed: force-push desynced PR tracking) and #313. All
reviewer feedback from @hbraswelrh and @marcusburghardt on #313 addressed:

- Header comment blocks on all workflow files (Hannah)
- Claude CLI → OpenCode CLI pinned to 1.2.26 (Hannah)
- Prompt injection defense via defensive preamble (Hannah)
- Collect workflow renamed to "Council Review - Collect" (Marcus, Hannah)
- Review prompt externalized to composite action (Marcus, Hannah)
- Comment deduplication via bot marker + cleanup (Hannah)
- Private repo references removed from proposal (Hannah)
- Reusable workflow callable cross-repo for downstream repos (Marcus)
- SHA-pinned composite action (Hannah)

## Dependencies

- [unbound-force/unbound-force#336](https://github.com/unbound-force/unbound-force/pull/336) —
  council-review-action composite action (SHA-pinned)

## Evidence

End-to-end validation in [#427](https://github.com/complytime/org-infra/pull/427):
- Collect workflow triggered on PR open, artifact uploaded
- Consumer workflow triggered via `workflow_dispatch`, ran successfully
- Council review posted 8 inline comments on valid diff lines
- Line annotation (`[L<N>]` prefix) eliminated patch-position confusion
- Previous bot comments cleaned up before posting new review

## Test plan

- [x] Collect workflow triggers on pull_request, artifact correct
- [x] Consumer → reusable chain via workflow_dispatch
- [x] WIF auth succeeds, OpenCode responds with structured JSON
- [x] Inline review comments posted on correct source-file lines (8/8)
- [x] Fallback to PR comment when inline posting fails
- [x] Previous bot comments deleted on re-review
- [x] End-to-end evidence: [#427](https://github.com/complytime/org-infra/pull/427)

## Post-merge checklist

- [x] Update action SHA in `reusable_council_review.yml` to merged `main` commit of unbound-force/unbound-force#336
- [ ] Verify full automatic chain fires on a real PR (collect → workflow_run → review)
- [ ] Delete stale branches: `test/council-review-bot`, `feat/council-review-production`, `test/council-review-evidence-v2`
- [ ] Close evidence PR #427
