### PR TITLE
feat(ci): add tag assertion guard to reusable_publish_ghcr.yml

### DIFF
--- a/.github/workflows/reusable_publish_ghcr.yml
+++ b/.github/workflows/reusable_publish_ghcr.yml
@@ -14,7 +14,7 @@
 # - Layer 3: Tag isolation (dev-sha-* and dev-* tags for unprotected refs)
 #
 # Tag Formats:
-# - Protected refs:   sha-<commit>, <branch> (e.g., sha-abc123, main)
+# - Protected refs:   sha-<commit>, <branch>, <tag> (e.g., sha-abc123, main, v1.2.3)
 # - Unprotected refs: dev-sha-<commit>, dev-<branch> (e.g., dev-sha-abc123, dev-feat-xyz)
 #
 # Attestations (SLSA provenance + SBOM):
@@ -261,6 +261,23 @@ jobs:
             org.opencontainers.image.title=${{ inputs.component_name }}
             org.opencontainers.image.description=${{ inputs.image_description || inputs.component_name }}
             ${{ inputs.image_vendor && format('org.opencontainers.image.vendor={0}', inputs.image_vendor) || '' }}
+
+      - name: Assert version tag for tag events
+        if: ${{ github.ref_type == 'tag' }}
+        env:
+          TAGS: ${{ steps.meta.outputs.tags }}
+          GIT_TAG: ${{ github.ref_name }}
+        run: |
+          if echo "$TAGS" | grep -qF ":${GIT_TAG}"; then
+            echo "::notice::✓ Version tag :${GIT_TAG} present in metadata output"
+          else
+            echo "::error::Version tag :${GIT_TAG} missing from metadata output"
+            echo "::error::Expected one of the generated tags to end with :${GIT_TAG}"
+            echo "::error::Generated tags:"
+            echo "$TAGS" | while read -r t; do echo "::error::  $t"; done
+            echo "::error::This usually means type=ref,event=tag was dropped from the metadata-action config"
+            exit 1
+          fi
 
       - name: Build and push
         id: build


### PR DESCRIPTION
## Summary

- Adds a pre-push validation step that asserts tag pushes produce a matching version tag in the `docker/metadata-action` output
- Fails the workflow **before** the build-and-push step if the version tag is missing, preventing silently untagged images
- Updates the header comment to document that tag events produce version tags
- Zero cost on branch/PR pushes (skipped by `if: github.ref_type == 'tag'`)

### Why

When `type=ref,event=tag` was accidentally dropped from the metadata config (fixed in #388), the workflow silently succeeded — images were pushed with only `sha-<commit>` tags. The regression went unnoticed for two release cycles in a downstream consumer (complytime/complypack#165). This assertion makes that class of failure loud and immediate.

### Test plan

- [ ] Tag push with `type=ref,event=tag` present: assertion passes, build proceeds
- [ ] Simulate removal of `type=ref,event=tag`: assertion fails with actionable error before build
- [ ] Branch push: assertion step is skipped entirely
- [ ] PR push: assertion step is skipped entirely

### Related

- Closes #432
- #388 — original fix that added `type=ref,event=tag`
- complytime/complypack#165 — downstream regression this prevents