### PR TITLE
fix(ci): use job-level env var for carabiner install-dir

### DIFF
--- a/.github/workflows/reusable_compliance.yml
+++ b/.github/workflows/reusable_compliance.yml
@@ -39,6 +39,9 @@ jobs:
     permissions:
       contents: read
 
+    env:
+      CARABINER_INSTALL_DIR: /home/runner/.carabiner
+
     steps:
       - name: Checkout complyctl source
         uses: actions/checkout@3d3c42e5aac5ba805825da76410c181273ba90b1 # v7.0.1
@@ -79,12 +82,12 @@ jobs:
       - name: Install snappy
         uses: carabiner-dev/actions/install/snappy@2a4b2cd115ede14629b03ef7e77586d3269d4c72
         with:
-          install-dir: ${{ env.HOME }}/.carabiner
+          install-dir: ${{ env.CARABINER_INSTALL_DIR }}
 
       - name: Install ampel
         uses: carabiner-dev/actions/install/ampel@2a4b2cd115ede14629b03ef7e77586d3269d4c72
         with:
-          install-dir: ${{ env.HOME }}/.carabiner
+          install-dir: ${{ env.CARABINER_INSTALL_DIR }}
 
       - name: Register ampel provider with complyctl
         run: |


### PR DESCRIPTION
## Problem

The daily `Compliance Checks` workflow is still failing after PR #453 ([run #30055881867](https://github.com/complytime/org-infra/actions/runs/30055881867/job/89367323356)).

The CI logs show:

```
INPUTS_INSTALL_DIR: /.carabiner
mkdir: cannot create directory '/.carabiner': Permission denied
curl: (23) Failure writing output to destination
```

## Root Cause

PR #453 used `${{ env.HOME }}/.carabiner`, expecting the GitHub Actions `env` context to include the system-inherited `HOME` variable. However, the `env` context only includes variables **explicitly set via `env:` keys** in the workflow/job/step — it does not include runner-inherited system environment variables like `HOME`. This caused `${{ env.HOME }}` to resolve to an empty string, producing `install-dir=/.carabiner` (filesystem root), which fails with `Permission denied`.

## Fix

Define `CARABINER_INSTALL_DIR` as a job-level `env` variable set to `/home/runner/.carabiner`. Since it is explicitly declared via `env:`, it is available in the `${{ env.* }}` expression context. Both the snappy and ampel install steps reference this single variable, making future updates straightforward.

## Verification

Trigger via `workflow_dispatch` on the Compliance Checks workflow after merge.