### PR TITLE
chore: add org label sync workflow

### DIFF
--- a/.github/workflows/sync_labels.yml
+++ b/.github/workflows/sync_labels.yml
@@ -1,0 +1,82 @@
+name: Sync Repository Labels
+
+# Manual workflow to reconcile labels across organization repositories
+# using labels-policy.json and scripts/sync-labels.py.
+
+on:
+  workflow_dispatch:
+    inputs:
+      dry_run:
+        description: "Preview label changes without applying them"
+        required: false
+        type: boolean
+        default: true
+      repos:
+        description: >-
+          Optional comma-separated list of repos to target.
+          Leave empty to target all repos except those excluded in labels-policy.json.
+        required: false
+        type: string
+        default: ""
+
+permissions:
+  contents: read
+
+concurrency:
+  group: label-sync
+  cancel-in-progress: false
+
+jobs:
+  sync-labels:
+    if: github.repository_owner == 'complytime'
+    name: Sync Labels
+    runs-on: ubuntu-latest
+    timeout-minutes: 20
+    permissions:
+      contents: read
+    steps:
+      - name: Checkout org-infra Repository
+        uses: actions/checkout@3d3c42e5aac5ba805825da76410c181273ba90b1 # v7.0.1
+        with:
+          fetch-depth: 1
+          persist-credentials: false
+
+      - name: Set up Python
+        uses: actions/setup-python@5fda3b95a4ea91299a34e894583c3862153e4b97 # v7.0.0
+        with:
+          python-version: "3.11"
+
+      - name: Generate GitHub App Token
+        id: generate-token
+        uses: actions/create-github-app-token@bcd2ba49218906704ab6c1aa796996da409d3eb1 # v3.2.0
+        with:
+          client-id: ${{ secrets.SYNC_APP_CLIENT_ID }}
+          private-key: ${{ secrets.SYNC_APP_PRIVATE_KEY }}
+          owner: ${{ github.repository_owner }} # zizmor: ignore[github-app]
+          permission-issues: write
+
+      - name: Sync labels
+        env:
+          GITHUB_TOKEN: ${{ steps.generate-token.outputs.token }}
+          INPUT_REPOS: ${{ inputs.repos }}
+          DRY_RUN: ${{ inputs.dry_run }}
+        run: |
+          set -eu
+
+          REPO_ARGS=""
+          if [ -n "$INPUT_REPOS" ]; then
+            CLEANED=$(printf '%s' "$INPUT_REPOS" | tr ',' ' ')
+            REPO_ARGS="--repos $CLEANED"
+          fi
+
+          if [ "$DRY_RUN" = "true" ]; then
+            DRY_ARG="--dry-run"
+          else
+            DRY_ARG=""
+          fi
+
+          # shellcheck disable=SC2086
+          python3 scripts/sync-labels.py \
+            --policy labels-policy.json \
+            $DRY_ARG \
+            $REPO_ARGS

--- a/.github/workflows/sync_labels.yml
+++ b/.github/workflows/sync_labels.yml
@@ -61,22 +61,21 @@ jobs:
           INPUT_REPOS: ${{ inputs.repos }}
           DRY_RUN: ${{ inputs.dry_run }}
         run: |
-          set -eu
+          set -euo pipefail
 
-          REPO_ARGS=""
-          if [ -n "$INPUT_REPOS" ]; then
-            CLEANED=$(printf '%s' "$INPUT_REPOS" | tr ',' ' ')
-            REPO_ARGS="--repos $CLEANED"
-          fi
+          ARGS=(--policy labels-policy.json)
 
           if [ "$DRY_RUN" = "true" ]; then
-            DRY_ARG="--dry-run"
-          else
-            DRY_ARG=""
+            ARGS+=(--dry-run)
           fi
 
-          # shellcheck disable=SC2086
-          python3 scripts/sync-labels.py \
-            --policy labels-policy.json \
-            $DRY_ARG \
-            $REPO_ARGS
+          if [ -n "$INPUT_REPOS" ]; then
+            # Keep the value as a single argv entry; Python splits/validates repo names.
+            if ! printf '%s' "$INPUT_REPOS" | grep -qE '^[A-Za-z0-9._-]+(,[A-Za-z0-9._-]+)*$'; then
+              echo "::error::Invalid repos input: only alphanumeric, dots, hyphens, underscores, and commas allowed"
+              exit 1
+            fi
+            ARGS+=(--repos "$INPUT_REPOS")
+          fi
+
+          python3 scripts/sync-labels.py "${ARGS[@]}"

