### PR TITLE
fix(workflow): compact JSON output and skip inputs for release preflight

### DIFF
--- a/.github/workflows/reusable_release_preflight.yml
+++ b/.github/workflows/reusable_release_preflight.yml
@@ -47,6 +47,21 @@ on:
         required: false
         type: string
         default: ''
+      skip_semver_check:
+        description: 'Skip semver ordering verification against the latest existing tag'
+        required: false
+        type: boolean
+        default: false
+      skip_ci_checks:
+        description: 'Skip CI check verification on HEAD commit'
+        required: false
+        type: boolean
+        default: false
+      skip_unreleased_check:
+        description: 'Skip verification that unreleased commits exist since the last tag'
+        required: false
+        type: boolean
+        default: false
     outputs:
       tag:
         description: 'Validated tag string'
@@ -153,7 +168,9 @@ jobs:
           fi
 
       - name: Verify semver ordering
-        if: steps.check_tag.outputs.tag_exists_at_head != 'true'
+        if: >-
+          steps.check_tag.outputs.tag_exists_at_head != 'true'
+          && inputs.skip_semver_check != true
         id: verify_ordering
         run: |
           # Get the latest existing semver tag
@@ -193,6 +210,7 @@ jobs:
           echo "::notice::Semver ordering verified: $LATEST_TAG < $RELEASE_TAG"
 
       - name: Discover CI checks
+        if: inputs.skip_ci_checks != true
         id: discover_checks
         env:
           CI_CHECKS_INPUT: ${{ inputs.ci_checks }}
@@ -270,6 +288,7 @@ jobs:
           echo "::notice::Security gate: $SECURITY_GATE"
 
       - name: Verify CI checks passed on HEAD
+        if: inputs.skip_ci_checks != true
         id: verify_ci
         env:
           GH_TOKEN: ${{ secrets.GITHUB_TOKEN }}
@@ -339,7 +358,9 @@ jobs:
           echo "::notice::All CI checks passed for commit $HEAD_SHA"
 
       - name: Verify unreleased commits
-        if: steps.check_tag.outputs.is_rerun != 'true'
+        if: >-
+          steps.check_tag.outputs.is_rerun != 'true'
+          && inputs.skip_unreleased_check != true
         id: verify_commits
         run: |
           LATEST_TAG=$(git tag -l 'v[0-9]*' --sort=-v:refname | head -1)

--- a/.github/workflows/reusable_release_preflight.yml
+++ b/.github/workflows/reusable_release_preflight.yml
@@ -263,7 +263,7 @@ jobs:
           fi
 
           # Output discovered checks as JSON array
-          CHECKS_JSON=$(printf '%s\n' "${REQUIRED_CHECKS[@]}" | jq -R . | jq -s .)
+          CHECKS_JSON=$(printf '%s\n' "${REQUIRED_CHECKS[@]}" | jq -R . | jq -s -c .)
           echo "required_checks=$CHECKS_JSON" >> "$GITHUB_OUTPUT"
           echo "security_gate=$SECURITY_GATE" >> "$GITHUB_OUTPUT"
           echo "::notice::Required checks: $CHECKS_JSON"


### PR DESCRIPTION
## Changes

Two commits fixing and improving `reusable_release_preflight.yml`:

### 1. Fix: compact JSON for GITHUB_OUTPUT (bug fix)

`jq -s .` produces pretty-printed multi-line JSON, but `$GITHUB_OUTPUT` expects `key=value` on a single line. The multi-line output caused:

```
##[error]Invalid format '  "unit-test",'
```

Fix: `jq -s -c .` produces compact single-line JSON.

Evidence: [complyctl run #30379489409](https://github.com/complytime/complyctl/actions/runs/30379489409/job/90343533191)

### 2. Feature: skip inputs for optional validations

Three new boolean inputs, all defaulting to `false` (everything required by default):

| Input | Skips |
|---|---|
| `skip_semver_check` | Semver ordering verification |
| `skip_ci_checks` | CI check discovery and verification |
| `skip_unreleased_check` | Unreleased commits verification |

Tag format validation and tag uniqueness remain **mandatory** and cannot be skipped.

Example usage in a consumer workflow:

```yaml
uses: complytime/org-infra/.github/workflows/reusable_release_preflight.yml@<sha>
with:
  tag: ${{ inputs.tag }}
  skip_ci_checks: true  # unblock release while CI catches up
```

## Context

This is the second preflight fix (first: #483). Together they address both failures seen in the complyctl release pipeline:
- Run #28: pip `--hash` CLI failure (fixed by #483)
- Run #29: multi-line JSON in `$GITHUB_OUTPUT` (fixed here)

## Follow-up

After merge, cut org-infra `v0.7.1` and update complyctl's `release.yml` SHA.