### PR TITLE
chore: add spike issue template

### DIFF
--- a/.github/ISSUE_TEMPLATE/spike.yml
+++ b/.github/ISSUE_TEMPLATE/spike.yml
@@ -22,20 +22,11 @@ body:
     validations:
       required: true
 
-  - type: input
-    id: branch-sandbox
-    attributes:
-      label: "Branch/Sandbox"
-      description: Branch or sandbox used for this investigation
-      placeholder: "spike/description-here"
-    validations:
-      required: true
-
   - type: checkboxes
     id: required-deliverables
     attributes:
       label: "🏁 Required Deliverables"
       options:
         - label: Written summary of findings added as a comment below or linked markdown file.
-        - label: Proof of Concept (PoC) code pushed to the spike branch (if applicable).
+        - label: Proof of Concept (PoC) code shared when applicable (branch, fork, or local investigation notes).
         - label: Clear "Go / No-Go" technical recommendation for the Architect.

--- a/.github/ISSUE_TEMPLATE/spike.yml
+++ b/.github/ISSUE_TEMPLATE/spike.yml
@@ -1,0 +1,41 @@
+name: "🔬 Spike"
+description: Time-boxed investigation to explore a technical approach or clear up uncertainty.
+title: "[Spike] "
+labels: ["type:spike"]
+body:
+  - type: textarea
+    id: core-question
+    attributes:
+      label: "❓ The Core Question"
+      description: What specific technical unknown are we trying to answer with this exploration?
+      placeholder: |
+        Example: Can our architecture handle 500 simultaneous requests on mobile viewports?
+    validations:
+      required: true
+
+  - type: input
+    id: time-allocated
+    attributes:
+      label: "⏱️ Time Allocated"
+      description: Time-box for this spike
+      placeholder: "e.g., 4 Hours / Max 1 Day"
+    validations:
+      required: true
+
+  - type: input
+    id: branch-sandbox
+    attributes:
+      label: "Branch/Sandbox"
+      description: Branch or sandbox used for this investigation
+      placeholder: "spike/description-here"
+    validations:
+      required: true
+
+  - type: checkboxes
+    id: required-deliverables
+    attributes:
+      label: "🏁 Required Deliverables"
+      options:
+        - label: Written summary of findings added as a comment below or linked markdown file.
+        - label: Proof of Concept (PoC) code pushed to the spike branch (if applicable).
+        - label: Clear "Go / No-Go" technical recommendation for the Architect.


### PR DESCRIPTION
## Summary

- Adds `.github/ISSUE_TEMPLATE/spike.yml` for time-boxed technical investigations
- Includes fillable **Core Question**, **Time Allocated**, and **Branch/Sandbox** fields
- Adds a **Required Deliverables** checklist (findings, PoC, Go/No-Go recommendation)
- Sets default label `type:spike` and title prefix `[Spike] `

## Related Issues

_N/A_

## Review Hints

- Open **New issue → 🔬 Spike** after merge and confirm all form fields render
- Confirm `type:spike` exists (or is created) in repos that will use this template

---

Generated with Cursor assistance