--- a/README.md
+++ b/README.md
@@ -18,6 +18,7 @@ Specifically, this repository includes:
 * Templates for PRs and Issues creation
 * Configuration files for lint checks
 * Synchronization script integrated with [peribolos](https://github.com/complytime/.github/blob/main/peribolos.yaml) to periodically check consistence among repositories
+* Label standardization workflow to create, rename, and clean up repository labels from a shared policy
 
 ---
 
@@ -56,6 +57,7 @@ org-infra/
 │  │  ├── reusable_sign_and_verify.yml      # Sigstore keyless signing and attestation verification for container images.
 │  │  ├── reusable_sonarqube.yml            # SonarCloud static analysis for code quality and security.
 │  │  ├── reusable_vuln_scan.yml            # Vulnerability scanning via OSV-Scanner and Trivy.
+│  │  ├── sync_labels.yml                   # Manual workflow to reconcile repository labels from policy.
 │  │  └── sync_org_repositories.yml         # Manual, scheduled, and event-based workflow to synchronize files.
 │  ├── dependabot.yml                       # Dependabot settings for GitHub Actions and Go modules.
 │  ├── dependabot_python.yml                # Dependabot settings for GitHub Actions (Python repos) and pip.
@@ -63,12 +65,15 @@ org-infra/
 ├── compliance/
 │  └── ampel/                               # Policy definitions for branch protection rule compliance checks.
 ├── docs/                                   # More detailed and specific documentation.
+│  ├── LABEL_SYNC.md                        # Documentation for cross-repo label standardization.
 │  ├── LOCAL_TESTING.md                     # Documentation on how to test synchronization locally.
 │  └── SYNC_REPOSITORIES_SETUP.md          # Documentation on how to setup the repository synchronization infrastructure.
 ├── scripts/
+│  ├── sync-labels.py                       # Python script to reconcile labels from labels-policy.json.
 │  ├── sync-org-repositories.py             # Python script to check and ensure consistence among repositories.
 │  └── resolve-go-packages.sh              # Bash: multi-module Go package auto-discovery
 ├── ...                                     # Multiple technology specific configuration files
+├── labels-policy.json                      # Label create/rename/preserve/delete policy for sync-labels.py
 ├── sync-config.yml                         # Configuration file consumed by `sync-org-repositories.py`
 └── README.md                               # This file.
 ```

--- a/docs/LABEL_SYNC.md
+++ b/docs/LABEL_SYNC.md
@@ -1,0 +1,54 @@
+# Repository Label Sync
+
+Use the **Sync Repository Labels** workflow for label-only changes across
+organization repositories. This complements repository file sync
+(`sync_org_repositories.yml`) and org-level tooling in `complytime/.github`.
+
+## Why a custom workflow
+
+GitHub organization default labels apply only within a single org and do not
+cover rename/cleanup of existing labels across many repositories. This workflow
+reads `labels-policy.json` and applies three kinds of changes:
+
+1. Ensure a shared set of standard labels exists everywhere.
+2. Rename legacy labels only in repositories where they already exist.
+3. Delete only explicitly-listed labels, leaving all other local labels alone.
+
+This is useful when some labels must remain repo-specific and should not be
+replicated across the organization.
+
+Native org default labels are still useful for brand-new repositories inside
+one org; this workflow is for cross-repo reconciliation and cleanup.
+
+## Files
+
+| File | Purpose |
+| --- | --- |
+| `labels-policy.json` | Source of truth for standard labels, renames, local-only preserves, and deletes |
+| `scripts/sync-labels.py` | Applies the policy repo by repo via the GitHub API |
+| `.github/workflows/sync_labels.yml` | Manual (`workflow_dispatch`) runner with dry-run support |
+
+## Run the workflow
+
+Go to **Actions → Sync Repository Labels → Run workflow**:
+
+- **dry_run**: `true` to preview, `false` to apply (defaults to `true`)
+- **repos**: comma-separated list of repos to target. Leave empty to apply to
+  all repos except those excluded in `labels-policy.json`
+
+Authentication uses the existing org-infra sync GitHub App secrets
+(`SYNC_APP_CLIENT_ID`, `SYNC_APP_PRIVATE_KEY`) with `issues:write` so labels
+can be created, renamed, and deleted.
+
+## Assumptions encoded in the policy
+
+- `private-sprint-sub-issue` is treated as **preserve**, not delete
+- `docker` is renamed to `container`
+- `question`, `to validate`, and `to validade` are consolidated into `validate`
+- `complytime/complytime` and `roadmap` are excluded from org-wide apply by default
+
+## Follow-ups
+
+As discussed for multi-org label management (CT, UF, ASDLC), org-infra may later
+host configs/workflows that cover those orgs as well. This first PR targets the
+current complytime org policy and runner.

--- a/labels-policy.json
+++ b/labels-policy.json
@@ -1,0 +1,199 @@
+{
+  "org": "complytime",
+  "exclude_repos": [
+    "complytime",
+    "roadmap"
+  ],
+  "preserve_local_only_labels": [
+    "60 day implementation",
+    "Fedora",
+    "ISO 42001 audit",
+    "RHEL Sec Compliance",
+    "automated",
+    "branch protection rules",
+    "ci",
+    "go",
+    "javascript",
+    "newsletter",
+    "peribolos-drift",
+    "post 60 day implementation",
+    "pre_commit",
+    "python",
+    "private-sprint-sub-issue"
+  ],
+  "rename_only_labels": [
+    {
+      "from": [
+        "60 days"
+      ],
+      "to": {
+        "name": "60 day implementation",
+        "color": "d4c5f9",
+        "description": "Tracking work scheduled for the 60 day implementation window."
+      }
+    },
+    {
+      "from": [
+        "clean up"
+      ],
+      "to": {
+        "name": "Clean up",
+        "color": "fbca04",
+        "description": "Maintenance work that cleans up existing code, config, or process."
+      }
+    },
+    {
+      "from": [
+        "test"
+      ],
+      "to": {
+        "name": "Test",
+        "color": "0e8a16",
+        "description": "Changes or work focused on testing."
+      }
+    },
+    {
+      "from": [
+        "uat"
+      ],
+      "to": {
+        "name": "UAT",
+        "color": "1d76db",
+        "description": "User acceptance testing and validation work."
+      }
+    },
+    {
+      "from": [
+        "docker"
+      ],
+      "to": {
+        "name": "container",
+        "color": "5319e7",
+        "description": "Container image, container runtime, or container packaging work."
+      }
+    },
+    {
+      "from": [
+        "llm_assisted"
+      ],
+      "to": {
+        "name": "AI assisted",
+        "color": "bfd4f2",
+        "description": "Work created or updated with AI assistance."
+      }
+    },
+    {
+      "from": [
+        "post 60 days"
+      ],
+      "to": {
+        "name": "post 60 day implementation",
+        "color": "f9d0c4",
+        "description": "Tracking work scheduled after the 60 day implementation window."
+      }
+    },
+    {
+      "from": [
+        "question",
+        "to validate",
+        "to validade"
+      ],
+      "to": {
+        "name": "validate",
+        "color": "fbca04",
+        "description": "Work that still needs validation before it is complete."
+      }
+    }
+  ],
+  "delete_labels": [
+    "Risk",
+    "Unbound force",
+    "autorelease: pending",
+    "autorelease: tagged",
+    "baklava sprint 8",
+    "breaking_change",
+    "complyctl-import",
+    "complyctl-plugins",
+    "complyscribe-imported",
+    "private",
+    "proposal",
+    "research"
+  ],
+  "standard_labels": [
+    {
+      "name": "Bug",
+      "color": "d73a4a",
+      "description": "Something is broken and needs to be fixed."
+    },
+    {
+      "name": "Dependencies",
+      "color": "0366d6",
+      "description": "Dependency updates or dependency management work."
+    },
+    {
+      "name": "documentation",
+      "color": "0075ca",
+      "description": "Improvements or additions to documentation."
+    },
+    {
+      "name": "Duplicate",
+      "color": "cfd3d7",
+      "description": "This issue or pull request already exists elsewhere."
+    },
+    {
+      "name": "Enhancement",
+      "color": "a2eeef",
+      "description": "New functionality, optimization, or an improvement to existing behavior."
+    },
+    {
+      "name": "Github_actions",
+      "color": "5319e7",
+      "description": "Changes related to GitHub Actions workflows or automation."
+    },
+    {
+      "name": "good first issue",
+      "color": "7057ff",
+      "description": "A good entry point for first-time contributors."
+    },
+    {
+      "name": "help wanted",
+      "color": "008672",
+      "description": "Extra attention is needed from contributors or maintainers."
+    },
+    {
+      "name": "Invalid",
+      "color": "e4e669",
+      "description": "This issue or pull request is not valid as filed."
+    },
+    {
+      "name": "Maintenance",
+      "color": "fbca04",
+      "description": "Routine maintenance or upkeep work."
+    },
+    {
+      "name": "Security",
+      "color": "b60205",
+      "description": "Security-related work, fixes, or hardening."
+    },
+    {
+      "name": "Ux",
+      "color": "1d76db",
+      "description": "User experience, usability, or interaction design work."
+    },
+    {
+      "name": "Wontfix",
+      "color": "ffffff",
+      "description": "This will not be worked on or accepted."
+    },
+    {
+      "name": "stakeholder",
+      "color": "0e8a16",
+      "description": "Requires input from or coordination with project stakeholders."
+    },
+    {
+      "name": "needs-adr",
+      "color": "5319e7",
+      "description": "An architecture decision record is needed before proceeding."
+    }
+  ]
+}

--- a/scripts/sync-labels.py
+++ b/scripts/sync-labels.py
@@ -1,4 +1,5 @@
 #!/usr/bin/env python3
+# SPDX-License-Identifier: Apache-2.0
 """Synchronize GitHub labels across organization repositories.
 
 This tool intentionally supports three behaviors:
@@ -12,6 +13,7 @@ from __future__ import annotations
 import argparse
 import json
 import os
+import re
 import urllib.error
 import urllib.parse
 import urllib.request
@@ -19,13 +21,19 @@ from typing import Dict, Iterable, List, Tuple
 
 
 API_ROOT = "https://api.github.com"
+REPO_NAME_RE = re.compile(r"^[A-Za-z0-9._-]+$")
+HTTP_ERROR_DETAIL_LIMIT = 500
 
 
 def parse_args() -> argparse.Namespace:
     parser = argparse.ArgumentParser(description="Sync labels across GitHub repositories")
     parser.add_argument("--policy", default="labels-policy.json", help="Path to the label policy JSON file")
     parser.add_argument("--org", help="GitHub organization to manage; defaults to policy value")
-    parser.add_argument("--repos", nargs="*", help="Optional subset of repos to target")
+    parser.add_argument(
+        "--repos",
+        nargs="*",
+        help="Optional subset of repos to target (space- or comma-separated names)",
+    )
     parser.add_argument("--dry-run", action="store_true", help="Show intended changes without applying them")
     parser.add_argument(
         "--token-env",
@@ -33,6 +41,26 @@ def parse_args() -> argparse.Namespace:
         help="Environment variable that contains the GitHub token",
     )
     return parser.parse_args()
+
+
+def expand_repo_args(repos: Iterable[str] | None) -> List[str] | None:
+    """Expand space/comma-separated repo names and validate each token."""
+    if not repos:
+        return None
+
+    expanded: List[str] = []
+    for item in repos:
+        for part in item.split(","):
+            name = part.strip()
+            if not name:
+                continue
+            if not REPO_NAME_RE.fullmatch(name):
+                raise SystemExit(
+                    f"Invalid repo name {name!r}: only alphanumeric, dots, hyphens, "
+                    "and underscores are allowed"
+                )
+            expanded.append(name)
+    return expanded
 
 
 def load_policy(path: str) -> dict:
@@ -77,6 +105,8 @@ def gh_request(
             return json.loads(payload.decode("utf-8"))
     except urllib.error.HTTPError as exc:
         detail = exc.read().decode("utf-8", errors="replace")
+        if len(detail) > HTTP_ERROR_DETAIL_LIMIT:
+            detail = detail[:HTTP_ERROR_DETAIL_LIMIT] + "...(truncated)"
         raise RuntimeError(f"{method} {path} failed: HTTP {exc.code}: {detail}") from exc
 
 
@@ -85,7 +115,8 @@ def gh_paginate(token: str, path: str) -> List[dict]:
     page = 1
     while True:
         batch = gh_request(token, "GET", path, query={"per_page": 100, "page": page})
-        assert isinstance(batch, list)
+        if not isinstance(batch, list):
+            raise TypeError(f"Expected list from {path}, got {type(batch).__name__}")
         if not batch:
             break
         items.extend(batch)
@@ -245,7 +276,8 @@ def main() -> int:
     policy = load_policy(args.policy)
     token = get_token(args.token_env)
     org = args.org or policy["org"]
-    repos = list_repos(token, org, args.repos, policy["exclude_repos"])
+    selected_repos = expand_repo_args(args.repos)
+    repos = list_repos(token, org, selected_repos, policy["exclude_repos"])
 
     if not repos:
         print("No repositories selected.")

--- a/scripts/sync-labels.py
+++ b/scripts/sync-labels.py
@@ -12,7 +12,6 @@ from __future__ import annotations
 import argparse
 import json
 import os
-import sys
 import urllib.error
 import urllib.parse
 import urllib.request

--- a/scripts/sync-labels.py
+++ b/scripts/sync-labels.py
@@ -1,0 +1,290 @@
+#!/usr/bin/env python3
+"""Synchronize GitHub labels across organization repositories.
+
+This tool intentionally supports three behaviors:
+1. Ensure a core set of standard labels exists everywhere.
+2. Rename legacy labels in-place only where they already exist.
+3. Delete only explicitly-listed labels, leaving all other local labels alone.
+"""
+
+from __future__ import annotations
+
+import argparse
+import json
+import os
+import sys
+import urllib.error
+import urllib.parse
+import urllib.request
+from typing import Dict, Iterable, List, Tuple
+
+
+API_ROOT = "https://api.github.com"
+
+
+def parse_args() -> argparse.Namespace:
+    parser = argparse.ArgumentParser(description="Sync labels across GitHub repositories")
+    parser.add_argument("--policy", default="labels-policy.json", help="Path to the label policy JSON file")
+    parser.add_argument("--org", help="GitHub organization to manage; defaults to policy value")
+    parser.add_argument("--repos", nargs="*", help="Optional subset of repos to target")
+    parser.add_argument("--dry-run", action="store_true", help="Show intended changes without applying them")
+    parser.add_argument(
+        "--token-env",
+        default="GITHUB_TOKEN",
+        help="Environment variable that contains the GitHub token",
+    )
+    return parser.parse_args()
+
+
+def load_policy(path: str) -> dict:
+    with open(path, "r", encoding="utf-8") as handle:
+        return json.load(handle)
+
+
+def get_token(name: str) -> str:
+    token = os.getenv(name)
+    if not token:
+        raise SystemExit(f"Missing required token environment variable: {name}")
+    return token
+
+
+def gh_request(
+    token: str,
+    method: str,
+    path: str,
+    body: dict | None = None,
+    query: dict | None = None,
+) -> dict | list | None:
+    url = f"{API_ROOT}{path}"
+    if query:
+        url = f"{url}?{urllib.parse.urlencode(query)}"
+    data = None if body is None else json.dumps(body).encode("utf-8")
+    request = urllib.request.Request(
+        url=url,
+        data=data,
+        method=method,
+        headers={
+            "Accept": "application/vnd.github+json",
+            "Authorization": f"Bearer {token}",
+            "X-GitHub-Api-Version": "2022-11-28",
+            "Content-Type": "application/json",
+        },
+    )
+    try:
+        with urllib.request.urlopen(request, timeout=30) as response:
+            payload = response.read()
+            if not payload:
+                return None
+            return json.loads(payload.decode("utf-8"))
+    except urllib.error.HTTPError as exc:
+        detail = exc.read().decode("utf-8", errors="replace")
+        raise RuntimeError(f"{method} {path} failed: HTTP {exc.code}: {detail}") from exc
+
+
+def gh_paginate(token: str, path: str) -> List[dict]:
+    items: List[dict] = []
+    page = 1
+    while True:
+        batch = gh_request(token, "GET", path, query={"per_page": 100, "page": page})
+        assert isinstance(batch, list)
+        if not batch:
+            break
+        items.extend(batch)
+        page += 1
+    return items
+
+
+def normalize(name: str) -> str:
+    return name.strip().casefold()
+
+
+def list_repos(token: str, org: str, include: Iterable[str] | None, exclude: Iterable[str]) -> List[str]:
+    include_set = {repo.strip() for repo in include or [] if repo.strip()}
+    exclude_set = {repo.strip() for repo in exclude if repo.strip()}
+    repos = [
+        repo["name"]
+        for repo in gh_paginate(token, f"/orgs/{org}/repos")
+        if repo.get("name") not in exclude_set
+    ]
+    repos.sort()
+    if include_set:
+        repos = [repo for repo in repos if repo in include_set]
+    return repos
+
+
+def list_labels(token: str, org: str, repo: str) -> List[dict]:
+    return gh_paginate(token, f"/repos/{org}/{repo}/labels")
+
+
+def patch_label(
+    token: str,
+    org: str,
+    repo: str,
+    current_name: str,
+    desired: dict,
+    dry_run: bool,
+) -> None:
+    print(f"  update label: {current_name!r} -> {desired['name']!r}")
+    if dry_run:
+        return
+    gh_request(
+        token,
+        "PATCH",
+        f"/repos/{org}/{repo}/labels/{urllib.parse.quote(current_name, safe='')}",
+        body=desired,
+    )
+
+
+def create_label(token: str, org: str, repo: str, desired: dict, dry_run: bool) -> None:
+    print(f"  create label: {desired['name']!r}")
+    if dry_run:
+        return
+    gh_request(token, "POST", f"/repos/{org}/{repo}/labels", body=desired)
+
+
+def delete_label(token: str, org: str, repo: str, name: str, dry_run: bool) -> None:
+    print(f"  delete label: {name!r}")
+    if dry_run:
+        return
+    gh_request(
+        token,
+        "DELETE",
+        f"/repos/{org}/{repo}/labels/{urllib.parse.quote(name, safe='')}",
+    )
+
+
+def ensure_standard_labels(
+    token: str,
+    org: str,
+    repo: str,
+    labels_by_norm: Dict[str, dict],
+    policy_labels: List[dict],
+    dry_run: bool,
+) -> None:
+    for desired in policy_labels:
+        key = normalize(desired["name"])
+        existing = labels_by_norm.get(key)
+        if existing is None:
+            create_label(token, org, repo, desired, dry_run)
+            labels_by_norm[key] = {"name": desired["name"], **desired}
+            continue
+
+        needs_update = (
+            existing.get("name") != desired["name"]
+            or normalize(existing.get("color", "")) != normalize(desired["color"])
+            or (existing.get("description") or "") != desired["description"]
+        )
+        if needs_update:
+            patch_label(token, org, repo, existing["name"], desired, dry_run)
+            labels_by_norm[key] = {"name": desired["name"], **desired}
+
+
+def apply_rename_only_labels(
+    token: str,
+    org: str,
+    repo: str,
+    labels_by_norm: Dict[str, dict],
+    rename_rules: List[dict],
+    dry_run: bool,
+) -> None:
+    for rule in rename_rules:
+        desired = rule["to"]
+        destination_key = normalize(desired["name"])
+        destination = labels_by_norm.get(destination_key)
+
+        sources: List[Tuple[str, dict]] = []
+        for legacy_name in rule["from"]:
+            source = labels_by_norm.get(normalize(legacy_name))
+            if source is not None:
+                sources.append((legacy_name, source))
+
+        if not sources and destination is None:
+            continue
+
+        if destination is not None:
+            needs_update = (
+                destination.get("name") != desired["name"]
+                or normalize(destination.get("color", "")) != normalize(desired["color"])
+                or (destination.get("description") or "") != desired["description"]
+            )
+            if needs_update:
+                patch_label(token, org, repo, destination["name"], desired, dry_run)
+                labels_by_norm[destination_key] = {"name": desired["name"], **desired}
+
+        if destination is None and sources:
+            source_name = sources[0][1]["name"]
+            patch_label(token, org, repo, source_name, desired, dry_run)
+            labels_by_norm[destination_key] = {"name": desired["name"], **desired}
+            del labels_by_norm[normalize(source_name)]
+            sources = sources[1:]
+
+        for _, source in sources:
+            if normalize(source["name"]) == destination_key:
+                continue
+            delete_label(token, org, repo, source["name"], dry_run)
+            labels_by_norm.pop(normalize(source["name"]), None)
+
+
+def apply_deletes(
+    token: str,
+    org: str,
+    repo: str,
+    labels_by_norm: Dict[str, dict],
+    names: List[str],
+    dry_run: bool,
+) -> None:
+    for name in names:
+        existing = labels_by_norm.get(normalize(name))
+        if existing is None:
+            continue
+        delete_label(token, org, repo, existing["name"], dry_run)
+        labels_by_norm.pop(normalize(existing["name"]), None)
+
+
+def main() -> int:
+    args = parse_args()
+    policy = load_policy(args.policy)
+    token = get_token(args.token_env)
+    org = args.org or policy["org"]
+    repos = list_repos(token, org, args.repos, policy["exclude_repos"])
+
+    if not repos:
+        print("No repositories selected.")
+        return 0
+
+    print(f"Target repositories ({len(repos)}): {', '.join(repos)}")
+    for repo in repos:
+        print(f"\n== {repo} ==")
+        labels = list_labels(token, org, repo)
+        labels_by_norm = {normalize(label["name"]): label for label in labels}
+        apply_rename_only_labels(
+            token,
+            org,
+            repo,
+            labels_by_norm,
+            policy["rename_only_labels"],
+            args.dry_run,
+        )
+        ensure_standard_labels(
+            token,
+            org,
+            repo,
+            labels_by_norm,
+            policy["standard_labels"],
+            args.dry_run,
+        )
+        apply_deletes(
+            token,
+            org,
+            repo,
+            labels_by_norm,
+            policy["delete_labels"],
+            args.dry_run,
+        )
+
+    print("\nDone.")
+    return 0
+
+
+if __name__ == "__main__":
+    raise SystemExit(main())

--- a/tests/test_sync_labels.py
+++ b/tests/test_sync_labels.py
@@ -1,0 +1,191 @@
+# SPDX-License-Identifier: Apache-2.0
+
+"""Tests for sync-labels.py."""
+
+from __future__ import annotations
+
+import importlib
+import io
+import sys
+from pathlib import Path
+from unittest.mock import patch
+
+import pytest
+
+sys.path.insert(0, str(Path(__file__).parent.parent / "scripts"))
+
+sync_labels = importlib.import_module("sync-labels")
+
+
+class TestNormalize:
+    def test_strips_and_casefolds(self):
+        assert sync_labels.normalize("  Bug ") == "bug"
+        assert sync_labels.normalize("ENHANCEMENT") == "enhancement"
+
+
+class TestExpandRepoArgs:
+    def test_none_returns_none(self):
+        assert sync_labels.expand_repo_args(None) is None
+
+    def test_splits_comma_separated_single_arg(self):
+        assert sync_labels.expand_repo_args(["complyctl,org-infra"]) == ["complyctl", "org-infra"]
+
+    def test_accepts_space_separated_args(self):
+        assert sync_labels.expand_repo_args(["complyctl", "org-infra"]) == ["complyctl", "org-infra"]
+
+    def test_rejects_shell_metacharacters(self):
+        with pytest.raises(SystemExit, match="Invalid repo name"):
+            sync_labels.expand_repo_args(["complyctl;rm -rf /"])
+
+
+class TestGhRequestErrors:
+    def test_truncates_http_error_body(self):
+        long_body = "x" * 800
+        error = sync_labels.urllib.error.HTTPError(
+            url="https://api.github.com/repos/org/repo/labels",
+            code=500,
+            msg="Server Error",
+            hdrs=None,
+            fp=io.BytesIO(long_body.encode("utf-8")),
+        )
+        with patch.object(sync_labels.urllib.request, "urlopen", side_effect=error):
+            with pytest.raises(RuntimeError) as exc_info:
+                sync_labels.gh_request("token", "GET", "/repos/org/repo/labels")
+
+        message = str(exc_info.value)
+        assert "truncated" in message
+        assert len(message) < 800
+
+
+class TestGhPaginate:
+    def test_raises_when_response_is_not_list(self):
+        with patch.object(sync_labels, "gh_request", return_value={"message": "nope"}):
+            with pytest.raises(TypeError, match="Expected list"):
+                sync_labels.gh_paginate("token", "/orgs/complytime/repos")
+
+    def test_collects_pages(self):
+        pages = [
+            [{"name": "a"}, {"name": "b"}],
+            [{"name": "c"}],
+            [],
+        ]
+
+        with patch.object(sync_labels, "gh_request", side_effect=pages) as mocked:
+            items = sync_labels.gh_paginate("token", "/orgs/complytime/repos")
+
+        assert [item["name"] for item in items] == ["a", "b", "c"]
+        assert mocked.call_count == 3
+
+
+class TestListRepos:
+    def test_filters_exclude_and_include(self):
+        api_repos = [{"name": "keep"}, {"name": "skip"}, {"name": "other"}]
+
+        with patch.object(sync_labels, "gh_paginate", return_value=api_repos):
+            repos = sync_labels.list_repos(
+                "token",
+                "complytime",
+                include=["keep", "other"],
+                exclude=["skip"],
+            )
+
+        assert repos == ["keep", "other"]
+
+
+class TestEnsureStandardLabels:
+    def test_creates_missing_label(self):
+        labels_by_norm: dict = {}
+        desired = {"name": "bug", "color": "d73a4a", "description": "Something broken"}
+
+        with patch.object(sync_labels, "create_label") as create_label:
+            sync_labels.ensure_standard_labels(
+                "token",
+                "complytime",
+                "demo",
+                labels_by_norm,
+                [desired],
+                dry_run=True,
+            )
+
+        create_label.assert_called_once()
+        assert "bug" in labels_by_norm
+
+    def test_updates_mismatched_label(self):
+        labels_by_norm = {
+            "bug": {"name": "bug", "color": "000000", "description": "old"},
+        }
+        desired = {"name": "bug", "color": "d73a4a", "description": "Something broken"}
+
+        with patch.object(sync_labels, "patch_label") as patch_label:
+            sync_labels.ensure_standard_labels(
+                "token",
+                "complytime",
+                "demo",
+                labels_by_norm,
+                [desired],
+                dry_run=True,
+            )
+
+        patch_label.assert_called_once()
+
+
+class TestApplyRenameOnlyLabels:
+    def test_renames_legacy_label_when_destination_missing(self):
+        labels_by_norm = {
+            "enhancement": {"name": "enhancement", "color": "a2eeef", "description": "old"},
+        }
+        rules = [
+            {
+                "from": ["enhancement"],
+                "to": {"name": "type:enhancement", "color": "a2eeef", "description": "new"},
+            }
+        ]
+
+        with patch.object(sync_labels, "patch_label") as patch_label:
+            sync_labels.apply_rename_only_labels(
+                "token",
+                "complytime",
+                "demo",
+                labels_by_norm,
+                rules,
+                dry_run=True,
+            )
+
+        patch_label.assert_called_once()
+        assert "type:enhancement" in labels_by_norm
+        assert "enhancement" not in labels_by_norm
+
+
+class TestApplyDeletes:
+    def test_deletes_matching_label(self):
+        labels_by_norm = {
+            "stale": {"name": "stale", "color": "ffffff", "description": ""},
+        }
+
+        with patch.object(sync_labels, "delete_label") as delete_label:
+            sync_labels.apply_deletes(
+                "token",
+                "complytime",
+                "demo",
+                labels_by_norm,
+                ["stale"],
+                dry_run=True,
+            )
+
+        delete_label.assert_called_once_with("token", "complytime", "demo", "stale", True)
+        assert "stale" not in labels_by_norm
+
+    def test_skips_missing_label(self):
+        labels_by_norm: dict = {}
+
+        with patch.object(sync_labels, "delete_label") as delete_label:
+            sync_labels.apply_deletes(
+                "token",
+                "complytime",
+                "demo",
+                labels_by_norm,
+                ["missing"],
+                dry_run=True,
+            )
+
+        delete_label.assert_not_called()


### PR DESCRIPTION
## Summary
- Moves the label standardization work from [`complytime/.github#192`](https://github.com/complytime/.github/pull/192) into **org-infra**, per review feedback from @marcusburghardt and @gxmiranda
- Adds `labels-policy.json`, `scripts/sync-labels.py`, and a manual **Sync Repository Labels** workflow
- Documents usage in `docs/LABEL_SYNC.md` and updates the README tree

## Why org-infra
- Better fit for org-wide automation (alongside `sync_org_repositories.yml`)
- Native GitHub org default labels only cover a single org; this workflow supports create/rename/cleanup across repos and can later extend to UF/ASDLC as discussed

## Behavior
- Targets complytime repositories except those excluded in `labels-policy.json` (currently `complytime` and `roadmap`)
- Create shared standard labels; rename legacy labels only where present; delete only explicitly listed labels; preserve local-only labels
- Workflow defaults to **dry-run**; uses `SYNC_APP_CLIENT_ID` / `SYNC_APP_PRIVATE_KEY` with `issues:write`

## Test plan
- [ ] Review `labels-policy.json` as the source of truth
- [ ] Confirm workflow secret/permission choices match org-infra conventions
- [ ] Dry-run the workflow after merge on a small repo subset before org-wide apply


Made with [Cursor](https://cursor.com)