### PR TITLE
feat(ci): security hardening for council review workflows

### DIFF
--- a/.github/workflows/ci_council_review.yml
+++ b/.github/workflows/ci_council_review.yml
@@ -8,8 +8,12 @@ name: Council Review
 
 # --------------------------------------------------------------------------
 # Thin consumer workflow for AI council review. Triggered by workflow_run
-# when the collect workflow completes (fork PR support), or manually via
-# workflow_dispatch. Delegates all review logic to reusable_council_review.yml.
+# when the collect workflow completes (comment-triggered via /council-review),
+# or manually via workflow_dispatch. Delegates all review logic to
+# reusable_council_review.yml.
+#
+# Rate limiting: per-PR concurrency group prevents parallel reviews on the
+# same PR. The reusable workflow enforces a 5-minute cooldown between reviews.
 # --------------------------------------------------------------------------
 on:
   workflow_dispatch:

--- a/.github/workflows/ci_council_review_collect.yml
+++ b/.github/workflows/ci_council_review_collect.yml
@@ -7,35 +7,56 @@
 name: Council Review - Collect
 
 # --------------------------------------------------------------------------
-# Fork-safe PR diff collection for AI council review. Runs on pull_request,
-# collects the PR diff and metadata, then uploads as an artifact for
+# Comment-triggered PR diff collection for AI council review.
+# Runs when an org member posts `/council-review` on a PR.
+# Collects the PR diff and metadata, then uploads as an artifact for
 # ci_council_review.yml to pick up via workflow_run.
+#
+# Security: only org members can invoke (verified via GitHub API).
+# Non-member comments are ignored with a notice reply.
 #
 # Org membership check uses ORG_CHECK_TOKEN (PAT with org:read scope) if
 # available, falling back to GITHUB_TOKEN (public membership only).
 # --------------------------------------------------------------------------
 on:
-  pull_request:
-    types: [opened, synchronize, reopened, ready_for_review]
-    branches: [main]
+  issue_comment:
+    types: [created]
 
 permissions: {}
 
 jobs:
   gate-check:
     name: Gate Check
+    # Only run on PR comments (not issue comments) that start with /council-review
+    if: >-
+      github.event.issue.pull_request &&
+      startsWith(github.event.comment.body, '/council-review')
     runs-on: ubuntu-latest
     permissions:
       contents: read
+      pull-requests: write
     outputs:
       should_collect: ${{ steps.org-check.outputs.should_collect != '' && steps.org-check.outputs.should_collect || steps.gate.outputs.should_collect }}
+      pr_number: ${{ github.event.issue.number }}
     steps:
       - name: Evaluate gate conditions
         id: gate
         env:
-          PR_AUTHOR: ${{ github.event.pull_request.user.login }}
-          PR_DRAFT: ${{ github.event.pull_request.draft }}
+          GH_TOKEN: ${{ github.token }}
+          PR_NUMBER: ${{ github.event.issue.number }}
+          REPO: ${{ github.repository }}
         run: |
+          # Fetch PR details to check state and draft status
+          PR_JSON=$(gh api "repos/${REPO}/pulls/${PR_NUMBER}")
+          PR_STATE=$(echo "${PR_JSON}" | jq -r '.state')
+          PR_DRAFT=$(echo "${PR_JSON}" | jq -r '.draft')
+          PR_AUTHOR=$(echo "${PR_JSON}" | jq -r '.user.login')
+
+          if [[ "${PR_STATE}" != "open" ]]; then
+            echo "::notice::PR is ${PR_STATE} — skipping council review"
+            echo "should_collect=false" >> "$GITHUB_OUTPUT"
+            exit 0
+          fi
           if [[ "${PR_DRAFT}" == "true" ]]; then
             echo "::notice::Draft PR — skipping council review"
             echo "should_collect=false" >> "$GITHUB_OUTPUT"
@@ -48,23 +69,40 @@ jobs:
           fi
           echo "should_collect=true" >> "$GITHUB_OUTPUT"
 
-      - name: Verify org membership
+      - name: Verify org membership of commenter
         if: steps.gate.outputs.should_collect == 'true'
         id: org-check
         env:
           GH_TOKEN: ${{ secrets.ORG_CHECK_TOKEN != '' && secrets.ORG_CHECK_TOKEN || github.token }}
-          ACTOR: ${{ github.event.pull_request.user.login }}
+          COMMENTER: ${{ github.event.comment.user.login }}
           ORG: ${{ github.repository_owner }}
+          REPO: ${{ github.repository }}
+          PR_NUMBER: ${{ github.event.issue.number }}
+          POST_TOKEN: ${{ github.token }}
         run: |
           HTTP_STATUS=$(curl -s -L -o /dev/null -w "%{http_code}" \
             -H "Authorization: token $GH_TOKEN" \
             -H "Accept: application/vnd.github+json" \
-            "https://api.github.com/orgs/$ORG/members/$ACTOR")
+            "https://api.github.com/orgs/$ORG/members/$COMMENTER")
+          if [[ "$HTTP_STATUS" == "401" || "$HTTP_STATUS" == "403" ]]; then
+            echo "::warning::Org membership check failed with HTTP ${HTTP_STATUS} — ORG_CHECK_TOKEN may be expired or misconfigured"
+            echo "should_collect=false" >> "$GITHUB_OUTPUT"
+            exit 0
+          fi
           if [[ "$HTTP_STATUS" != "204" ]]; then
