### PR TITLE
feat(ci): sync Compliance Automation project board across orgs

### DIFF
--- a/.github/workflows/sync_project_board.yml
+++ b/.github/workflows/sync_project_board.yml
@@ -50,8 +50,8 @@ jobs:
 
       - name: Install dependencies
         run: |
-          python -m pip install --upgrade pip
-          pip install -r requirements.txt
+          # Hash-pinned install for Scorecard Pinned-Dependencies
+          python -m pip install --require-hashes -r requirements-project-sync.txt
 
       - name: Sync project board
         env:

--- a/.github/workflows/sync_project_board.yml
+++ b/.github/workflows/sync_project_board.yml
@@ -1,0 +1,75 @@
+# SPDX-License-Identifier: Apache-2.0
+#
+# Sync open issues/PRs from configured organizations into the
+# Compliance Automation planning project board.
+#
+# Cross-org access requires a classic or fine-grained PAT stored as
+# PROJECT_SYNC_TOKEN (GitHub App installation tokens are single-org).
+# See docs/PROJECT_BOARD_SYNC.md.
+
+name: Sync Compliance Automation Project Board
+
+on:
+  workflow_dispatch:
+    inputs:
+      dry_run:
+        description: 'Dry run (discover only; do not mutate the project)'
+        required: false
+        type: boolean
+        default: false
+      orgs:
+        description: 'Optional org filter (space-separated). Leave empty for all configured orgs.'
+        required: false
+        type: string
+        default: ''
+  schedule:
+    # Daily catch-up for newly opened issues/PRs across orgs.
+    - cron: '0 6 * * *'
+
+permissions:
+  contents: read
+
+jobs:
+  sync-project-board:
+    name: Sync project board
+    runs-on: ubuntu-latest
+    timeout-minutes: 60
+
+    steps:
+      - name: Checkout org-infra
+        uses: actions/checkout@3d3c42e5aac5ba805825da76410c181273ba90b1 # v7.0.1
+        with:
+          fetch-depth: 1
+          persist-credentials: false
+
+      - name: Set up Python
+        uses: actions/setup-python@5fda3b95a4ea91299a34e894583c3862153e4b97 # v7.0.0
+        with:
+          python-version: '3.11'
+          cache: 'pip'
+
+      - name: Install dependencies
+        run: |
+          python -m pip install --upgrade pip
+          pip install -r requirements.txt
+
+      - name: Sync project board
+        env:
+          GITHUB_TOKEN: ${{ secrets.PROJECT_SYNC_TOKEN }}
+          DRY_RUN: ${{ inputs.dry_run || false }}
+          ORGS: ${{ inputs.orgs || '' }}
+        run: |
+          if [ -z "$GITHUB_TOKEN" ]; then
+            echo "::error::PROJECT_SYNC_TOKEN secret is not configured. See docs/PROJECT_BOARD_SYNC.md"
+            exit 1
+          fi
+
+          ARGS=(--config project-sync-config.yml)
+          if [ "$DRY_RUN" = "true" ]; then
+            ARGS+=(--dry-run)
+          fi
+          if [ -n "$ORGS" ]; then
+            ARGS+=(--orgs "$ORGS")
+          fi
+
+          python scripts/sync-project-board.py "${ARGS[@]}"

--- a/README.md
+++ b/README.md
@@ -56,7 +56,8 @@ org-infra/
 │  │  ├── reusable_sign_and_verify.yml      # Sigstore keyless signing and attestation verification for container images.
 │  │  ├── reusable_sonarqube.yml            # SonarCloud static analysis for code quality and security.
 │  │  ├── reusable_vuln_scan.yml            # Vulnerability scanning via OSV-Scanner and Trivy.
-│  │  └── sync_org_repositories.yml         # Manual, scheduled, and event-based workflow to synchronize files.
+│  │  ├── sync_org_repositories.yml         # Manual, scheduled, and event-based workflow to synchronize files.
+│  │  └── sync_project_board.yml            # Sync open issues/PRs into Compliance Automation planning board.
 │  ├── dependabot.yml                       # Dependabot settings for GitHub Actions and Go modules.
 │  ├── dependabot_python.yml                # Dependabot settings for GitHub Actions (Python repos) and pip.
 │  └── pull_request_template.md             # PR template applicable to all repositories.
@@ -64,12 +65,15 @@ org-infra/
 │  └── ampel/                               # Policy definitions for branch protection rule compliance checks.
 ├── docs/                                   # More detailed and specific documentation.
 │  ├── LOCAL_TESTING.md                     # Documentation on how to test synchronization locally.
+│  ├── PROJECT_BOARD_SYNC.md                # Compliance Automation project board sync setup.
 │  └── SYNC_REPOSITORIES_SETUP.md          # Documentation on how to setup the repository synchronization infrastructure.
 ├── scripts/
 │  ├── sync-org-repositories.py             # Python script to check and ensure consistence among repositories.
+│  ├── sync-project-board.py                # Sync open issues/PRs into the Compliance Automation project board.
 │  └── resolve-go-packages.sh              # Bash: multi-module Go package auto-discovery
 ├── ...                                     # Multiple technology specific configuration files
 ├── sync-config.yml                         # Configuration file consumed by `sync-org-repositories.py`
