### PR TITLE
feat(compliance): expand branch protection targets

### DIFF
--- a/.complytime/complytime.yaml
+++ b/.complytime/complytime.yaml
@@ -7,11 +7,11 @@ complypacks:
     id: ampel-bp-pack
 
 targets:
-  - id: complytime-org-infra
+  - id: complytime-complyapi
     policies:
       - ampel-bp
     variables:
-      url: https://github.com/complytime/org-infra
+      url: https://github.com/complytime/complyapi
       specs: builtin:github/branch-rules.yaml
 
   - id: complytime-complyctl
@@ -19,4 +19,39 @@ targets:
       - ampel-bp
     variables:
       url: https://github.com/complytime/complyctl
+      specs: builtin:github/branch-rules.yaml
+
+  - id: complytime-complypack
+    policies:
+      - ampel-bp
+    variables:
+      url: https://github.com/complytime/complypack
+      specs: builtin:github/branch-rules.yaml
+
+  - id: complytime-collector-components
+    policies:
+      - ampel-bp
+    variables:
+      url: https://github.com/complytime/complytime-collector-components
+      specs: builtin:github/branch-rules.yaml
+
+  - id: complytime-policies
+    policies:
+      - ampel-bp
+    variables:
+      url: https://github.com/complytime/complytime-policies
+      specs: builtin:github/branch-rules.yaml
+
+  - id: complytime-org-infra
+    policies:
+      - ampel-bp
+    variables:
+      url: https://github.com/complytime/org-infra
+      specs: builtin:github/branch-rules.yaml
+
+  - id: complytime-providers
+    policies:
+      - ampel-bp
+    variables:
+      url: https://github.com/complytime/complytime-providers
       specs: builtin:github/branch-rules.yaml


### PR DESCRIPTION
## Summary

Expand the daily branch protection compliance check to cover all active code repositories in the ComplyTime org.

### Added targets (5 new)
- **complyapi** — push-based evidence API
- **complypack** — assessment logic packaging
- **complytime-collector-components** — policy-driven observability toolkit
- **complytime-policies** — engineering policies in Gemara
- **complytime-providers** — complyctl providers (formerly plugins)

### Existing targets (2)
- **complyctl** — CLI tool
- **org-infra** — reusable workflows and shared configs

### Excluded repositories
| Repository | Reason |
|---|---|
| `.github` | Workflow will be implemented there separately |
| `complyscribe` | Archived |
| `complytime` | Documentation only for now |
| `community` | Non-code |
| `complytime-demos` | Non-production |
| `homebrew-tap` | Distribution |
| `website` | Non-code |

### Other changes
- Targets sorted alphabetically by ID