-            echo "::notice::PR author ${ACTOR} is not a member of ${ORG} (HTTP ${HTTP_STATUS}) — skipping council review"
+            echo "::notice::Commenter ${COMMENTER} is not a member of ${ORG} (HTTP ${HTTP_STATUS}) — ignoring /council-review"
+            # Post a notice reply so the commenter knows why it was ignored
+            {
+              echo "<!-- council-review-bot -->"
+              echo "> \`/council-review\` is available to org members."
+              echo "> If you'd like a council review on this PR, ask an org member to run the command."
+            } > /tmp/council-review-notice.md
+            GH_TOKEN="${POST_TOKEN}" gh pr comment "${PR_NUMBER}" \
+              --repo "${REPO}" \
+              --body-file /tmp/council-review-notice.md
             echo "should_collect=false" >> "$GITHUB_OUTPUT"
           else
-            echo "::notice::✓ ${ACTOR} is a member of ${ORG}"
+            echo "::notice::${COMMENTER} is a member of ${ORG}"
             echo "should_collect=true" >> "$GITHUB_OUTPUT"
           fi
 
@@ -77,20 +115,39 @@ jobs:
       contents: read
       pull-requests: read
     steps:
+      - name: Fetch PR details
+        id: pr
+        env:
+          GH_TOKEN: ${{ github.token }}
+          PR_NUMBER: ${{ needs.gate-check.outputs.pr_number }}
+          REPO: ${{ github.repository }}
+        run: |
+          PR_JSON=$(gh api "repos/${REPO}/pulls/${PR_NUMBER}")
+          {
+            echo "head_sha=$(echo "${PR_JSON}" | jq -r '.head.sha')"
+            echo "base_ref=$(echo "${PR_JSON}" | jq -r '.base.ref')"
+          } >> "$GITHUB_OUTPUT"
+          # Use heredoc delimiter for title to handle newlines safely
+          {
+            echo "title<<TITLE_EOF"
+            echo "${PR_JSON}" | jq -r '.title'
+            echo "TITLE_EOF"
+          } >> "$GITHUB_OUTPUT"
+
       - name: Collect PR diff
         env:
           GH_TOKEN: ${{ github.token }}
-          PR_NUMBER: ${{ github.event.pull_request.number }}
+          PR_NUMBER: ${{ needs.gate-check.outputs.pr_number }}
         run: |
           gh pr diff "${PR_NUMBER}" \
             --repo "${{ github.repository }}" > pr-diff.patch
 
       - name: Write PR metadata
         env:
-          PR_NUMBER: ${{ github.event.pull_request.number }}
-          PR_HEAD_SHA: ${{ github.event.pull_request.head.sha }}
-          PR_BASE_REF: ${{ github.event.pull_request.base.ref }}
-          PR_TITLE: ${{ github.event.pull_request.title }}
+          PR_NUMBER: ${{ needs.gate-check.outputs.pr_number }}
+          PR_HEAD_SHA: ${{ steps.pr.outputs.head_sha }}
+          PR_BASE_REF: ${{ steps.pr.outputs.base_ref }}
+          PR_TITLE: ${{ steps.pr.outputs.title }}
         run: |
           jq -n \
             --arg number "${PR_NUMBER}" \

--- a/.github/workflows/reusable_council_review.yml
+++ b/.github/workflows/reusable_council_review.yml
@@ -9,6 +9,11 @@ name: Reusable Council Review
 # inline review comments on the PR.
 #
 # Called by ci_council_review.yml (consumer workflow).
+#
+# Security hardening (#429):
+# - Network egress blocked via step-security/harden-runner; only Vertex AI,
+#   GitHub API, npm registry, and GCP auth endpoints are allowed.
+# - 5-minute cooldown between reviews per PR to prevent token exhaustion.
 # --------------------------------------------------------------------------
 on:
   workflow_call:
@@ -42,6 +47,29 @@ jobs:
     env:
       VERTEX_LOCATION: global
     steps:
+      - name: Harden runner
+        uses: step-security/harden-runner@bf7454d06d71f1098171f2acdf0cd4708d7b5920 # v2.20.0
+        with:
+          egress-policy: block
+          # Vertex AI may route to regional endpoints for Anthropic models
+          # even when using the global endpoint. Add new regions here if
+          # the model routing changes.
+          allowed-endpoints: >
+            agent.api.stepsecurity.io:443
+            api.github.com:443
+            github.com:443
+            uploads.github.com:443
+            objects.githubusercontent.com:443
+            global-aiplatform.googleapis.com:443
+            us-central1-aiplatform.googleapis.com:443
+            us-east1-aiplatform.googleapis.com:443
+            oauth2.googleapis.com:443
+            iamcredentials.googleapis.com:443
+            sts.googleapis.com:443
+            storage.googleapis.com:443
+            registry.npmjs.org:443
+            nodejs.org:443
+
       - name: Check WIF credentials
         id: gate
         env:
@@ -79,22 +107,73 @@ jobs:
             echo "pr_head_sha=${PR_HEAD_SHA}"
           } >> "$GITHUB_OUTPUT"
 