+├── project-sync-config.yml                 # Orgs/repos synced into Compliance Automation planning board
 └── README.md                               # This file.
 ```
 

--- a/docs/PROJECT_BOARD_SYNC.md
+++ b/docs/PROJECT_BOARD_SYNC.md
@@ -1,0 +1,88 @@
+# Compliance Automation Project Board Sync
+
+Automates keeping the private
+[Compliance Automation planning](https://github.com/orgs/complytime/projects/14)
+board populated with open issues and pull requests from:
+
+| Organization | Selection |
+|---|---|
+| `Agentic-SSDLC` | All repositories |
+| `complytime` | All repositories **except** `roadmap` and `complytime` |
+| `unbound-force` | All repositories |
+
+Archived repositories are skipped by default.
+
+## What the automation does
+
+On a daily schedule (and via manual `workflow_dispatch`):
+
+1. Discovers repositories from `project-sync-config.yml`
+2. Links each repository to project `#14` (idempotent)
+3. Collects open issues and open PRs
+4. Adds any missing items to the board with **Status = Backlog**
+
+The workflow lives only in `org-infra` (it is **not** synced out to consumer repos).
+
+| File | Role |
+|---|---|
+| `project-sync-config.yml` | Orgs, exclusions, and project target |
+| `scripts/sync-project-board.py` | Discovery + GraphQL mutations |
+| `.github/workflows/sync_project_board.yml` | Schedule + manual trigger |
+
+## Why a PAT (not the sync GitHub App)
+
+GitHub App installation tokens are scoped to a **single** organization.
+Adding an issue from `Agentic-SSDLC` or `unbound-force` onto a project owned
+by `complytime` requires a credential that can see all three orgs and write
+to the project. Use a classic or fine-grained personal access token (or a
+machine-user token) stored as `PROJECT_SYNC_TOKEN`.
+
+## One-time setup
+
+### 1. Create the token
+
+**Classic PAT** (simplest for multi-org):
+
+- Scopes: `repo`, `read:org`, `project`
+- The token owner must be able to access private repos in all three orgs and
+  edit project `#14`
+
+**Fine-grained PAT** alternative:
+
+- Resource owner / repository access covering the three orgs (or all repos the
+  bot can see)
+- Permissions: Issues (read), Pull requests (read), Metadata (read)
+- Organization permission for `complytime`: **Projects = Read and write**
+
+### 2. Add the repository secret
+
+In `complytime/org-infra` → Settings → Secrets and variables → Actions:
+
+- Name: `PROJECT_SYNC_TOKEN`
+- Value: the PAT from step 1
+
+### 3. Run an initial backfill
+
+Actions → **Sync Compliance Automation Project Board** → Run workflow
+
+- Leave `dry_run` checked first to validate discovery
+- Re-run with `dry_run` unchecked to add items
+
+Optional: set `orgs` to a single org (for example `complytime`) to stage the rollout.
+
+## Local dry-run
+
+```bash
+export GITHUB_TOKEN="$(gh auth token)"   # needs project write for apply mode
+pip install -r requirements.txt
+python scripts/sync-project-board.py --config project-sync-config.yml --dry-run
+```
+
+## Changing scope
+
+Edit `project-sync-config.yml`:
+
+- Add/remove orgs under `organizations`
+- Adjust `exclude_repos`
+- Toggle `sync.issues` / `sync.pull_requests`
+- Change `project.default_status` (must match a Status option on the board)

