### PR TITLE
fix(ci): use absolute install-dir for carabiner tool installs

### DIFF
--- a/.github/workflows/reusable_compliance.yml
+++ b/.github/workflows/reusable_compliance.yml
@@ -78,9 +78,13 @@ jobs:
 
       - name: Install snappy
         uses: carabiner-dev/actions/install/snappy@2a4b2cd115ede14629b03ef7e77586d3269d4c72
+        with:
+          install-dir: ${{ env.HOME }}/.carabiner
 
       - name: Install ampel
         uses: carabiner-dev/actions/install/ampel@2a4b2cd115ede14629b03ef7e77586d3269d4c72
+        with:
+          install-dir: ${{ env.HOME }}/.carabiner
 
       - name: Register ampel provider with complyctl
         run: |


### PR DESCRIPTION
## Problem

The daily `Compliance Checks` workflow has been failing since July 18 ([run #29879925190](https://github.com/complytime/org-infra/actions/runs/29879925190)).

The error from `complyctl generate`:
```
Error: provider ampel (evaluator "ampel"): required tools not found: snappy, ampel.
```

## Root Cause

A dependency bump of `carabiner-dev/actions/install/snappy` (1.2.1 -> 1.2.2, PR #435) changed how the composite action handles the `install-dir` input.

**Old action** hardcoded `$HOME` directly in shell scripts:
```bash
echo "$HOME/.carabiner/bin" >> $GITHUB_PATH
```
Bash expands `$HOME` to `/home/runner`, producing an **absolute** PATH entry.

**New action** uses `${INPUTS_INSTALL_DIR}` (set from the `install-dir` input, which defaults to `$HOME/.carabiner`):
```bash
echo "${INPUTS_INSTALL_DIR}/bin" >> $GITHUB_PATH
```
Bash does **not** recursively expand variables, so the `$HOME` inside the result is never expanded. This produces a **relative** PATH entry (`$HOME/.carabiner/bin` literally).

- **Bash** can still find tools via relative PATH entries (which is why `snappy version` / `ampel version` pass within the composite action sub-steps).
- **Go's `exec.LookPath`** (used by `complyctl-provider-ampel`) returns `exec.ErrDot` for non-absolute PATH entries (security hardening since Go 1.19), causing the provider to report the tools as not found.

## Fix

Pass `install-dir` explicitly using `${{ env.HOME }}/.carabiner`. The `${{ env.HOME }}` GitHub Actions expression is evaluated at the runner level to an absolute path (`/home/runner`), so the composite action receives an already-resolved absolute path. No bash re-expansion needed.

## Verification

Once merged, the next scheduled compliance run (daily at 00:00 UTC) should pass. It can also be verified via `workflow_dispatch`.