-      - name: Authenticate to Google Cloud (WIF)
+      - name: Check cooldown (5-minute minimum between reviews)
         if: steps.gate.outputs.should_review == 'true'
+        id: cooldown
+        env:
+          GH_TOKEN: ${{ github.token }}
+          PR_NUMBER: ${{ steps.meta.outputs.pr_number }}
+          REPO: ${{ github.repository }}
+          COOLDOWN_SECONDS: "300"
+        run: |
+          # Find the most recent actual review comment timestamp.
+          # Filter for "## AI Council Review" to exclude cooldown notices
+          # and non-member notices (which also contain the bot sentinel).
+          LAST_REVIEW=$(gh api "repos/${REPO}/issues/${PR_NUMBER}/comments" \
+            --paginate --jq '[.[] | select(.body | contains("<!-- council-review-bot -->") and (.body | contains("## AI Council Review"))) | .created_at] | sort | last // empty')
+
+          if [[ -z "${LAST_REVIEW}" ]]; then
+            echo "::notice::No previous council review found — proceeding"
+            echo "cooled_down=true" >> "$GITHUB_OUTPUT"
+            exit 0
+          fi
+
+          LAST_EPOCH=$(date -d "${LAST_REVIEW}" +%s 2>/dev/null || echo "0")
+          if [[ "${LAST_EPOCH}" == "0" ]]; then
+            echo "::warning::Could not parse last review timestamp '${LAST_REVIEW}' — skipping cooldown"
+            echo "cooled_down=true" >> "$GITHUB_OUTPUT"
+            exit 0
+          fi
+
+          NOW_EPOCH=$(date +%s)
+          ELAPSED=$((NOW_EPOCH - LAST_EPOCH))
+
+          if [[ "${ELAPSED}" -lt "${COOLDOWN_SECONDS}" ]]; then
+            REMAINING=$((COOLDOWN_SECONDS - ELAPSED))
+            echo "::notice::Council review cooldown active — last review ${ELAPSED}s ago, ${REMAINING}s remaining. Skipping."
+            # Post a notice comment so the user knows why the review was skipped
+            {
+              echo "<!-- council-review-bot -->"
+              echo "> Council review cooldown active — last review was ${ELAPSED}s ago."
+              echo "> Please wait ${REMAINING}s before requesting another review."
+            } > /tmp/council-review-cooldown.md
+            gh pr comment "${PR_NUMBER}" --repo "${REPO}" --body-file /tmp/council-review-cooldown.md
+            echo "cooled_down=false" >> "$GITHUB_OUTPUT"
+          else
+            echo "::notice::Cooldown elapsed (${ELAPSED}s since last review) — proceeding"
+            echo "cooled_down=true" >> "$GITHUB_OUTPUT"
+          fi
+
+      - name: Authenticate to Google Cloud (WIF)
+        if: >-
+          steps.gate.outputs.should_review == 'true' &&
+          steps.cooldown.outputs.cooled_down == 'true'
         uses: google-github-actions/auth@7c6bc770dae815cd3e89ee6cdf493a5fab2cc093 # v3.0.0
         with:
           project_id: ${{ secrets.GCP_PROJECT_ID }}
           workload_identity_provider: ${{ secrets.GCP_WORKLOAD_IDENTITY_PROVIDER }}
 
       - name: Set up gcloud CLI
-        if: steps.gate.outputs.should_review == 'true'
+        if: >-
+          steps.gate.outputs.should_review == 'true' &&
+          steps.cooldown.outputs.cooled_down == 'true'
         uses: google-github-actions/setup-gcloud@aa5489c8933f4cc7a4f7d45035b3b1440c9c10db # v3.0.1
 
-      # TODO(#440): remove continue-on-error once council review is stable
       - name: Run council review
-        if: steps.gate.outputs.should_review == 'true'
+        if: >-
+          steps.gate.outputs.should_review == 'true' &&
+          steps.cooldown.outputs.cooled_down == 'true'
         id: review
-        continue-on-error: true
         uses: unbound-force/unbound-force/council-review-action@7836c070a63f3eeeab78ebd48c5dd5921ae486e2  # main (merged #336)
         with:
           model: ${{ inputs.model }}
@@ -105,6 +184,7 @@ jobs:
       - name: Clean up previous bot comments
         if: >-
           steps.gate.outputs.should_review == 'true' &&
+          steps.cooldown.outputs.cooled_down == 'true' &&
           steps.review.outcome == 'success'
         env:
           GH_TOKEN: ${{ github.token }}
@@ -135,6 +215,7 @@ jobs:
       - name: Post review summary
         if: >-
           steps.gate.outputs.should_review == 'true' &&
+          steps.cooldown.outputs.cooled_down == 'true' &&
           steps.review.outcome == 'success'
         env:
           GH_TOKEN: ${{ github.token }}
@@ -172,6 +253,7 @@ jobs:
       - name: Post inline comments
         if: >-
           steps.gate.outputs.should_review == 'true' &&
+          steps.cooldown.outputs.cooled_down == 'true' &&
           steps.review.outcome == 'success' &&
           steps.review.outputs.review-mode == 'inline'
         env:

--- a/AGENTS.md
+++ b/AGENTS.md
@@ -30,24 +30,29 @@ make clean           # Remove __pycache__ and .pyc
 
 ## Council Review (AI-assisted PR review)
 
