### PR TITLE
chore: update user story issue template

### DIFF
--- a/.github/ISSUE_TEMPLATE/user_story.yml
+++ b/.github/ISSUE_TEMPLATE/user_story.yml
@@ -1,61 +1,74 @@
-name: User Story
-description: A user story with acceptance criteria, out-of-scope boundaries, and a definition of done
+name: "📖 User Story"
+description: Describe a feature or user outcome from the user's perspective.
 title: "[Story] "
+labels: ["type:story"]
 body:
-  - type: input
-    id: stakeholders
+  - type: markdown
     attributes:
-      label: "As (Stakeholders)"
-      description: Who are the stakeholders for this story?
-    validations:
-      required: true
+      value: |
+        ### 👤 User Story
   - type: input
-    id: outcome
+    id: as-a
     attributes:
-      label: "I want (Business Outcome)"
-      description: What is the desired business outcome?
+      label: "As a"
+      description: Type of user
+      placeholder: "[type of user]"
     validations:
       required: true
   - type: input
-    id: benefits
+    id: i-want
     attributes:
-      label: "So that (Business Benefits)"
-      description: What are the expected business benefits?
+      label: "I want to"
+      description: Perform an action / have a capability
+      placeholder: "[perform an action / have a capability]"
     validations:
       required: true
-  - type: textarea
-    id: description
+  - type: input
+    id: so-that
     attributes:
-      label: Description
-      description: What is the user benefit from this story?
+      label: "So that"
+      description: The business value or benefit received
+      placeholder: "[the business value or benefit received]"
     validations:
       required: true
+
   - type: textarea
     id: acceptance-criteria
     attributes:
-      label: Acceptance Criteria
-      description: List the criteria that must be met for this story to be considered complete.
+      label: "🎯 Acceptance Criteria"
+      description: What must happen for this feature to be considered structurally functional?
       placeholder: |
-        - [ ] Criterion 1
-        - [ ] Criterion 2
+        - [ ] Criteria 1 (e.g., Clicking 'Export' generates a CSV file download)
+        - [ ] Criteria 2
+        - [ ] Criteria 3
     validations:
       required: true
+
   - type: textarea
     id: out-of-scope
     attributes:
-      label: Out of Scope
-      description: What is explicitly out of scope for this story?
+      label: "🚫 Out of Scope"
+      description: What is explicitly not included in this story?
+      placeholder: |
+        - [ ] Item 1
+        - [ ] Item 2
     validations:
       required: false
+
   - type: checkboxes
-    id: definition-of-done
+    id: definition-of-done-quality
     attributes:
-      label: Definition of Done
-      description: Standard completion checklist.
+      label: "🏁 Definition of Done — 🛠️ Quality & Testing"
       options:
-        - label: Initial usage documentation has been created
-        - label: The feature has been demonstrated successfully in the target environment
-        - label: Proper testing has been completed (unit, integration, e2e, GitHub Actions)
-        - label: Code has been reviewed for bugs and vulnerabilities
-        - label: Technical debt has been documented if introduced
-        - label: Community buy-in/awareness has been obtained
+        - label: Code has been peer-reviewed for bugs and vulnerabilities.
+        - label: Proper testing has been completed and passes (Unit, Integration, E2E via GitHub Actions).
+        - label: The feature has been demonstrated/validated successfully in the target environment.
+
+  - type: checkboxes
+    id: definition-of-done-docs
+    attributes:
+      label: "🏁 Definition of Done — 📝 Architecture & Docs"
+      options:
+        - label: Usage documentation or changelog updated (if user-facing changes introduced).
+        - label: Local ADR written and verified by Tech Lead if technical architecture deviated.
+        - label: Any newly introduced technical debt has been logged as a GitHub issue.


### PR DESCRIPTION
## Summary

- Updates `.github/ISSUE_TEMPLATE/user_story.yml` to use classic **As a / I want to / So that** framing
- Adds **Acceptance Criteria** and **Out of Scope** fillable fields
- Splits **Definition of Done** into Quality & Testing and Architecture & Docs checkboxes
- Sets default label `type:story` and title prefix `[Story] `

## Related Issues

_N/A_

## Review Hints

- Open **New issue → 📖 User Story** after merge and confirm all form fields render
- Confirm `type:story` exists (or is created) in repos that sync this template
- Compare against the previous User Story form fields to ensure nothing critical was dropped unintentionally

---

Generated with Cursor assistance