### PR TITLE
chore: disable renovate vulnerability alerts

### DIFF
--- a/go-toolchain-patches.json
+++ b/go-toolchain-patches.json
@@ -28,5 +28,9 @@
       "enabled": false
     }
   ],
-  "postUpdateOptions": ["gomodTidy", "gomodVendor"]
+  "postUpdateOptions": ["gomodTidy", "gomodVendor"],
+  "vulnerabilityAlerts": {
+    "description": "Disabled — vulnerability remediation is handled by Dependabot",
+    "enabled": false
+  }
 }


### PR DESCRIPTION
## Summary

Explicitly disable Renovate's `vulnerabilityAlerts` feature in `go-toolchain-patches.json`.

## Problem

The Renovate workflow summary shows warnings for every autodiscovered repository:

> Cannot access vulnerability alerts. Please ensure permissions have been granted.

This happens because Renovate's `vulnerabilityAlerts` feature is enabled by default and the `complytime-renovate[bot]` App lacks the `Dependabot alerts: read` permission.

## Solution

Rather than granting additional permissions, disable the feature explicitly since:

- **Dependabot is already enabled** across org repositories and handles vulnerability remediation.
- Enabling Renovate's vulnerability alerts would create **duplicate/conflicting PRs** with Dependabot.
- Renovate's vulnerability fix PRs **bypass package rules** (`enabled: false`, schedules, rate limits), which would expand the workflow's scope beyond its intended purpose of Go version patch updates only.

## Changes

- `go-toolchain-patches.json`: Added `"vulnerabilityAlerts": { "enabled": false }` with a description explaining the rationale.

## Verification

After merging, the next scheduled or manual Renovate run should no longer show the "Cannot access vulnerability alerts" warnings in the job summary.

Ref: https://github.com/complytime/org-infra/actions/runs/30334293691