-Three-workflow chain for automated AI code review using OpenCode on Vertex AI,
-with Divisor persona discovery from the reviewed repo.
+Comment-triggered workflow chain for AI code review using OpenCode on Vertex AI,
+with Divisor persona discovery from the reviewed repo. Invoked by posting
+`/council-review` as a PR comment. Only org members can invoke.
 
 ### Workflow chain
 
 ```text
-ci_council_review_collect.yml  (pull_request)  [synced to downstream repos]
-  ├── Gate: skip drafts, dependabot, non-org-members
+ci_council_review_collect.yml  (issue_comment: /council-review)  [synced]
+  ├── Gate: only PR comments starting with /council-review
+  ├── Gate: skip drafts, dependabot PRs
+  ├── Gate: verify commenter is an org member (notice reply if not)
   ├── Collect diff: gh pr diff → pr-diff.patch
   ├── Build metadata: pr-meta.json
   └── Upload artifact (1-day retention)
          │
          ▼  workflow_run / workflow_dispatch
-ci_council_review.yml  (consumer)  [synced to downstream repos]
+ci_council_review.yml  (consumer)  [synced]
   └── Calls reusable_council_review.yml@main (org-infra only)
          │
          ▼  workflow_call
 reusable_council_review.yml  [NOT synced — org-infra only]
+  ├── Harden runner (egress blocked, allowlist only)
+  ├── Cooldown check (5-minute minimum between reviews)
   ├── WIF auth → Vertex AI
   ├── council-review-action (composite, SHA-pinned, from unbound-force)
   ├── Clean up previous bot comments
@@ -77,7 +82,6 @@ are in place.
 
 - Security hardening: #429
 - Token consumption controls: #430
-- `continue-on-error` removal: #440
 - Composite action: `unbound-force/unbound-force` → `council-review-action/`
 
 See `docs/COUNCIL_REVIEW.md` for the full operational guide.

--- a/CODEOWNERS
+++ b/CODEOWNERS
@@ -2,3 +2,11 @@
 # Unless a later match takes precedence, the team will be requested for review
 # when someone opens a pull request.
 *       @complytime/complytime-dev
+
+# Council review workflow files — explicit entries ensure these files always
+# require complytime-dev review even if the default owner changes in the future.
+# These files control AI review infrastructure, token consumption, and security
+# gates. Refs: #429 (security hardening)
+.github/workflows/ci_council_review.yml           @complytime/complytime-dev
+.github/workflows/ci_council_review_collect.yml    @complytime/complytime-dev
+.github/workflows/reusable_council_review.yml      @complytime/complytime-dev

--- a/docs/COUNCIL_REVIEW.md
+++ b/docs/COUNCIL_REVIEW.md
@@ -2,6 +2,8 @@
 
 AI-assisted PR review using OpenCode on Vertex AI with Divisor persona
 discovery. Reviews are posted as inline comments on PR diff lines.
+Invoked by posting `/council-review` as a PR comment. Only org members
+can invoke.
 
 ## Architecture
 
@@ -9,8 +11,10 @@ discovery. Reviews are posted as inline comments on PR diff lines.
 ┌─────────────────────────────────────────────────────────┐
 │  Downstream Repo (e.g., complytime, gaze)               │
 │                                                         │
-│  ci_council_review_collect.yml  (pull_request trigger)  │
-│  ├── Gate: skip bots, drafts, non-org-members           │
+│  ci_council_review_collect.yml  (issue_comment trigger) │
+│  ├── Gate: only PR comments starting with /council-review│
+│  ├── Gate: skip drafts, dependabot PRs                  │
+│  ├── Gate: verify commenter is org member (notice if not)│
 │  ├── Capture diff: gh pr diff → pr-diff.patch           │
 │  ├── Build metadata: pr-meta.json                       │
 │  └── Upload artifact: council-review-diff               │
@@ -22,6 +26,8 @@ discovery. Reviews are posted as inline comments on PR diff lines.
 ┌────────────────────────▼────────────────────────────────┐
 │  org-infra: reusable_council_review.yml                 │
 │                                                         │
+│  ├── Harden runner (egress blocked, allowlist only)     │
+│  ├── Cooldown check (5-minute minimum between reviews)  │
 │  ├── Download artifact (pr-diff.patch, pr-meta.json)    │
 │  ├── WIF auth → Google Cloud (Vertex AI)                │
 │  ├── council-review-action (SHA-pinned composite)       │
@@ -41,9 +47,9 @@ discovery. Reviews are posted as inline comments on PR diff lines.
 
 | File | Synced? | Trigger | Purpose |
 |------|---------|---------|---------|
-| `ci_council_review_collect.yml` | Yes | `pull_request` | Fork-safe diff collection, no secrets needed |
+| `ci_council_review_collect.yml` | Yes | `issue_comment` | Comment-triggered diff collection (`/council-review`) |
 | `ci_council_review.yml` | Yes | `workflow_run` / `workflow_dispatch` | Thin consumer, passes secrets to the reusable |
-| `reusable_council_review.yml` | **No** | `workflow_call` | Core logic: WIF auth, action invocation, comment posting |
+| `reusable_council_review.yml` | **No** | `workflow_call` | Core logic: egress blocking, cooldown, WIF auth, action invocation, comment posting |
 
 Consumer workflows have `DO NOT EDIT` provenance headers indicating they
 are managed by org-infra. Downstream repos should not modify them directly.
@@ -63,13 +69,20 @@ If `ORG_CHECK_TOKEN` is not set, the collect workflow falls back to
 `GITHUB_TOKEN` which can only check **public** org membership. Private org
 members (the GitHub default) will be treated as non-members and skipped.
 
+## Invocation
+
+Post `/council-review` as a comment on a PR to trigger a review.
+
 ## Gate conditions
 
 The collect workflow skips council review when:
 
+- The comment does not start with `/council-review`
+- The comment is on an issue (not a PR)
 - PR is a draft
 - PR author is `dependabot[bot]`
-- PR author is not a member of the repository's org
+- The **commenter** is not a member of the repository's org (a notice
+  reply is posted so the commenter knows why it was ignored)
 
 ## Composite action
 
@@ -92,21 +105,27 @@ The action:
 
 Rollout is staged via `sync-config.yml` `exclude_repos`:
 
-1. **Current**: Only org-infra receives the consumer workflows
+1. **Current**: Only org-infra receives the consumer workflows. Reviews
+   are comment-triggered (`/council-review`) only — no automatic runs.
 2. **Phase 2**: Remove repos from `exclude_repos` after:
    - Composite action SHA points to a merged `main` commit
    - Security hardening (#429) is in place
    - Token consumption controls (#430) are in place
    - End-to-end chain validated on org-infra
+3. **Future graduation**: Once battle-tested, consider re-adding an
+   automatic `pull_request` trigger alongside the comment command (#429).
 
 ## Manual trigger
 
-To manually trigger a council review on an existing PR:
+The standard way to trigger a review is to post `/council-review` as a PR
+comment. The collect workflow runs automatically and the consumer workflow
+picks up the artifact via `workflow_run`.
 
-1. Find the collect workflow run ID from the PR's "Checks" tab
-   (the "Council Review - Collect" run)
+To manually trigger via `workflow_dispatch` (e.g., for debugging):
+
+1. Find the collect workflow run ID from Actions → "Council Review - Collect"
 2. Go to Actions → "Council Review" → "Run workflow"
-3. Select the PR's branch, enter the collect run ID
+3. Enter the collect run ID
 
 Or via CLI:
 
@@ -116,6 +135,34 @@ gh workflow run ci_council_review.yml \
   --ref <branch> \
   -f triggering_run_id=<collect-run-id>
 ```
