### PR TITLE
fix: exclude complytime-policies from ruff.toml sync and pip dependabot

### DIFF
--- a/sync-config.yml
+++ b/sync-config.yml
@@ -86,6 +86,7 @@ files_to_sync:
       - complypack
       - complytime
       - complytime-collector-components
+      - complytime-policies
       - complytime-providers
       - community
       - website
@@ -205,16 +206,6 @@ dependabot:
           include: "scope"
 
     complytime-demos:
-      - package-ecosystem: "pip"
-        directory: "/"
-        schedule:
-          interval: "weekly"
-        open-pull-requests-limit: 10
-        commit-message:
-          prefix: "chore"
-          include: "scope"
-
-    complytime-policies:
       - package-ecosystem: "pip"
         directory: "/"
         schedule:


### PR DESCRIPTION
## Summary

`complytime-policies` is an OSCAL YAML/JSON repository (Gemara governance artifacts) with no Python source code. The sync workflow was distributing `ruff.toml` and generating a `pip` Dependabot entry for it — both inert and flagged by reviewers in complytime-policies#51.

This PR:
- Adds `complytime-policies` to the `exclude_repos` list for `ruff.toml` in `sync-config.yml`
- Removes the `complytime-policies` override under `dependabot.overrides` that generated a `pip` ecosystem entry

The common Dependabot entries (`github-actions`, `pre-commit`) continue to apply to `complytime-policies` via the `dependabot.common` block — no coverage gap.

## Related Issues

Closes #486

A follow-up issue (#491) tracks the longer-term solution: an opt-in language group system to replace per-file `exclude_repos` lists.

## Review Hints

Only `sync-config.yml` is modified. The two changes are:
1. **Line 89** — `complytime-policies` added to `ruff.toml`'s `exclude_repos` (alphabetical order preserved)
2. **Lines 217–225 removed** — the `complytime-policies` pip Dependabot override block