### PR TITLE
fix(renovate): add rangeStrategy bump for go directive updates

### DIFF
--- a/go-toolchain-patches.json
+++ b/go-toolchain-patches.json
@@ -14,6 +14,7 @@
       "matchManagers": ["gomod"],
       "matchDepNames": ["go"],
       "enabled": true,
+      "rangeStrategy": "bump",
       "separateMinorPatch": true,
       "automerge": false,
       "labels": ["dependencies"],


### PR DESCRIPTION
## Problem

The Renovate job runs successfully but never creates PRs to bump the `go` directive in `go.mod` files, even when repos are behind on patch versions.

**Affected repos** (from [run #25](https://github.com/complytime/org-infra/actions/runs/30071819441) report artifact):

| Repository | Current | Latest | Gap |
|:-----------|:--------|:-------|:----|
| complytime-collector-components | `1.26.4` | `1.26.5` | 1 patch behind |
| website | `1.25.8` | `1.25.12` | 4 patches behind |
| complytime-providers | `1.25.11` | `1.25.12` | 1 patch behind |

## Root Cause

The [`go-mod-directive` versioning](https://docs.renovatebot.com/modules/versioning/go-mod-directive/) treats the `go` directive as a **range constraint** (`^1.X.Y`), not a pinned version.

With the default `rangeStrategy` (`auto`/`replace`), Renovate only updates ranges when the latest version **falls outside** the existing range. Since `go 1.26.4` (treated as `^1.26.4`) already satisfies Go 1.26.5, Renovate considers it up-to-date and generates no update.

From the [Renovate docs](https://docs.renovatebot.com/configuration-options/#rangestrategy):
> By default, Renovate assumes that if you are using ranges then it's because you want them to be wide/open. Renovate won't deliberately "narrow" any range by increasing the semver value inside.

The `go-mod-directive` docs explicitly call this out:
> If you wish to upgrade this value every time there's a new minor Go release, configure `rangeStrategy` to be `"bump"`.

## Fix

Add `"rangeStrategy": "bump"` to the package rule that re-enables Go version directive updates in `go-toolchain-patches.json`. This tells Renovate to bump the minimum version even when the latest version already satisfies the current range.

The existing `separateMinorPatch: true` + Rule 3 (`matchUpdateTypes: ["minor", "major"]` disabled) correctly ensures only patch updates produce PRs.