### PR TITLE
fix: add retry loop to cosign verify in Quay promote test

### DIFF
--- a/.github/workflows/ci_test_publish_quay.yml
+++ b/.github/workflows/ci_test_publish_quay.yml
@@ -177,10 +177,26 @@ jobs:
 
       - name: Verify destination signature independently
         run: |
-          cosign verify "${DEST_IMAGE}@${SOURCE_DIGEST}" \
-            --certificate-identity-regexp="$IDENTITY" \
-            --certificate-oidc-issuer="$OIDC_ISSUER"
-          echo "::notice::Independent signature verification passed"
+          # Retry loop: registry signature propagation may lag behind the
+          # signing step in the previous job, causing transient "no valid
+          # bundles" errors from cosign verify.
+          MAX_ATTEMPTS=3
+          DELAY=10
+          for attempt in $(seq 1 "$MAX_ATTEMPTS"); do
+            echo "Attempt ${attempt}/${MAX_ATTEMPTS}: verifying destination signature"
+            if cosign verify "${DEST_IMAGE}@${SOURCE_DIGEST}" \
+                 --certificate-identity-regexp="$IDENTITY" \
+                 --certificate-oidc-issuer="$OIDC_ISSUER"; then
+              echo "::notice::Independent signature verification passed"
+              exit 0
+            fi
+            if [[ "$attempt" -lt "$MAX_ATTEMPTS" ]]; then
+              echo "::warning::Verification attempt ${attempt} failed, retrying in ${DELAY}s..."
+              sleep "$DELAY"
+            fi
+          done
+          echo "::error::Signature verification failed after ${MAX_ATTEMPTS} attempts"
+          exit 1
 
       - name: Confirm independent signature
         env:


### PR DESCRIPTION
## Summary

The "Verify destination signature independently" step in `ci_test_publish_quay.yml` intermittently fails with `no valid bundles exist in registry` because registry signature propagation may lag behind the signing step in the preceding job.

This adds a retry loop (3 attempts, 10s delay) to handle transient propagation delays.

## Evidence

2 of 5 recent workflow runs failed at this exact step, 3 succeeded — confirming a transient race condition rather than a deterministic failure.

| Run | Date | Conclusion |
|-----|------|------------|
| 31401523454 | 2026-08-10 | failure |
| 31049477670 | 2026-08-05 | success |
| 31048890230 | 2026-08-05 | failure |
| 31024113131 | 2026-08-05 | success |
| 31022895246 | 2026-08-05 | success |

All failures occur at the same step: **Verify Promoted Image → Verify destination signature independently**.

## Root Cause

The `test-promote` job signs the destination image via `cosign sign`, then the `verify-promote` job (a separate runner) attempts independent `cosign verify`. Registry signature propagation between these two independent jobs is not instantaneous, causing sporadic verification failures.

## Changes

- `.github/workflows/ci_test_publish_quay.yml`: Replace single `cosign verify` call with a retry loop (3 attempts, 10s delay between retries). Emits `::warning::` annotations on transient failures and `::error::` if all attempts are exhausted.

## Related

Discovered during review of #504 (unrelated to that PR's changes — #504 only modified version comments in this workflow file).