+
+## Security controls
+
+### Network egress blocking
+
+The reusable workflow uses `step-security/harden-runner` with
+`egress-policy: block`. Only the following endpoints are allowed:
+
+- GitHub API and CDN (`api.github.com`, `github.com`, etc.)
+- Vertex AI (`global-aiplatform.googleapis.com`, regional endpoints)
+- GCP auth (`oauth2.googleapis.com`, `iamcredentials.googleapis.com`, etc.)
+- npm registry (`registry.npmjs.org`, `nodejs.org`)
+- StepSecurity agent (`agent.api.stepsecurity.io`)
+
+To add a new endpoint, update the `allowed-endpoints` list in
+`reusable_council_review.yml`.
+
+### Cooldown
+
+A 5-minute (300s) cooldown is enforced between reviews per PR. The
+cooldown checks the timestamp of the most recent `<!-- council-review-bot -->`
+comment on the PR. If the cooldown is active, the review is skipped and a
+notice comment is posted on the PR.
+
+### CODEOWNERS
+
+Council review workflow files require review from `@complytime/complytime-dev`
+via CODEOWNERS. This ensures human review of security-sensitive changes.
 
 ## Bot comment lifecycle
 
@@ -134,11 +181,18 @@ On each new review:
 The `GCP_WORKLOAD_IDENTITY_PROVIDER` secret is not configured for this repo.
 Set it at the org level or add a repo-level secret.
 
-### Review skipped — "PR author is not a member"
+### Review skipped — "commenter is not a member"
 
-Either the author is not an org member, or `ORG_CHECK_TOKEN` is not set and
-the author's membership is private. Configure `ORG_CHECK_TOKEN` with a PAT
-that has `org:read` scope.
+Either the commenter is not an org member, or `ORG_CHECK_TOKEN` is not set
+and the commenter's membership is private. A notice reply is posted on the
+PR. Configure `ORG_CHECK_TOKEN` with a PAT that has `org:read` scope to
+support private membership checks.
+
+### Review skipped — "cooldown active"
+
+A council review was posted on this PR within the last 5 minutes. Wait for
+the cooldown to elapse and invoke `/council-review` again. The cooldown
+prevents token exhaustion from rapid re-invocations.
 
 ### Review produced no inline comments
 
