### PR TITLE
chore: sync issue templates across org repositories

### DIFF
--- a/README.md
+++ b/README.md
@@ -28,7 +28,8 @@ org-infra/
 ├── .github/
 │  ├── ISSUE_TEMPLATE/
 │  │  ├── bug_report.yml                    # Issue form to report a Bug.
-│  │  ├── feature_request.yml               # Issue form to request a Feature.
+│  │  ├── feature_request.yml               # Issue form for Features.
+│  │  ├── spike.yml                         # Issue form for time-boxed Spikes.
 │  │  ├── task.yml                          # Issue form for tracked work items.
 │  │  └── user_story.yml                    # Issue form for user stories.
 │  ├── workflows/

--- a/sync-config.yml
+++ b/sync-config.yml
@@ -124,11 +124,32 @@ files_to_sync:
   - source: .github/pull_request_template.md
     destination: .github/pull_request_template.md
 
+  # Issue forms — synced to all org repos except roadmap (global exclude)
+  # and complytime/complytime (per-file exclude below).
   - source: .github/ISSUE_TEMPLATE/bug_report.yml
     destination: .github/ISSUE_TEMPLATE/bug_report.yml
+    exclude_repos:
+      - complytime
 
   - source: .github/ISSUE_TEMPLATE/feature_request.yml
     destination: .github/ISSUE_TEMPLATE/feature_request.yml
+    exclude_repos:
+      - complytime
+
+  - source: .github/ISSUE_TEMPLATE/task.yml
+    destination: .github/ISSUE_TEMPLATE/task.yml
+    exclude_repos:
+      - complytime
+
+  - source: .github/ISSUE_TEMPLATE/user_story.yml
+    destination: .github/ISSUE_TEMPLATE/user_story.yml
+    exclude_repos:
+      - complytime
+
+  - source: .github/ISSUE_TEMPLATE/spike.yml
+    destination: .github/ISSUE_TEMPLATE/spike.yml
+    exclude_repos:
+      - complytime
 
 # Dependabot configuration
 # Common entries are applied to all repos (unless excluded).


### PR DESCRIPTION
## Summary

- Updates `sync-config.yml` so org issue forms are distributed to ComplyTime repositories via the existing sync workflow
- Syncs: `bug_report.yml`, `feature_request.yml`, `task.yml`, `user_story.yml`, `spike.yml`
- **Excludes** `roadmap` (already in global `exclude_repos`) and `complytime` (`complytime/complytime`) from issue template sync
- Updates `README.md` directory listing to include `spike.yml`

## Dependencies (do not merge until these are approved)

This PR depends on the **approval and merge** of the updated issue template PRs. Sync would otherwise distribute the old templates (or fail for missing files like `spike.yml`):

- #470 — User Story template
- #471 — Task template
- #472 — Spike template
- #473 — Bug Report template
- #474 — Feature template

**Please merge those first**, then merge this PR, then run (or wait for) the org repository sync workflow.

## Related Issues

_N/A_

## Review Hints

- Confirm `roadmap` remains in global `exclude_repos`
- Confirm each issue template entry excludes `complytime`
- After dependent PRs merge, dry-run sync against one target repo if helpful

---

Generated with Cursor assistance