### PR TITLE
chore: update task issue template

### DIFF
--- a/.github/ISSUE_TEMPLATE/task.yml
+++ b/.github/ISSUE_TEMPLATE/task.yml
@@ -1,33 +1,32 @@
-name: Task
-description: A tracked unit of work with sub-issues and a definition of done
+name: "⚙️ Task"
+description: A technical delivery task that does not directly introduce a new user-facing feature.
 title: "[Task] "
+labels: ["type:task"]
 body:
   - type: textarea
     id: description
     attributes:
-      label: Description
-      description: What is this task and why does it matter?
+      label: "📝 Description"
+      description: Provide a clear, technical overview of what needs to be changed in the codebase.
     validations:
       required: true
+
   - type: textarea
-    id: acceptance-criteria
+    id: technical-checklist
     attributes:
-      label: Acceptance Criteria
-      description: List the criteria that must be met for this task to be considered complete.
+      label: "🛠️ Technical Checklist"
+      description: Steps to complete this task.
       placeholder: |
-        - [ ] Criterion 1
-        - [ ] Criterion 2
+        - [ ] Step 1 (e.g., Run database migration scripts)
+        - [ ] Step 2 (e.g., Update configuration variables in environment files)
+        - [ ] Step 3
     validations:
       required: true
+
   - type: checkboxes
-    id: definition-of-done
+    id: verification-plan
     attributes:
-      label: Definition of Done
-      description: Standard completion checklist.
+      label: "🧪 Verification Plan"
       options:
-        - label: Initial usage documentation has been created
-        - label: The feature has been demonstrated successfully in the target environment
-        - label: Proper testing has been completed (unit, integration, e2e, GitHub Actions)
-        - label: Code has been reviewed for bugs and vulnerabilities
-        - label: Technical debt has been documented if introduced
-        - label: Community buy-in/awareness has been obtained
+        - label: Peer review completed.
+        - label: All CI/CD checks pass successfully in GitHub Actions.


### PR DESCRIPTION
## Summary

- Updates `.github/ISSUE_TEMPLATE/task.yml` for technical delivery work that is not a new user-facing feature
- Adds fillable **Description** and **Technical Checklist** fields
- Replaces the long Definition of Done with a short **Verification Plan**
- Sets default label `type:task` and title prefix `[Task] `

## Related Issues

_N/A_

## Review Hints

- Open **New issue → ⚙️ Task** after merge and confirm all form fields render
- Confirm `type:task` exists (or is created) in repos that sync this template

---

Generated with Cursor assistance