@@ -162,6 +216,5 @@ environment when `opencode run` executes.
 
 - Security hardening: [#429](https://github.com/complytime/org-infra/issues/429)
 - Token consumption controls: [#430](https://github.com/complytime/org-infra/issues/430)
-- `continue-on-error` removal: [#440](https://github.com/complytime/org-infra/issues/440)
 - Error handling hardening: [#454](https://github.com/complytime/org-infra/issues/454)
 - Composite action tracking: [unbound-force#253](https://github.com/unbound-force/unbound-force/issues/253)

--- a/tests/test_council_review_security.py
+++ b/tests/test_council_review_security.py
@@ -1,0 +1,313 @@
+"""Tests for council review security gate logic.
+
+Mirrors workflow bash logic as Python functions and tests them with pytest,
+following the established pattern from TestWorkflowInputValidation in
+test_crapload_package_resolution.py.
+
+Refs: #429 (security hardening for council review workflows)
+"""
+
+class TestCouncilReviewGateLogic:
+    """Tests for the gate-check job logic in ci_council_review_collect.yml."""
+
+    @staticmethod
+    def _check_gate(pr_draft, pr_author):
+        """Mirror: ci_council_review_collect.yml "Evaluate gate conditions" step.
+
+        Returns True if the PR should proceed to org membership check,
+        False if it should be skipped.
+        """
+        if pr_draft:
+            return False
+        if pr_author == "dependabot[bot]":
+            return False
+        return True
+
+    def test_draft_pr_skipped(self):
+        assert self._check_gate(pr_draft=True, pr_author="someone") is False
+
+    def test_dependabot_pr_skipped(self):
+        assert self._check_gate(pr_draft=False, pr_author="dependabot[bot]") is False
+
+    def test_normal_pr_proceeds(self):
+        assert self._check_gate(pr_draft=False, pr_author="orgmember") is True
+
+    def test_draft_dependabot_pr_skipped(self):
+        """Draft check takes precedence over dependabot check."""
+        assert self._check_gate(pr_draft=True, pr_author="dependabot[bot]") is False
+
+    def test_renovate_bot_not_skipped(self):
+        """Only dependabot[bot] is explicitly skipped, not other bots."""
+        assert self._check_gate(pr_draft=False, pr_author="renovate[bot]") is True
+
+
+class TestOrgMembershipCheck:
+    """Tests for the org membership verification in ci_council_review_collect.yml."""
+
+    @staticmethod
+    def _check_org_membership(http_status):
+        """Mirror: ci_council_review_collect.yml "Verify org membership" step.
+
+        Returns True if the commenter is an org member (HTTP 204),
+        False otherwise.
+        """
+        return http_status == 204
+
+    def test_member_returns_204(self):
+        assert self._check_org_membership(204) is True
+
+    def test_non_member_returns_302(self):
+        """Public membership check returns 302 for non-members."""
+        assert self._check_org_membership(302) is False
+
+    def test_non_member_returns_404(self):
+        """Private membership returns 404 when using GITHUB_TOKEN."""
+        assert self._check_org_membership(404) is False
+
+    def test_forbidden_returns_403(self):
+        assert self._check_org_membership(403) is False
+
+    def test_server_error_returns_500(self):
+        assert self._check_org_membership(500) is False
+
+    def test_zero_status_rejected(self):
+        assert self._check_org_membership(0) is False
+
+    def test_200_not_member(self):
+        """200 is not the membership confirmation code — only 204 is."""
+        assert self._check_org_membership(200) is False
+
+
+class TestCooldownCalculation:
+    """Tests for the cooldown logic in reusable_council_review.yml."""
+
+    @staticmethod
+    def _check_cooldown(last_review_epoch, now_epoch, cooldown_seconds=300):
+        """Mirror: reusable_council_review.yml "Check cooldown" step.
+
+        Returns True if the review should proceed (cooldown elapsed or
+        no previous review), False if cooldown is active.
+
+        A last_review_epoch of 0 means no previous review was found or
+        the timestamp could not be parsed.
+        """
+        if last_review_epoch == 0:
+            return True
+        elapsed = now_epoch - last_review_epoch
+        return elapsed >= cooldown_seconds
+
+    def test_no_previous_review(self):
+        """No previous review found — proceed."""
+        assert self._check_cooldown(0, 1000000) is True
+
+    def test_cooldown_active(self):
+        """Review within cooldown window — block."""
+        now = 1000300
+        last = 1000100  # 200s ago, less than 300s cooldown
+        assert self._check_cooldown(last, now) is False
+
+    def test_cooldown_elapsed(self):
+        """Review outside cooldown window — proceed."""
+        now = 1000600
+        last = 1000000  # 600s ago, more than 300s cooldown
+        assert self._check_cooldown(last, now) is True
+
+    def test_cooldown_exact_boundary(self):
+        """Review exactly at cooldown boundary (300s) — proceed."""
+        now = 1000300
+        last = 1000000  # exactly 300s ago
+        assert self._check_cooldown(last, now) is True
+
+    def test_cooldown_one_second_before_boundary(self):
+        """Review 1 second before cooldown expires — block."""
+        now = 1000299
+        last = 1000000  # 299s ago
+        assert self._check_cooldown(last, now) is False
+
+    def test_custom_cooldown_period(self):
+        """Custom cooldown period of 60s."""
+        now = 1000061
+        last = 1000000  # 61s ago, cooldown is 60s
+        assert self._check_cooldown(last, now, cooldown_seconds=60) is True
+
+    def test_custom_cooldown_period_blocked(self):
+        """Custom cooldown period of 600s — still within window."""
+        now = 1000500
+        last = 1000000  # 500s ago, cooldown is 600s
+        assert self._check_cooldown(last, now, cooldown_seconds=600) is False
+
+
+class TestCommentTriggerFilter:
+    """Tests for the /council-review comment trigger filter."""
+
+    @staticmethod
+    def _is_council_review_command(comment_body):
+        """Mirror: ci_council_review_collect.yml job-level if condition.
+
+        The workflow uses startsWith(github.event.comment.body, '/council-review').
+        """
+        return comment_body.startswith("/council-review")
+
+    def test_exact_command(self):
+        assert self._is_council_review_command("/council-review") is True
+
+    def test_command_with_trailing_text(self):
+        assert self._is_council_review_command("/council-review please") is True
+
+    def test_command_with_newline(self):
+        assert self._is_council_review_command("/council-review\nsome context") is True
+
+    def test_not_a_command(self):
+        assert self._is_council_review_command("please run /council-review") is False
+
+    def test_empty_comment(self):
+        assert self._is_council_review_command("") is False
+
+    def test_similar_but_wrong_command(self):
+        assert self._is_council_review_command("/council-reviews") is True  # startsWith matches prefix
+
+    def test_case_sensitive(self):
+        """GitHub Actions startsWith is case-insensitive, but our mirror is case-sensitive.
+        This test documents the Python behavior. In production, GitHub Actions
+        would match '/Council-Review' too."""
+        assert self._is_council_review_command("/Council-Review") is False
+
+
+class TestPRStateGate:
+    """Tests for the PR state check in ci_council_review_collect.yml."""
+
+    @staticmethod
+    def _check_pr_state(pr_state):
+        """Mirror: ci_council_review_collect.yml "Evaluate gate conditions" step.
+
+        Returns True only if the PR is open.
+        """
+        return pr_state == "open"
+
+    def test_open_pr_proceeds(self):
+        assert self._check_pr_state("open") is True
+
+    def test_closed_pr_skipped(self):
+        assert self._check_pr_state("closed") is False
+
+    def test_merged_pr_skipped(self):
+        """GitHub API returns 'closed' for merged PRs, not 'merged'."""
+        assert self._check_pr_state("closed") is False
+
+    def test_empty_state_skipped(self):
+        assert self._check_pr_state("") is False
+
+
+class TestOrgCheckTokenErrorHandling:
+    """Tests for ORG_CHECK_TOKEN error code handling."""
+
+    @staticmethod
+    def _is_token_error(http_status):
+        """Mirror: ci_council_review_collect.yml token error check.
+
+        Returns True if the HTTP status indicates a token configuration
+        problem (401/403) rather than a membership check result.
+        """
+        return http_status in (401, 403)
+
+    def test_401_is_token_error(self):
+        assert self._is_token_error(401) is True
+
+    def test_403_is_token_error(self):
+        assert self._is_token_error(403) is True
+
+    def test_404_is_not_token_error(self):
+        """404 is a valid non-member response, not a token error."""
+        assert self._is_token_error(404) is False
+
+    def test_204_is_not_token_error(self):
+        assert self._is_token_error(204) is False
+
+    def test_302_is_not_token_error(self):
+        assert self._is_token_error(302) is False
+
+
+class TestCooldownFilterLogic:
+    """Tests that the cooldown filter distinguishes review comments from notices.
+
+    The cooldown check must only count actual review summary comments (containing
+    '## AI Council Review'), not cooldown notices or non-member notices. Otherwise
+    the cooldown timer resets on every notice, creating an infinite loop.
+    """
+
+    SENTINEL = "<!-- council-review-bot -->"
+    REVIEW_MARKER = "## AI Council Review"
+
+    @staticmethod
+    def _is_review_comment(body):
+        """Mirror: reusable_council_review.yml cooldown jq filter.
+
+        Returns True if the comment is an actual review (not a notice).
+        """
+        return ("<!-- council-review-bot -->" in body
+                and "## AI Council Review" in body)
+
+    def test_review_summary_matches(self):
+        body = "<!-- council-review-bot -->\n## AI Council Review\n\nFindings..."
+        assert self._is_review_comment(body) is True
+
+    def test_cooldown_notice_excluded(self):
+        body = ("<!-- council-review-bot -->\n"
+                "> Council review cooldown active")
+        assert self._is_review_comment(body) is False
+
+    def test_non_member_notice_excluded(self):
+        body = ("<!-- council-review-bot -->\n"
+                "> `/council-review` is available to org members.")
+        assert self._is_review_comment(body) is False
+
+    def test_plain_comment_excluded(self):
+        body = "LGTM, looks good to me!"
+        assert self._is_review_comment(body) is False
+
+    def test_sentinel_without_review_header_excluded(self):
+        body = "<!-- council-review-bot -->\nSome other bot message"
+        assert self._is_review_comment(body) is False
+
+    def test_review_header_in_reusable_workflow(self):
+        """The review summary step must include the review header marker."""
+        with open(".github/workflows/reusable_council_review.yml") as f:
+            content = f.read()
+        assert self.REVIEW_MARKER in content, (
+            "Review marker '## AI Council Review' not found in "
+            "reusable_council_review.yml — cooldown filter will never match"
+        )
+
+
+class TestSentinelConsistency:
+    """Tests that the bot comment sentinel is consistent across workflow files.
+
+    The sentinel <!-- council-review-bot --> is used by:
+    - ci_council_review_collect.yml (non-member notice reply)
+    - reusable_council_review.yml (cooldown search, cleanup, review summary, inline comments)
+
+    If the sentinel drifts between files, cooldown and cleanup will silently break.
+    """
+
+    SENTINEL = "<!-- council-review-bot -->"
+
+    def test_sentinel_in_collect_workflow(self):
+        """The collect workflow must include the sentinel in the non-member notice."""
+        with open(".github/workflows/ci_council_review_collect.yml") as f:
+            content = f.read()
+        assert self.SENTINEL in content, (
+            "Sentinel not found in ci_council_review_collect.yml — "
+            "non-member notice reply won't be cleaned up by the reusable workflow"
+        )
+
+    def test_sentinel_in_reusable_workflow(self):
+        """The reusable workflow must include the sentinel in multiple locations."""
+        with open(".github/workflows/reusable_council_review.yml") as f:
+            content = f.read()
+        # Must appear in: cooldown search, cleanup selectors, review summary,
+        # cooldown notice, inline comments
+        occurrences = content.count(self.SENTINEL)
+        assert occurrences >= 3, (
+            f"Expected sentinel to appear at least 3 times in reusable_council_review.yml "
+            f"(cooldown, cleanup, summary), found {occurrences}"
+        )


### PR DESCRIPTION
## Summary

Security hardening for the council review workflow chain, implementing all
phases of #429. Also removes `continue-on-error: true` from the review step
(closes #440 — 35 successful runs exceed the >= 10 stabilization threshold).

### Phase 1: Comment-triggered invocation (Critical)
- Switch from automatic `pull_request` trigger to `/council-review` comment
  command on `issue_comment` event
- Only org members can invoke (verified via GitHub API with `ORG_CHECK_TOKEN`
  fallback to `GITHUB_TOKEN`)
- Non-member comments get a welcoming notice reply
- Draft, dependabot, and closed/merged PRs rejected at the gate
- 401/403 token errors detected with actionable `::warning::`

### Phase 2: Network egress restriction (High)
- `step-security/harden-runner` v2.20.0 with `egress-policy: block`
- Allowlist: Vertex AI (global + regional), GitHub API, GCP auth, npm registry,
  StepSecurity agent

### Phase 3: Rate limiting / cooldown (Medium)
- 5-minute cooldown between reviews per PR
- Cooldown filters for actual review summaries (`## AI Council Review`) to
  prevent self-resetting timer loop from cooldown notices
- Posts PR comment when cooldown blocks for user feedback
- Per-commit concurrency group in consumer workflow prevents parallel runs

### Phase 4: CODEOWNERS protection (Medium)
- Explicit entries for all 3 council review workflow files
- Future-proofing comment explains redundancy with wildcard rule

### #440: Remove `continue-on-error: true`
- 35 successful council review runs exceed the >= 10 stabilization threshold
- Review step failures now surface properly in CI
- TODO comment and doc references to #440 removed

### Documentation
- `AGENTS.md` workflow chain updated for `issue_comment` trigger,
  harden-runner, and cooldown
- `docs/COUNCIL_REVIEW.md` fully updated: architecture diagram, workflow table,
  gate conditions, invocation section, security controls section, troubleshooting
- Future graduation path documented in rollout section

### Tests
- 43 new tests in `tests/test_council_review_security.py` across 8 test classes

## Related Issues

- Closes #429
- Closes #440

## Review Hints

- Single commit — review all changes together.
- The key design decision is the **cooldown filter**: it uses `## AI Council Review`
  header (not just the bot sentinel `<!-- council-review-bot -->`) to distinguish
  actual review comments from cooldown/non-member notices. Without this, the
  cooldown timer resets itself on every blocked invocation, creating an infinite loop.
- **No guard workflow**: Phase 5 (workflow change detection) from the issue is
  covered by CODEOWNERS. A separate workflow spinning up a runner to echo a
  warning adds no value over CODEOWNERS review enforcement.
- **`author_association` alternative not adopted**: The event payload provides
  `author_association` which could replace the API-based org membership check.
  Deferred to a separate PR to keep this focused on security hardening.

### Evidence

| Test | Result | Link |
|------|--------|------|
| Fork trigger chain | `issue_comment` fires, gate logic works, non-member notice posted | [sonupreetam/org-infra#4](https://github.com/sonupreetam/org-infra/pull/4) |
| Full end-to-end (org repo) | Collect -> workflow_run -> reusable -> harden-runner -> WIF -> review -> 11 inline comments, 0 failures | [workflow run](https://github.com/complytime/org-infra/actions/runs/30895974433) |

### Acceptance criteria

- [x] Reviews only run when an org member posts `/council-review`
- [x] Non-member comments are ignored with notice
- [x] Network egress blocked except Vertex AI + GitHub + npm
- [x] Rapid re-triggers within 5 minutes are skipped
- [x] Workflow file changes require designated reviewer approval (CODEOWNERS)

### Post-merge validation

> `issue_comment` workflows run from the default branch, so the comment-trigger
> path can only be validated after merge.

- [ ] Post `/council-review` on a real PR — verify the full chain fires
- [ ] Post `/council-review` again within 5 minutes — verify cooldown blocks

### Verification

- `make lint` — clean
- `make test` — 155/155 pass (43 new + 112 existing)
- All pre-commit hooks pass

Assisted-by: OpenCode (claude-opus-4-6)