--- a/docs/PROJECT_BOARD_SYNC.md
+++ b/docs/PROJECT_BOARD_SYNC.md
@@ -34,25 +34,29 @@ The workflow lives only in `org-infra` (it is **not** synced out to consumer rep
 GitHub App installation tokens are scoped to a **single** organization.
 Adding an issue from `Agentic-SSDLC` or `unbound-force` onto a project owned
 by `complytime` requires a credential that can see all three orgs and write
-to the project. Use a classic or fine-grained personal access token (or a
+to the project. Use a fine-grained or classic personal access token (or a
 machine-user token) stored as `PROJECT_SYNC_TOKEN`.
 
 ## One-time setup
 
 ### 1. Create the token
 
-**Classic PAT** (simplest for multi-org):
-
-- Scopes: `repo`, `read:org`, `project`
-- The token owner must be able to access private repos in all three orgs and
-  edit project `#14`
-
-**Fine-grained PAT** alternative:
+**Fine-grained PAT** (preferred — least privilege):
 
 - Resource owner / repository access covering the three orgs (or all repos the
   bot can see)
-- Permissions: Issues (read), Pull requests (read), Metadata (read)
+- Repository permissions: **Issues** (read), **Pull requests** (read),
+  **Metadata** (read)
 - Organization permission for `complytime`: **Projects = Read and write**
+- The token owner must be able to access private repos in all three orgs and
+  edit project `#14`
+
+**Classic PAT** (fallback when fine-grained multi-org access is impractical):
+
+- Prefer `public_repo` instead of `repo` if every target repository is public
+- Otherwise scopes: `repo`, `read:org`, `project`
+- Note: classic `repo` grants full read/write to all private repos the token
+  owner can access — broader than this sync needs
 
 ### 2. Add the repository secret
 

--- a/project-sync-config.yml
+++ b/project-sync-config.yml
@@ -1,0 +1,33 @@
+# Configuration for syncing repositories and open work items into the
+# Compliance Automation planning GitHub Project board.
+#
+# Consumed by scripts/sync-project-board.py and
+# .github/workflows/sync_project_board.yml
+
+project:
+  owner: complytime
+  number: 14
+  # Status option applied to newly added items (must match a Status field option)
+  default_status: "Backlog"
+
+# What to sync onto the board
+sync:
+  issues: true
+  pull_requests: true
+  # Skip archived repositories unless explicitly listed under include_archived
+  skip_archived: true
+  # Also link each discovered repository to the project (enables native Project automations)
+  link_repositories: true
+
+# Organizations and repository selection rules
+organizations:
+  - name: Agentic-SSDLC
+    # All repositories
+
+  - name: complytime
+    exclude_repos:
+      - roadmap
+      - complytime
+
+  - name: unbound-force
+    # All repositories

--- a/requirements-project-sync.txt
+++ b/requirements-project-sync.txt
@@ -1,0 +1,16 @@
+# Hash-pinned runtime deps for sync_project_board.yml (ubuntu-latest / CPython 3.11).
+# Generated for Scorecard Pinned-Dependencies. Install with:
+#   pip install --require-hashes -r requirements-project-sync.txt
+
+PyYAML==6.0.3 \
+    --hash=sha256:b8bb0864c5a28024fac8a632c443c87c5aa6f215c0b126c449ae1a150412f31d
+requests==2.34.2 \
+    --hash=sha256:2a0d60c172f83ac6ab31e4554906c0f3b3588d37b5cb939b1c061f4907e278e0
+charset-normalizer==3.4.9 \
+    --hash=sha256:04ce310cb89c15df659582aee80a0603788732a5e017d5bd5c81158106ce249c
+idna==3.18 \
+    --hash=sha256:7f952cbe720b688055e3f87de14f5c3e5fdaa8bc3928985c4077ca689de849a2
+urllib3==2.7.0 \
+    --hash=sha256:9fb4c81ebbb1ce9531cce37674bbc6f1360472bc18ca9a553ede278ef7276897
+certifi==2026.7.22 \
+    --hash=sha256:62f22742b58a1a33014a2b6b706588a8d7e2a88ae7bd1a6ebe8c992928483775

--- a/scripts/sync-project-board.py
+++ b/scripts/sync-project-board.py
@@ -26,6 +26,10 @@ GITHUB_API = "https://api.github.com"
 GITHUB_GRAPHQL = f"{GITHUB_API}/graphql"
 DEFAULT_CONFIG = "project-sync-config.yml"
 
+# Expected failure modes while iterating orgs/repos (HTTP + explicit RuntimeError).
+# Keeps programming bugs (TypeError, KeyError, …) from being swallowed per item.
+SYNC_EXCEPTIONS = (requests.RequestException, RuntimeError)
+
 
 @dataclass
 class SyncStats:
@@ -138,6 +142,26 @@ def parse_args() -> argparse.Namespace:
 def load_config(path: Path) -> Dict[str, Any]:
     with path.open(encoding="utf-8") as handle:
         return yaml.safe_load(handle)
+
+
+def validate_config(config: Any) -> Dict[str, Any]:
+    """Validate required sync config shape; return the config on success."""
+    if not isinstance(config, dict):
+        raise ValueError("Config must be a mapping")
+    project = config.get("project")
+    if not isinstance(project, dict):
+        raise ValueError("Config missing 'project' mapping")
+    if not project.get("owner"):
+        raise ValueError("Config project requires 'owner'")
+    if "number" not in project:
+        raise ValueError("Config project requires 'number'")
+    organizations = config.get("organizations")
+    if not isinstance(organizations, list) or not organizations:
+        raise ValueError("Config requires a non-empty 'organizations' list")
+    for org in organizations:
+        if not isinstance(org, dict) or not org.get("name"):
+            raise ValueError("Each organization requires a 'name'")
+    return config
 
 
 def list_org_repos(
@@ -333,7 +357,8 @@ def add_item(
         )
 
 
-def write_summary(stats: SyncStats, dry_run: bool) -> None:
+def format_summary(stats: SyncStats, dry_run: bool) -> str:
+    """Format the job summary markdown (pure; no I/O)."""
     lines = [
         "## Compliance Automation project sync",
         "",
@@ -349,8 +374,12 @@ def write_summary(stats: SyncStats, dry_run: bool) -> None:
     if stats.errors:
         lines.extend(["", "### Errors", ""])
         lines.extend(f"- `{err}`" for err in stats.errors[:50])
+    return "\n".join(lines) + "\n"
 
-    summary = "\n".join(lines) + "\n"
+
+def write_summary(stats: SyncStats, dry_run: bool) -> None:
+    """Print the job summary and append it to GITHUB_STEP_SUMMARY when set."""
+    summary = format_summary(stats, dry_run)
     print(summary)
     step_summary = os.getenv("GITHUB_STEP_SUMMARY")
     if step_summary:
@@ -392,7 +421,7 @@ def sync(config: Dict[str, Any], client: GitHubClient, org_filter: Set[str]) -> 
             repos = list_org_repos(
                 client, org, exclude=exclude, skip_archived=skip_archived
             )
-        except Exception as exc:  # noqa: BLE001 - surface per-org failures
+        except SYNC_EXCEPTIONS as exc:
             msg = f"Failed listing repos for {org}: {exc}"
             print(msg)
             stats.errors.append(msg)
@@ -412,7 +441,7 @@ def sync(config: Dict[str, Any], client: GitHubClient, org_filter: Set[str]) -> 
                     else:
                         stats.repos_link_skipped += 1
                         print("  already linked (or skipped)")
-                except Exception as exc:  # noqa: BLE001
+                except SYNC_EXCEPTIONS as exc:
                     msg = f"Link failed for {full_name}: {exc}"
                     print(f"  {msg}")
                     stats.errors.append(msg)
@@ -424,7 +453,7 @@ def sync(config: Dict[str, Any], client: GitHubClient, org_filter: Set[str]) -> 
                     include_issues=include_issues,
                     include_prs=include_prs,
                 )
-            except Exception as exc:  # noqa: BLE001
+            except SYNC_EXCEPTIONS as exc:
                 msg = f"Failed listing items for {full_name}: {exc}"
                 print(f"  {msg}")
                 stats.errors.append(msg)
@@ -453,7 +482,7 @@ def sync(config: Dict[str, Any], client: GitHubClient, org_filter: Set[str]) -> 
                     stats.items_added += 1
                     on_board.add(node_id)
                     print(f"  + {label}")
-                except Exception as exc:  # noqa: BLE001
+                except SYNC_EXCEPTIONS as exc:
                     stats.items_failed += 1
                     msg = f"Failed adding {full_name} {label}: {exc}"
                     print(f"  ! {msg}")
@@ -474,7 +503,11 @@ def main() -> int:
         print(f"Config not found: {config_path}", file=sys.stderr)
         return 2
 
-    config = load_config(config_path)
+    try:
+        config = validate_config(load_config(config_path))
+    except ValueError as exc:
+        print(f"Invalid config: {exc}", file=sys.stderr)
+        return 2
     org_filter = {part for part in args.orgs.split() if part}
     client = GitHubClient(token=token, dry_run=args.dry_run)
     stats = sync(config, client, org_filter)

--- a/scripts/sync-project-board.py
+++ b/scripts/sync-project-board.py
@@ -1,0 +1,486 @@
+#!/usr/bin/env python3
+# SPDX-License-Identifier: Apache-2.0
+
+"""Sync open issues/PRs from configured orgs into a GitHub Project (v2).
+
+Discovers repositories across one or more organizations, optionally links
+them to the target project, and adds any open issues/PRs that are not
+already on the board. Designed for cross-org boards where a single GitHub
+App installation token is insufficient (use a PAT with multi-org access).
+"""
+
+from __future__ import annotations
+
+import argparse
+import os
+import sys
+import time
+from dataclasses import dataclass, field
+from pathlib import Path
+from typing import Any, Dict, List, Optional, Set, Tuple
+
+import requests
+import yaml
+
+GITHUB_API = "https://api.github.com"
+GITHUB_GRAPHQL = f"{GITHUB_API}/graphql"
+DEFAULT_CONFIG = "project-sync-config.yml"
+
+
+@dataclass
+class SyncStats:
+    """Counters written to the job summary."""
+
+    repos_considered: int = 0
+    repos_linked: int = 0
+    repos_link_skipped: int = 0
+    items_seen: int = 0
+    items_already_on_board: int = 0
+    items_added: int = 0
+    items_failed: int = 0
+    errors: List[str] = field(default_factory=list)
+
+
+class GitHubClient:
+    """Thin GitHub REST + GraphQL client."""
+
+    def __init__(self, token: str, dry_run: bool = False) -> None:
+        self.dry_run = dry_run
+        self.session = requests.Session()
+        self.session.headers.update(
+            {
+                "Authorization": f"Bearer {token}",
+                "Accept": "application/vnd.github+json",
+                "X-GitHub-Api-Version": "2022-11-28",
+                "User-Agent": "complytime-project-board-sync",
+            }
+        )
+
+    def _request(
+        self,
+        method: str,
+        url: str,
+        *,
+        params: Optional[Dict[str, Any]] = None,
+        json_body: Optional[Dict[str, Any]] = None,
+        max_retries: int = 5,
+    ) -> requests.Response:
+        for attempt in range(max_retries):
+            response = self.session.request(
+                method, url, params=params, json=json_body, timeout=60
+            )
+            if response.status_code in (403, 429) and "rate limit" in response.text.lower():
+                reset = response.headers.get("X-RateLimit-Reset")
+                sleep_for = 30
+                if reset and reset.isdigit():
+                    sleep_for = max(5, int(reset) - int(time.time()) + 1)
+                print(f"Rate limited; sleeping {sleep_for}s (attempt {attempt + 1})")
+                time.sleep(min(sleep_for, 120))
+                continue
+            if response.status_code >= 500:
+                time.sleep(2 ** attempt)
+                continue
+            return response
+        return response
+
+    def rest_paginate(self, path: str, params: Optional[Dict[str, Any]] = None) -> List[Dict[str, Any]]:
+        """Paginate a REST collection endpoint."""
+        url = f"{GITHUB_API}{path}"
+        query = dict(params or {})
+        query.setdefault("per_page", 100)
+        items: List[Dict[str, Any]] = []
+        while url:
+            response = self._request("GET", url, params=query)
+            response.raise_for_status()
+            payload = response.json()
+            if isinstance(payload, list):
+                items.extend(payload)
+            else:
+                raise RuntimeError(f"Unexpected REST payload for {path}: {type(payload)}")
+            # Subsequent pages already encode query in Link URL
+            query = None
+            url = response.links.get("next", {}).get("url")
+        return items
+
+    def graphql(self, query: str, variables: Optional[Dict[str, Any]] = None) -> Dict[str, Any]:
+        response = self._request(
+            "POST",
+            GITHUB_GRAPHQL,
+            json_body={"query": query, "variables": variables or {}},
+        )
+        response.raise_for_status()
+        payload = response.json()
+        if payload.get("errors"):
+            raise RuntimeError(f"GraphQL errors: {payload['errors']}")
+        return payload["data"]
+
+
+def parse_args() -> argparse.Namespace:
+    parser = argparse.ArgumentParser(description=__doc__)
+    parser.add_argument(
+        "--config",
+        default=DEFAULT_CONFIG,
+        help=f"Path to sync config (default: {DEFAULT_CONFIG})",
+    )
+    parser.add_argument(
+        "--dry-run",
+        action="store_true",
+        help="Discover work and report actions without mutating the project",
+    )
+    parser.add_argument(
+        "--orgs",
+        default="",
+        help="Optional space-separated org filter (defaults to all configured orgs)",
+    )
+    return parser.parse_args()
+
+
+def load_config(path: Path) -> Dict[str, Any]:
+    with path.open(encoding="utf-8") as handle:
+        return yaml.safe_load(handle)
+
+
+def list_org_repos(
+    client: GitHubClient,
+    org: str,
+    *,
+    exclude: Set[str],
+    skip_archived: bool,
+) -> List[Dict[str, Any]]:
+    repos = client.rest_paginate(f"/orgs/{org}/repos", {"type": "all", "sort": "full_name"})
+    selected = []
+    for repo in repos:
+        name = repo["name"]
+        if name in exclude:
+            continue
+        if skip_archived and repo.get("archived"):
+            continue
+        selected.append(repo)
+    return selected
+
+
+def get_project(
+    client: GitHubClient, owner: str, number: int
+) -> Tuple[str, Optional[str], Dict[str, str]]:
+    """Return project id, Status field id, and Status option name→id map."""
+    data = client.graphql(
+        """
+        query($owner: String!, $number: Int!) {
+          organization(login: $owner) {
+            projectV2(number: $number) {
+              id
+              fields(first: 50) {
+                nodes {
+                  ... on ProjectV2SingleSelectField {
+                    id
+                    name
+                    options { id name }
+                  }
+                }
+              }
+            }
+          }
+        }
+        """,
+        {"owner": owner, "number": number},
+    )
+    project = data["organization"]["projectV2"]
+    if not project:
+        raise RuntimeError(f"Project #{number} not found in org {owner}")
+
+    status_field_id = None
+    status_options: Dict[str, str] = {}
+    for node in project["fields"]["nodes"]:
+        if not node:
+            continue
+        if node.get("name") == "Status":
+            status_field_id = node["id"]
+            status_options = {opt["name"]: opt["id"] for opt in node.get("options", [])}
+            break
+    return project["id"], status_field_id, status_options
+
+
+def existing_content_ids(client: GitHubClient, project_id: str) -> Set[str]:
+    """Return node IDs of issues/PRs already on the project."""
+    query = """
+    query($projectId: ID!, $cursor: String) {
+      node(id: $projectId) {
+        ... on ProjectV2 {
+          items(first: 100, after: $cursor) {
+            pageInfo { hasNextPage endCursor }
+            nodes {
+              content {
+                ... on Issue { id }
+                ... on PullRequest { id }
+              }
+            }
+          }
+        }
+      }
+    }
+    """
+    ids: Set[str] = set()
+    cursor = None
+    while True:
+        data = client.graphql(query, {"projectId": project_id, "cursor": cursor})
+        items = data["node"]["items"]
+        for node in items["nodes"]:
+            content = node.get("content") or {}
+            content_id = content.get("id")
+            if content_id:
+                ids.add(content_id)
+        if not items["pageInfo"]["hasNextPage"]:
+            break
+        cursor = items["pageInfo"]["endCursor"]
+    return ids
+
+
+def link_repository(client: GitHubClient, project_id: str, repository_id: str) -> bool:
+    """Link a repository to the project. Returns True if a link was created."""
+    if client.dry_run:
+        print(f"  [dry-run] would link repository {repository_id}")
+        return True
+    try:
+        client.graphql(
+            """
+            mutation($projectId: ID!, $repositoryId: ID!) {
+              linkProjectV2ToRepository(input: {
+                projectId: $projectId
+                repositoryId: $repositoryId
+              }) {
+                repository { id nameWithOwner }
+              }
+            }
+            """,
+            {"projectId": project_id, "repositoryId": repository_id},
+        )
+        return True
+    except RuntimeError as exc:
+        message = str(exc)
+        # Already linked is not a failure for idempotent syncs.
+        if "already linked" in message.lower() or "already exists" in message.lower():
+            return False
+        raise
+
+
+def list_open_items(
+    client: GitHubClient,
+    full_name: str,
+    *,
+    include_issues: bool,
+    include_prs: bool,
+) -> List[Dict[str, Any]]:
+    """List open issues and/or PRs for a repository via REST."""
+    items: List[Dict[str, Any]] = []
+    # /issues returns issues + PRs; filter client-side.
+    raw = client.rest_paginate(
+        f"/repos/{full_name}/issues",
+        {"state": "open", "direction": "asc"},
+    )
+    for entry in raw:
+        is_pr = "pull_request" in entry
+        if is_pr and not include_prs:
+            continue
+        if (not is_pr) and not include_issues:
+            continue
+        items.append(entry)
+    return items
+
+
+def add_item(
+    client: GitHubClient,
+    project_id: str,
+    content_id: str,
+    status_field_id: Optional[str],
+    status_option_id: Optional[str],
+) -> None:
+    if client.dry_run:
+        print(f"  [dry-run] would add {content_id}")
+        return
+
+    data = client.graphql(
+        """
+        mutation($projectId: ID!, $contentId: ID!) {
+          addProjectV2ItemById(input: {projectId: $projectId, contentId: $contentId}) {
+            item { id }
+          }
+        }
+        """,
+        {"projectId": project_id, "contentId": content_id},
+    )
+    item_id = data["addProjectV2ItemById"]["item"]["id"]
+
+    if status_field_id and status_option_id:
+        client.graphql(
+            """
+            mutation($projectId: ID!, $itemId: ID!, $fieldId: ID!, $optionId: String!) {
+              updateProjectV2ItemFieldValue(input: {
+                projectId: $projectId
+                itemId: $itemId
+                fieldId: $fieldId
+                value: { singleSelectOptionId: $optionId }
+              }) {
+                projectV2Item { id }
+              }
+            }
+            """,
+            {
+                "projectId": project_id,
+                "itemId": item_id,
+                "fieldId": status_field_id,
+                "optionId": status_option_id,
+            },
+        )
+
+
+def write_summary(stats: SyncStats, dry_run: bool) -> None:
+    lines = [
+        "## Compliance Automation project sync",
+        "",
+        f"- Mode: `{'dry-run' if dry_run else 'apply'}`",
+        f"- Repositories considered: **{stats.repos_considered}**",
+        f"- Repositories linked: **{stats.repos_linked}**"
+        + (f" (skipped/already linked: {stats.repos_link_skipped})" if stats.repos_link_skipped else ""),
+        f"- Open items scanned: **{stats.items_seen}**",
+        f"- Already on board: **{stats.items_already_on_board}**",
+        f"- Added: **{stats.items_added}**",
+        f"- Failed: **{stats.items_failed}**",
+    ]
+    if stats.errors:
+        lines.extend(["", "### Errors", ""])
+        lines.extend(f"- `{err}`" for err in stats.errors[:50])
+
+    summary = "\n".join(lines) + "\n"
+    print(summary)
+    step_summary = os.getenv("GITHUB_STEP_SUMMARY")
+    if step_summary:
+        with open(step_summary, "a", encoding="utf-8") as handle:
+            handle.write(summary)
+
+
+def sync(config: Dict[str, Any], client: GitHubClient, org_filter: Set[str]) -> SyncStats:
+    stats = SyncStats()
+    project_cfg = config["project"]
+    sync_cfg = config.get("sync", {})
+    owner = project_cfg["owner"]
+    number = int(project_cfg["number"])
+    default_status = project_cfg.get("default_status", "Backlog")
+    include_issues = bool(sync_cfg.get("issues", True))
+    include_prs = bool(sync_cfg.get("pull_requests", True))
+    skip_archived = bool(sync_cfg.get("skip_archived", True))
+    link_repos = bool(sync_cfg.get("link_repositories", True))
+
+    project_id, status_field_id, status_options = get_project(client, owner, number)
+    status_option_id = status_options.get(default_status) if status_options else None
+    if default_status and status_field_id and not status_option_id:
+        print(
+            f"Warning: Status option '{default_status}' not found; "
+            "items will be added without a Status value"
+        )
+
+    print(f"Project {owner}/{number} id={project_id}")
+    on_board = existing_content_ids(client, project_id)
+    print(f"Existing board items with content: {len(on_board)}")
+
+    for org_cfg in config.get("organizations", []):
+        org = org_cfg["name"]
+        if org_filter and org not in org_filter:
+            continue
+        exclude = set(org_cfg.get("exclude_repos") or [])
+        print(f"\n=== {org} (exclude={sorted(exclude) or 'none'}) ===")
+        try:
+            repos = list_org_repos(
+                client, org, exclude=exclude, skip_archived=skip_archived
+            )
+        except Exception as exc:  # noqa: BLE001 - surface per-org failures
+            msg = f"Failed listing repos for {org}: {exc}"
+            print(msg)
+            stats.errors.append(msg)
+            continue
+
+        for repo in repos:
+            full_name = repo["full_name"]
+            stats.repos_considered += 1
+            print(f"\n- {full_name}")
+
+            if link_repos:
+                try:
+                    linked = link_repository(client, project_id, repo["node_id"])
+                    if linked:
+                        stats.repos_linked += 1
+                        print("  linked to project")
+                    else:
+                        stats.repos_link_skipped += 1
+                        print("  already linked (or skipped)")
+                except Exception as exc:  # noqa: BLE001
+                    msg = f"Link failed for {full_name}: {exc}"
+                    print(f"  {msg}")
+                    stats.errors.append(msg)
+
+            try:
+                open_items = list_open_items(
+                    client,
+                    full_name,
+                    include_issues=include_issues,
+                    include_prs=include_prs,
+                )
+            except Exception as exc:  # noqa: BLE001
+                msg = f"Failed listing items for {full_name}: {exc}"
+                print(f"  {msg}")
+                stats.errors.append(msg)
+                continue
+
+            for item in open_items:
+                stats.items_seen += 1
+                node_id = item["node_id"]
+                title = item.get("title", "")
+                number_ = item.get("number")
+                kind = "PR" if "pull_request" in item else "Issue"
+                label = f"{kind} #{number_}: {title}"
+
+                if node_id in on_board:
+                    stats.items_already_on_board += 1
+                    continue
+
+                try:
+                    add_item(
+                        client,
+                        project_id,
+                        node_id,
+                        status_field_id,
+                        status_option_id,
+                    )
+                    stats.items_added += 1
+                    on_board.add(node_id)
+                    print(f"  + {label}")
+                except Exception as exc:  # noqa: BLE001
+                    stats.items_failed += 1
+                    msg = f"Failed adding {full_name} {label}: {exc}"
+                    print(f"  ! {msg}")
+                    stats.errors.append(msg)
+
+    return stats
+
+
+def main() -> int:
+    args = parse_args()
+    token = os.getenv("GITHUB_TOKEN") or os.getenv("PROJECT_SYNC_TOKEN")
+    if not token:
+        print("GITHUB_TOKEN or PROJECT_SYNC_TOKEN is required", file=sys.stderr)
+        return 2
+
+    config_path = Path(args.config)
+    if not config_path.exists():
+        print(f"Config not found: {config_path}", file=sys.stderr)
+        return 2
+
+    config = load_config(config_path)
+    org_filter = {part for part in args.orgs.split() if part}
+    client = GitHubClient(token=token, dry_run=args.dry_run)
+    stats = sync(config, client, org_filter)
+    write_summary(stats, dry_run=args.dry_run)
+    return 1 if stats.items_failed or stats.errors else 0
+
+
+if __name__ == "__main__":
+    sys.exit(main())

--- a/tests/test_sync_project_board.py
+++ b/tests/test_sync_project_board.py
@@ -1,0 +1,325 @@
+# SPDX-License-Identifier: Apache-2.0
+
+"""Tests for sync-project-board.py."""
+
+from __future__ import annotations
+
+import importlib
+import sys
+from pathlib import Path
+from typing import Any, Dict, Optional
+from unittest.mock import MagicMock, patch
+
+import pytest
+import requests
+import yaml
+
+sys.path.insert(0, str(Path(__file__).parent.parent / "scripts"))
+
+sync = importlib.import_module("sync-project-board")
+
+
+def _minimal_config(**overrides: Any) -> Dict[str, Any]:
+    config: Dict[str, Any] = {
+        "project": {"owner": "complytime", "number": 14, "default_status": "Backlog"},
+        "sync": {
+            "issues": True,
+            "pull_requests": True,
+            "skip_archived": True,
+            "link_repositories": True,
+        },
+        "organizations": [
+            {"name": "complytime", "exclude_repos": ["roadmap", "complytime"]},
+            {"name": "Agentic-SSDLC"},
+        ],
+    }
+    config.update(overrides)
+    return config
+
+
+class TestLoadAndValidateConfig:
+    def test_load_config_reads_yaml(self, tmp_path: Path):
+        path = tmp_path / "cfg.yml"
+        path.write_text(yaml.safe_dump(_minimal_config()), encoding="utf-8")
+        loaded = sync.load_config(path)
+        assert loaded["project"]["owner"] == "complytime"
+        assert loaded["organizations"][0]["exclude_repos"] == ["roadmap", "complytime"]
+
+    def test_validate_config_accepts_minimal(self):
+        assert sync.validate_config(_minimal_config())["project"]["number"] == 14
+
+    @pytest.mark.parametrize(
+        "bad",
+        [
+            None,
+            [],
+            {"project": {"owner": "x"}},  # missing number + orgs
+            {"project": {"owner": "x", "number": 1}, "organizations": []},
+            {
+                "project": {"owner": "x", "number": 1},
+                "organizations": [{"exclude_repos": ["a"]}],
+            },
+        ],
+    )
+    def test_validate_config_rejects_invalid(self, bad: Any):
+        with pytest.raises(ValueError):
+            sync.validate_config(bad)
+
+
+class TestListOrgRepos:
+    def test_filters_exclude_and_archived(self):
+        client = MagicMock()
+        client.rest_paginate.return_value = [
+            {"name": "keep", "archived": False},
+            {"name": "roadmap", "archived": False},
+            {"name": "old", "archived": True},
+        ]
+        repos = sync.list_org_repos(
+            client, "complytime", exclude={"roadmap"}, skip_archived=True
+        )
+        assert [r["name"] for r in repos] == ["keep"]
+        client.rest_paginate.assert_called_once_with(
+            "/orgs/complytime/repos", {"type": "all", "sort": "full_name"}
+        )
+
+    def test_includes_archived_when_not_skipped(self):
+        client = MagicMock()
+        client.rest_paginate.return_value = [
+            {"name": "keep", "archived": False},
+            {"name": "old", "archived": True},
+        ]
+        repos = sync.list_org_repos(
+            client, "complytime", exclude=set(), skip_archived=False
+        )
+        assert [r["name"] for r in repos] == ["keep", "old"]
+
+
+class TestListOpenItems:
+    def test_filters_issues_vs_prs(self):
+        client = MagicMock()
+        client.rest_paginate.return_value = [
+            {"number": 1, "title": "issue", "node_id": "I_1"},
+            {"number": 2, "title": "pr", "node_id": "PR_2", "pull_request": {}},
+        ]
+        issues_only = sync.list_open_items(
+            client, "org/repo", include_issues=True, include_prs=False
+        )
+        prs_only = sync.list_open_items(
+            client, "org/repo", include_issues=False, include_prs=True
+        )
+        both = sync.list_open_items(
+            client, "org/repo", include_issues=True, include_prs=True
+        )
+        assert [i["number"] for i in issues_only] == [1]
+        assert [i["number"] for i in prs_only] == [2]
+        assert [i["number"] for i in both] == [1, 2]
+
+
+class TestExistingContentIds:
+    def test_paginates_until_exhausted(self):
+        client = MagicMock()
+        client.graphql.side_effect = [
+            {
+                "node": {
+                    "items": {
+                        "pageInfo": {"hasNextPage": True, "endCursor": "c1"},
+                        "nodes": [
+                            {"content": {"id": "I_1"}},
+                            {"content": None},
+                            {"content": {"id": "PR_2"}},
+                        ],
+                    }
+                }
+            },
+            {
+                "node": {
+                    "items": {
+                        "pageInfo": {"hasNextPage": False, "endCursor": "c2"},
+                        "nodes": [{"content": {"id": "I_3"}}],
+                    }
+                }
+            },
+        ]
+        ids = sync.existing_content_ids(client, "PROJECT_ID")
+        assert ids == {"I_1", "PR_2", "I_3"}
+        assert client.graphql.call_count == 2
+        assert client.graphql.call_args_list[1].args[1]["cursor"] == "c1"
+
+
+class TestFormatAndWriteSummary:
+    def test_format_summary_includes_counts_and_errors(self):
+        stats = sync.SyncStats(
+            repos_considered=3,
+            repos_linked=1,
+            repos_link_skipped=2,
+            items_seen=10,
+            items_already_on_board=4,
+            items_added=5,
+            items_failed=1,
+            errors=["boom"],
+        )
+        text = sync.format_summary(stats, dry_run=True)
+        assert "dry-run" in text
+        assert "**3**" in text
+        assert "skipped/already linked: 2" in text
+        assert "**5**" in text
+        assert "`boom`" in text
+
+    def test_write_summary_appends_step_summary(self, tmp_path: Path, monkeypatch):
+        summary_path = tmp_path / "summary.md"
+        monkeypatch.setenv("GITHUB_STEP_SUMMARY", str(summary_path))
+        stats = sync.SyncStats(repos_considered=1, items_added=2)
+        sync.write_summary(stats, dry_run=False)
+        written = summary_path.read_text(encoding="utf-8")
+        assert "Compliance Automation project sync" in written
+        assert "Added: **2**" in written
+
+
+class TestGitHubClientErrors:
+    def _response(
+        self,
+        status: int,
+        text: str = "",
+        *,
+        json_body: Optional[Any] = None,
+        headers: Optional[Dict[str, str]] = None,
+        links: Optional[Dict[str, Dict[str, str]]] = None,
+    ) -> MagicMock:
+        response = MagicMock(spec=requests.Response)
+        response.status_code = status
+        response.text = text
+        response.headers = headers or {}
+        response.links = links or {}
+        if json_body is not None:
+            response.json.return_value = json_body
+        response.raise_for_status = MagicMock()
+        if status >= 400:
+            response.raise_for_status.side_effect = requests.HTTPError(response=response)
+        return response
+
+    def test_retries_rate_limit_then_succeeds(self):
+        client = sync.GitHubClient("token")
+        limited = self._response(
+            403,
+            "API rate limit exceeded",
+            headers={"X-RateLimit-Reset": "1"},
+        )
+        ok = self._response(200, json_body=[{"name": "repo"}])
+        with (
+            patch.object(client.session, "request", side_effect=[limited, ok]) as req,
+            patch.object(sync.time, "sleep") as sleeper,
+        ):
+            response = client._request("GET", "https://api.github.com/orgs/x/repos")
+        assert response is ok
+        assert req.call_count == 2
+        sleeper.assert_called()
+
+    def test_retries_server_errors(self):
+        client = sync.GitHubClient("token")
+        server = self._response(500, "nope")
+        ok = self._response(200, json_body=[])
+        with (
+            patch.object(client.session, "request", side_effect=[server, ok]),
+            patch.object(sync.time, "sleep") as sleeper,
+        ):
+            response = client._request("GET", "https://api.github.com/orgs/x/repos")
+        assert response is ok
+        sleeper.assert_called_once()
+
+    def test_graphql_raises_runtime_error_on_errors_payload(self):
+        client = sync.GitHubClient("token")
+        ok = self._response(
+            200,
+            json_body={"errors": [{"message": "forbidden"}]},
+        )
+        with patch.object(client, "_request", return_value=ok):
+            with pytest.raises(RuntimeError, match="GraphQL errors"):
+                client.graphql("query { viewer { login } }")
+
+
+class TestSyncErrorHandling:
+    def _project_mocks(self, monkeypatch: pytest.MonkeyPatch) -> None:
+        monkeypatch.setattr(
+            sync,
+            "get_project",
+            lambda *_a, **_k: ("PROJECT", "STATUS_FIELD", {"Backlog": "OPT"}),
+        )
+        monkeypatch.setattr(sync, "existing_content_ids", lambda *_a, **_k: set())
+
+    def test_per_org_request_errors_are_recorded(self, monkeypatch: pytest.MonkeyPatch):
+        self._project_mocks(monkeypatch)
+        client = MagicMock()
+        monkeypatch.setattr(
+            sync,
+            "list_org_repos",
+            MagicMock(side_effect=requests.Timeout("slow")),
+        )
+        stats = sync.sync(_minimal_config(), client, org_filter=set())
+        assert stats.errors
+        assert "Failed listing repos for" in stats.errors[0]
+
+    def test_programming_errors_are_not_swallowed(self, monkeypatch: pytest.MonkeyPatch):
+        self._project_mocks(monkeypatch)
+        client = MagicMock()
+        monkeypatch.setattr(
+            sync,
+            "list_org_repos",
+            MagicMock(side_effect=TypeError("bug")),
+        )
+        with pytest.raises(TypeError, match="bug"):
+            sync.sync(_minimal_config(), client, org_filter={"complytime"})
+
+    def test_add_item_runtime_error_counts_as_failed(
+        self, monkeypatch: pytest.MonkeyPatch
+    ):
+        self._project_mocks(monkeypatch)
+        client = MagicMock(dry_run=False)
+        monkeypatch.setattr(
+            sync,
+            "list_org_repos",
+            MagicMock(
+                return_value=[
+                    {
+                        "name": "demo",
+                        "full_name": "complytime/demo",
+                        "node_id": "R_1",
+                        "archived": False,
+                    }
+                ]
+            ),
+        )
+        monkeypatch.setattr(sync, "link_repository", MagicMock(return_value=True))
+        monkeypatch.setattr(
+            sync,
+            "list_open_items",
+            MagicMock(
+                return_value=[
+                    {"number": 7, "title": "work", "node_id": "I_7"},
+                ]
+            ),
+        )
+        monkeypatch.setattr(
+            sync,
+            "add_item",
+            MagicMock(side_effect=RuntimeError("GraphQL errors: boom")),
+        )
+        stats = sync.sync(
+            _minimal_config(),
+            client,
+            org_filter={"complytime"},
+        )
+        assert stats.items_failed == 1
+        assert stats.items_added == 0
+        assert any("Failed adding" in err for err in stats.errors)
+
+
+class TestLinkRepository:
+    def test_dry_run_does_not_call_graphql(self):
+        client = MagicMock(dry_run=True)
+        assert sync.link_repository(client, "P", "R") is True
+        client.graphql.assert_not_called()
+
+    def test_already_linked_is_idempotent(self):
+        client = MagicMock(dry_run=False)
+        client.graphql.side_effect = RuntimeError("already linked to project")
+        assert sync.link_repository(client, "P", "R") is False


### PR DESCRIPTION
## Summary
- Adds a daily + `workflow_dispatch` workflow that discovers repos from **Agentic-SSDLC** (all), **complytime** (all except `roadmap` and `complytime`), and **unbound-force** (all)
- Links those repos to [Compliance Automation planning](https://github.com/orgs/complytime/projects/14) and backfills open issues/PRs (Status = Backlog)
- Documents `PROJECT_SYNC_TOKEN` setup (cross-org PAT required; GitHub App install tokens are single-org)

## Test plan
- [ ] Add `PROJECT_SYNC_TOKEN` secret to `complytime/org-infra` (see `docs/PROJECT_BOARD_SYNC.md`)
- [ ] Run **Sync Compliance Automation Project Board** with `dry_run=true`
- [ ] Confirm discovery covers the three orgs and excludes `complytime/roadmap` + `complytime/complytime`
- [ ] Re-run with `dry_run=false` and verify items appear on project #14
- [ ] Confirm scheduled run is enabled after merge


Made with [Cursor](https://cursor.com)