### PR TITLE
fix(workflow): use requirements file for pip hash verification

### DIFF
--- a/.github/workflows/reusable_release_preflight.yml
+++ b/.github/workflows/reusable_release_preflight.yml
@@ -179,11 +179,12 @@ jobs:
           fi
 
           # Compare versions using semver library (section 11 compliant)
-          # semver==3.0.4
-          pip install -q "semver==3.0.4" \
-            --require-hashes --no-deps \
-            --hash=sha256:9c824d87ba7f7ab4a1890799cec8596f15c1241cb473404ea1cb0c55e4b04746 \
-            >/dev/null 2>&1
+          # semver==3.0.4 — use requirements file for pip 25.x compatibility
+          echo "semver==3.0.4 \
+            --hash=sha256:9c824d87ba7f7ab4a1890799cec8596f15c1241cb473404ea1cb0c55e4b04746" \
+            > /tmp/requirements-semver.txt
+          pip install -q --require-hashes --no-deps \
+            -r /tmp/requirements-semver.txt >/dev/null 2>&1
           python3 -c "import semver, sys; sys.exit(0 if semver.compare(sys.argv[1], sys.argv[2]) < 0 else 1)" \
             "$LATEST_VER" "$NEW_VER" || {
             echo "::error::New tag $RELEASE_TAG is not greater than $LATEST_TAG"


### PR DESCRIPTION
## Problem

pip 25.x (now shipped on `ubuntu-latest` / `ubuntu-24.04` runner images) removed `--hash` as a CLI option. The `--hash` syntax is now only valid as a [per-requirement option inside requirements files](https://pip.pypa.io/en/stable/reference/requirements-file-format/#per-requirement-options).

The "Verify semver ordering" step in `reusable_release_preflight.yml` used `--hash=sha256:...` on the `pip install` command line. This caused pip to exit with code 2 ("no such option"), and because stderr was redirected to `/dev/null`, the step failed silently before the semver comparison ever ran.

**This blocks any repository using this reusable workflow from cutting a release.**

Evidence: [complytime/complyctl release run #30375819666](https://github.com/complytime/complyctl/actions/runs/30375819666/job/90331111728)

## Fix

Write the pinned dependency with its hash to a temporary requirements file and install via `-r`:

```bash
echo "semver==3.0.4 \\
  --hash=sha256:9c824d87ba7f7ab4a1890799cec8596f15c1241cb473404ea1cb0c55e4b04746" \
  > /tmp/requirements-semver.txt
pip install -q --require-hashes --no-deps \
  -r /tmp/requirements-semver.txt >/dev/null 2>&1
```

- `--hash` inside requirements files: supported in all pip versions (documented per-requirement option since pip 7.0)
- `--require-hashes` on the CLI: supported in all pip versions (documented CLI flag)
- `-r <file>` on the CLI: supported in all pip versions

## Follow-up (after merge)

1. Cut org-infra release `v0.6.1`
2. Update `complytime/complyctl` `release.yml` to reference the new SHA (currently pinned to `aff4817` / v0.6.0)
3. Re-run the complyctl release workflow with tag `v1.0.0`