### PR TITLE
feat(ci): auto-set Organization on Compliance Automation board items

### DIFF
--- a/.github/workflows/sync_project_board.yml
+++ b/.github/workflows/sync_project_board.yml
@@ -22,6 +22,18 @@ on:
         required: false
         type: string
         default: ''
+      backfill_org:
+        description: >-
+          When to walk existing board items to fix Organization.
+          auto skips that listing when this tick already set Organization on
+          new items; always forces a full backfill; never skips it.
+        required: false
+        type: choice
+        options:
+          - auto
+          - always
+          - never
+        default: auto
   schedule:
     # Fastest GitHub Actions interval. Cron of every 1 minute is valid YAML
     # but GitHub will not honor intervals shorter than 5 minutes.
@@ -66,13 +78,14 @@ jobs:
           GITHUB_TOKEN: ${{ secrets.PROJECT_SYNC_TOKEN }}
           DRY_RUN: ${{ inputs.dry_run || false }}
           ORGS: ${{ inputs.orgs || '' }}
+          BACKFILL_ORG: ${{ inputs.backfill_org || 'auto' }}
         run: |
           if [ -z "$GITHUB_TOKEN" ]; then
             echo "::error::PROJECT_SYNC_TOKEN secret is not configured. See docs/PROJECT_BOARD_SYNC.md"
             exit 1
           fi
 
-          ARGS=(--config project-sync-config.yml)
+          ARGS=(--config project-sync-config.yml --backfill-org "$BACKFILL_ORG")
           if [ "$DRY_RUN" = "true" ]; then
             ARGS+=(--dry-run)
           fi

--- a/docs/PROJECT_BOARD_SYNC.md
+++ b/docs/PROJECT_BOARD_SYNC.md
@@ -24,9 +24,13 @@ delayed under GitHub load:
 3. Collects open issues and open PRs
 4. Adds any missing items to the board with **Status = Backlog** and
    **Organization** set from the source GitHub org (`Agentic-SSDLC`,
-   `complytime`, or `unbound-force`)
-5. Backfills **Organization** on any existing board items that are unset or
-   incorrect (for example items added manually)
+   `complytime`, or `unbound-force`). Organization updates are best-effort:
+   a field-write failure does not undo the board add.
+5. Backfills **Organization** on existing board items that are unset or
+   incorrect (for example items added manually). Default `--backfill-org auto`
+   skips that extra board listing when this tick already set Organization on
+   newly added items. Quiet ticks still backfill. Pass `--backfill-org always`
+   (or the workflow input) to force a full walk.
 
 The workflow lives only in `org-infra` (it is **not** synced out to consumer repos).
 
@@ -87,6 +91,7 @@ Optional: set `orgs` to a single org (for example `complytime`) to stage the rol
 export GITHUB_TOKEN="$(gh auth token)"   # needs project write for apply mode
 pip install -r requirements.txt
 python scripts/sync-project-board.py --config project-sync-config.yml --dry-run
+python scripts/sync-project-board.py --config project-sync-config.yml --backfill-org always
 ```
 
 ## Changing scope

--- a/docs/PROJECT_BOARD_SYNC.md
+++ b/docs/PROJECT_BOARD_SYNC.md
@@ -22,7 +22,11 @@ delayed under GitHub load:
 2. Links same-org repositories to project `#14` (idempotent). Cross-org repos
    cannot be linked (GitHub restriction) but their issues/PRs still sync.
 3. Collects open issues and open PRs
-4. Adds any missing items to the board with **Status = Backlog**
+4. Adds any missing items to the board with **Status = Backlog** and
+   **Organization** set from the source GitHub org (`Agentic-SSDLC`,
+   `complytime`, or `unbound-force`)
+5. Backfills **Organization** on any existing board items that are unset or
+   incorrect (for example items added manually)
 
 The workflow lives only in `org-infra` (it is **not** synced out to consumer repos).
 

--- a/project-sync-config.yml
+++ b/project-sync-config.yml
@@ -9,6 +9,9 @@ project:
   number: 14
   # Status option applied to newly added items (must match a Status field option)
   default_status: "Backlog"
+  # Organization is set automatically from the source GitHub org (see
+  # OWNER_TO_ORGANIZATION in scripts/sync-project-board.py). Options must
+  # match the project Organization field: Agentic-SSDLC, complytime, unbound-force.
 
 # What to sync onto the board
 sync:

--- a/scripts/sync-project-board.py
+++ b/scripts/sync-project-board.py
@@ -5,8 +5,10 @@
 
 Discovers repositories across one or more organizations, optionally links
 them to the target project, and adds any open issues/PRs that are not
-already on the board. Designed for cross-org boards where a single GitHub
-App installation token is insufficient (use a PAT with multi-org access).
+already on the board. Newly added items (and any existing items missing a
+value) get Organization set from the source GitHub org. Designed for
+cross-org boards where a single GitHub App installation token is
+insufficient (use a PAT with multi-org access).
 """
 
 from __future__ import annotations
@@ -26,6 +28,15 @@ GITHUB_API = "https://api.github.com"
 GITHUB_GRAPHQL = f"{GITHUB_API}/graphql"
 DEFAULT_CONFIG = "project-sync-config.yml"
 
+# Map GitHub repository owner login → Organization single-select option name
+# on the Compliance Automation planning board.
+OWNER_TO_ORGANIZATION = {
+    "Agentic-SSDLC": "Agentic-SSDLC",
+    "complytime": "complytime",
+    "complytime-labs": "complytime",
+    "unbound-force": "unbound-force",
+}
+
 # Expected failure modes while iterating orgs/repos (HTTP + explicit RuntimeError).
 # Keeps programming bugs (TypeError, KeyError, …) from being swallowed per item.
 SYNC_EXCEPTIONS = (requests.RequestException, RuntimeError)
@@ -42,6 +53,8 @@ class SyncStats:
     items_already_on_board: int = 0
     items_added: int = 0
     items_failed: int = 0
+    organization_set: int = 0
+    organization_failed: int = 0
     errors: List[str] = field(default_factory=list)
 
 
@@ -183,10 +196,19 @@ def list_org_repos(
     return selected
 
 
-def get_project(
-    client: GitHubClient, owner: str, number: int
-) -> Tuple[str, Optional[str], Dict[str, str]]:
-    """Return project id, Status field id, and Status option name→id map."""
+@dataclass
+class ProjectFields:
+    """Resolved project id plus Status / Organization single-select metadata."""
+
+    project_id: str
+    status_field_id: Optional[str]
+    status_options: Dict[str, str]
+    organization_field_id: Optional[str]
+    organization_options: Dict[str, str]
+
+
+def get_project(client: GitHubClient, owner: str, number: int) -> ProjectFields:
+    """Return project id and Status / Organization field metadata."""
     data = client.graphql(
         """
         query($owner: String!, $number: Int!) {
@@ -214,14 +236,27 @@ def get_project(
 
     status_field_id = None
     status_options: Dict[str, str] = {}
+    organization_field_id = None
+    organization_options: Dict[str, str] = {}
     for node in project["fields"]["nodes"]:
         if not node:
             continue
-        if node.get("name") == "Status":
+        name = node.get("name")
+        if name == "Status":
             status_field_id = node["id"]
             status_options = {opt["name"]: opt["id"] for opt in node.get("options", [])}
-            break
-    return project["id"], status_field_id, status_options
+        elif name == "Organization":
+            organization_field_id = node["id"]
+            organization_options = {
+                opt["name"]: opt["id"] for opt in node.get("options", [])
+            }
+    return ProjectFields(
+        project_id=project["id"],
+        status_field_id=status_field_id,
+        status_options=status_options,
+        organization_field_id=organization_field_id,
+        organization_options=organization_options,
+    )
 
 
 def existing_content_ids(client: GitHubClient, project_id: str) -> Set[str]:
@@ -311,16 +346,65 @@ def list_open_items(
     return items
 
 
+def set_single_select(
+    client: GitHubClient,
+    project_id: str,
+    item_id: str,
+    field_id: str,
+    option_id: str,
+) -> None:
+    """Set a project single-select field value."""
+    if client.dry_run:
+        print(f"  [dry-run] would set field {field_id}={option_id} on {item_id}")
+        return
+    client.graphql(
+        """
+        mutation($projectId: ID!, $itemId: ID!, $fieldId: ID!, $optionId: String!) {
+          updateProjectV2ItemFieldValue(input: {
+            projectId: $projectId
+            itemId: $itemId
+            fieldId: $fieldId
+            value: { singleSelectOptionId: $optionId }
+          }) {
+            projectV2Item { id }
+          }
+        }
+        """,
+        {
+            "projectId": project_id,
+            "itemId": item_id,
+            "fieldId": field_id,
+            "optionId": option_id,
+        },
+    )
+
+
+def organization_option_for_owner(
+    owner_login: str, organization_options: Dict[str, str]
+) -> Optional[Tuple[str, str]]:
+    """Return (option_name, option_id) for a repository owner, if mapped."""
+    option_name = OWNER_TO_ORGANIZATION.get(owner_login)
+    if not option_name:
+        return None
+    option_id = organization_options.get(option_name)
+    if not option_id:
+        return None
+    return option_name, option_id
+
+
 def add_item(
     client: GitHubClient,
     project_id: str,
     content_id: str,
     status_field_id: Optional[str],
     status_option_id: Optional[str],
-) -> None:
+    organization_field_id: Optional[str] = None,
+    organization_option_id: Optional[str] = None,
+) -> str:
+    """Add content to the project and set Status / Organization. Returns item id."""
     if client.dry_run:
         print(f"  [dry-run] would add {content_id}")
-        return
+        return "DRY_RUN_ITEM"
 
     data = client.graphql(
         """
@@ -335,26 +419,101 @@ def add_item(
     item_id = data["addProjectV2ItemById"]["item"]["id"]
 
     if status_field_id and status_option_id:
-        client.graphql(
-            """
-            mutation($projectId: ID!, $itemId: ID!, $fieldId: ID!, $optionId: String!) {
-              updateProjectV2ItemFieldValue(input: {
-                projectId: $projectId
-                itemId: $itemId
-                fieldId: $fieldId
-                value: { singleSelectOptionId: $optionId }
-              }) {
-                projectV2Item { id }
+        set_single_select(
+            client, project_id, item_id, status_field_id, status_option_id
+        )
+    if organization_field_id and organization_option_id:
+        set_single_select(
+            client, project_id, item_id, organization_field_id, organization_option_id
+        )
+    return item_id
+
+
+
+def iter_board_items_for_organization(
+    client: GitHubClient, project_id: str
+) -> List[Dict[str, Any]]:
+    """Return board items with Organization value and content repository owner."""
+    query = """
+    query($projectId: ID!, $cursor: String) {
+      node(id: $projectId) {
+        ... on ProjectV2 {
+          items(first: 100, after: $cursor) {
+            pageInfo { hasNextPage endCursor }
+            nodes {
+              id
+              organization: fieldValueByName(name: "Organization") {
+                ... on ProjectV2ItemFieldSingleSelectValue { name }
+              }
+              content {
+                ... on Issue {
+                  id
+                  repository { owner { login } nameWithOwner }
+                }
+                ... on PullRequest {
+                  id
+                  repository { owner { login } nameWithOwner }
+                }
               }
             }
-            """,
-            {
-                "projectId": project_id,
-                "itemId": item_id,
-                "fieldId": status_field_id,
-                "optionId": status_option_id,
-            },
-        )
+          }
+        }
+      }
+    }
+    """
+    collected: List[Dict[str, Any]] = []
+    cursor = None
+    while True:
+        data = client.graphql(query, {"projectId": project_id, "cursor": cursor})
+        items = data["node"]["items"]
+        collected.extend(items["nodes"])
+        if not items["pageInfo"]["hasNextPage"]:
+            break
+        cursor = items["pageInfo"]["endCursor"]
+    return collected
+
+
+def ensure_organizations(
+    client: GitHubClient,
+    fields: ProjectFields,
+    stats: SyncStats,
+) -> None:
+    """Set Organization on board items that are missing or incorrect."""
+    if not fields.organization_field_id or not fields.organization_options:
+        print("Organization field missing on project; skipping organization sync")
+        return
+
+    print("\n=== Ensuring Organization on existing board items ===")
+    for node in iter_board_items_for_organization(client, fields.project_id):
+        content = node.get("content") or {}
+        repo = content.get("repository") or {}
+        owner_login = (repo.get("owner") or {}).get("login")
+        if not owner_login:
+            continue
+        mapped = organization_option_for_owner(owner_login, fields.organization_options)
+        if not mapped:
+            continue
+        option_name, option_id = mapped
+        current = (node.get("organization") or {}).get("name")
+        if current == option_name:
+            continue
+        item_id = node["id"]
+        label = repo.get("nameWithOwner") or owner_login
+        try:
+            set_single_select(
+                client,
+                fields.project_id,
+                item_id,
+                fields.organization_field_id,
+                option_id,
+            )
+            stats.organization_set += 1
+            print(f"  org {label} -> {option_name}")
+        except SYNC_EXCEPTIONS as exc:
+            stats.organization_failed += 1
+            msg = f"Failed setting Organization on {label}: {exc}"
+            print(f"  ! {msg}")
+            stats.errors.append(msg)
 
 
 def format_summary(stats: SyncStats, dry_run: bool) -> str:
@@ -370,6 +529,8 @@ def format_summary(stats: SyncStats, dry_run: bool) -> str:
         f"- Already on board: **{stats.items_already_on_board}**",
         f"- Added: **{stats.items_added}**",
         f"- Failed: **{stats.items_failed}**",
+        f"- Organization set/updated: **{stats.organization_set}**",
+        f"- Organization failed: **{stats.organization_failed}**",
     ]
     if stats.errors:
         lines.extend(["", "### Errors", ""])
@@ -399,12 +560,20 @@ def sync(config: Dict[str, Any], client: GitHubClient, org_filter: Set[str]) -> 
     skip_archived = bool(sync_cfg.get("skip_archived", True))
     link_repos = bool(sync_cfg.get("link_repositories", True))
 
-    project_id, status_field_id, status_options = get_project(client, owner, number)
+    fields = get_project(client, owner, number)
+    project_id = fields.project_id
+    status_field_id = fields.status_field_id
+    status_options = fields.status_options
     status_option_id = status_options.get(default_status) if status_options else None
     if default_status and status_field_id and not status_option_id:
         print(
             f"Warning: Status option '{default_status}' not found; "
             "items will be added without a Status value"
+        )
+    if not fields.organization_field_id:
+        print(
+            "Warning: Organization field not found; "
+            "items will be added without an Organization value"
         )
 
     print(f"Project {owner}/{number} id={project_id}")
@@ -417,6 +586,13 @@ def sync(config: Dict[str, Any], client: GitHubClient, org_filter: Set[str]) -> 
             continue
         exclude = set(org_cfg.get("exclude_repos") or [])
         print(f"\n=== {org} (exclude={sorted(exclude) or 'none'}) ===")
+        org_mapped = organization_option_for_owner(org, fields.organization_options)
+        organization_option_id = org_mapped[1] if org_mapped else None
+        if fields.organization_field_id and not organization_option_id:
+            print(
+                f"  Warning: no Organization option mapped for '{org}'; "
+                "new items will omit Organization"
+            )
         try:
             repos = list_org_repos(
                 client, org, exclude=exclude, skip_archived=skip_archived
@@ -492,8 +668,12 @@ def sync(config: Dict[str, Any], client: GitHubClient, org_filter: Set[str]) -> 
                         node_id,
                         status_field_id,
                         status_option_id,
+                        fields.organization_field_id,
+                        organization_option_id,
                     )
                     stats.items_added += 1
+                    if organization_option_id:
+                        stats.organization_set += 1
                     on_board.add(node_id)
                     print(f"  + {label}")
                 except SYNC_EXCEPTIONS as exc:
@@ -502,6 +682,7 @@ def sync(config: Dict[str, Any], client: GitHubClient, org_filter: Set[str]) -> 
                     print(f"  ! {msg}")
                     stats.errors.append(msg)
 
+    ensure_organizations(client, fields, stats)
     return stats
 
 

--- a/scripts/sync-project-board.py
+++ b/scripts/sync-project-board.py
@@ -33,6 +33,8 @@ DEFAULT_CONFIG = "project-sync-config.yml"
 OWNER_TO_ORGANIZATION = {
     "Agentic-SSDLC": "Agentic-SSDLC",
     "complytime": "complytime",
+    # Not in project-sync-config.yml yet; maps to complytime when labs repos
+    # land on the board (manual add or future sync scope).
     "complytime-labs": "complytime",
     "unbound-force": "unbound-force",
 }
@@ -149,6 +151,16 @@ def parse_args() -> argparse.Namespace:
         default="",
         help="Optional space-separated org filter (defaults to all configured orgs)",
     )
+    parser.add_argument(
+        "--backfill-org",
+        choices=("auto", "always", "never"),
+        default="auto",
+        help=(
+            "When to walk existing board items to fix Organization. "
+            "auto skips that extra listing when this tick already set "
+            "Organization on newly added items (default: auto)"
+        ),
+    )
     return parser.parse_args()
 
 
@@ -205,6 +217,20 @@ class ProjectFields:
     status_options: Dict[str, str]
     organization_field_id: Optional[str]
     organization_options: Dict[str, str]
+
+
+@dataclass
+class AddItemResult:
+    """Outcome of adding a project item and optionally setting Organization.
+
+    ``item_id`` is None in dry-run mode (no mutation, so no board item id).
+    Organization field updates are best-effort: a failure is recorded on this
+    result instead of raising, so the caller can still treat the add as success.
+    """
+
+    item_id: Optional[str]
+    organization_set: bool = False
+    organization_error: Optional[str] = None
 
 
 def get_project(client: GitHubClient, owner: str, number: int) -> ProjectFields:
@@ -400,11 +426,20 @@ def add_item(
     status_option_id: Optional[str],
     organization_field_id: Optional[str] = None,
     organization_option_id: Optional[str] = None,
-) -> str:
-    """Add content to the project and set Status / Organization. Returns item id."""
+) -> AddItemResult:
+    """Add content to the project and set Status / Organization.
+
+    Returns an ``AddItemResult``. In dry-run mode ``item_id`` is None.
+    Organization updates are best-effort: if ``set_single_select`` fails after
+    the item was added, the result still includes the item id so the caller
+    can record a successful add.
+    """
     if client.dry_run:
         print(f"  [dry-run] would add {content_id}")
-        return "DRY_RUN_ITEM"
+        return AddItemResult(
+            item_id=None,
+            organization_set=bool(organization_field_id and organization_option_id),
+        )
 
     data = client.graphql(
         """
@@ -422,18 +457,33 @@ def add_item(
         set_single_select(
             client, project_id, item_id, status_field_id, status_option_id
         )
+
+    organization_set = False
+    organization_error: Optional[str] = None
     if organization_field_id and organization_option_id:
-        set_single_select(
-            client, project_id, item_id, organization_field_id, organization_option_id
-        )
-    return item_id
+        try:
+            set_single_select(
+                client,
+                project_id,
+                item_id,
+                organization_field_id,
+                organization_option_id,
+            )
+            organization_set = True
+        except SYNC_EXCEPTIONS as exc:
+            organization_error = str(exc)
+
+    return AddItemResult(
+        item_id=item_id,
+        organization_set=organization_set,
+        organization_error=organization_error,
+    )
 
 
-
-def iter_board_items_for_organization(
+def list_board_items_with_org_metadata(
     client: GitHubClient, project_id: str
 ) -> List[Dict[str, Any]]:
-    """Return board items with Organization value and content repository owner."""
+    """Return all board items with Organization value and content repository owner."""
     query = """
     query($projectId: ID!, $cursor: String) {
       node(id: $projectId) {
@@ -484,7 +534,7 @@ def ensure_organizations(
         return
 
     print("\n=== Ensuring Organization on existing board items ===")
-    for node in iter_board_items_for_organization(client, fields.project_id):
+    for node in list_board_items_with_org_metadata(client, fields.project_id):
         content = node.get("content") or {}
         repo = content.get("repository") or {}
         owner_login = (repo.get("owner") or {}).get("login")
@@ -514,6 +564,20 @@ def ensure_organizations(
             msg = f"Failed setting Organization on {label}: {exc}"
             print(f"  ! {msg}")
             stats.errors.append(msg)
+
+
+def should_run_organization_backfill(backfill_org: str, stats: SyncStats) -> bool:
+    """Decide whether to paginate the board to fix Organization values.
+
+    ``auto`` skips the extra listing when this tick already added items and no
+    add-time Organization update failed. Quiet ticks still backfill so
+    manually added items are corrected within one schedule interval.
+    """
+    if backfill_org == "always":
+        return True
+    if backfill_org == "never":
+        return False
+    return stats.items_added == 0 or stats.organization_failed > 0
 
 
 def format_summary(stats: SyncStats, dry_run: bool) -> str:
@@ -548,7 +612,12 @@ def write_summary(stats: SyncStats, dry_run: bool) -> None:
             handle.write(summary)
 
 
-def sync(config: Dict[str, Any], client: GitHubClient, org_filter: Set[str]) -> SyncStats:
+def sync(
+    config: Dict[str, Any],
+    client: GitHubClient,
+    org_filter: Set[str],
+    backfill_org: str = "auto",
+) -> SyncStats:
     stats = SyncStats()
     project_cfg = config["project"]
     sync_cfg = config.get("sync", {})
@@ -662,7 +731,7 @@ def sync(config: Dict[str, Any], client: GitHubClient, org_filter: Set[str]) -> 
                     continue
 
                 try:
-                    add_item(
+                    result = add_item(
                         client,
                         project_id,
                         node_id,
@@ -672,17 +741,33 @@ def sync(config: Dict[str, Any], client: GitHubClient, org_filter: Set[str]) -> 
                         organization_option_id,
                     )
                     stats.items_added += 1
-                    if organization_option_id:
-                        stats.organization_set += 1
                     on_board.add(node_id)
                     print(f"  + {label}")
+                    if result.organization_set:
+                        stats.organization_set += 1
+                    if result.organization_error:
+                        stats.organization_failed += 1
+                        msg = (
+                            f"Failed setting Organization on {full_name} "
+                            f"{label}: {result.organization_error}"
+                        )
+                        print(f"  ! {msg}")
+                        stats.errors.append(msg)
                 except SYNC_EXCEPTIONS as exc:
                     stats.items_failed += 1
                     msg = f"Failed adding {full_name} {label}: {exc}"
                     print(f"  ! {msg}")
                     stats.errors.append(msg)
 
-    ensure_organizations(client, fields, stats)
+    if should_run_organization_backfill(backfill_org, stats):
+        ensure_organizations(client, fields, stats)
+    else:
+        reason = (
+            "--backfill-org never"
+            if backfill_org == "never"
+            else "newly added items already have Organization"
+        )
+        print(f"\nSkipping Organization backfill ({reason})")
     return stats
 
 
@@ -705,7 +790,7 @@ def main() -> int:
         return 2
     org_filter = {part for part in args.orgs.split() if part}
     client = GitHubClient(token=token, dry_run=args.dry_run)
-    stats = sync(config, client, org_filter)
+    stats = sync(config, client, org_filter, backfill_org=args.backfill_org)
     write_summary(stats, dry_run=args.dry_run)
     return 1 if stats.items_failed or stats.errors else 0
 

--- a/tests/test_sync_project_board.py
+++ b/tests/test_sync_project_board.py
@@ -242,9 +242,20 @@ class TestSyncErrorHandling:
         monkeypatch.setattr(
             sync,
             "get_project",
-            lambda *_a, **_k: ("PROJECT", "STATUS_FIELD", {"Backlog": "OPT"}),
+            lambda *_a, **_k: sync.ProjectFields(
+                project_id="PROJECT",
+                status_field_id="STATUS_FIELD",
+                status_options={"Backlog": "OPT"},
+                organization_field_id="ORG_FIELD",
+                organization_options={
+                    "Agentic-SSDLC": "ORG_A",
+                    "complytime": "ORG_C",
+                    "unbound-force": "ORG_U",
+                },
+            ),
         )
         monkeypatch.setattr(sync, "existing_content_ids", lambda *_a, **_k: set())
+        monkeypatch.setattr(sync, "ensure_organizations", lambda *_a, **_k: None)
 
     def test_per_org_request_errors_are_recorded(self, monkeypatch: pytest.MonkeyPatch):
         self._project_mocks(monkeypatch)
@@ -392,3 +403,103 @@ class TestLinkRepository:
         client = MagicMock(dry_run=False)
         client.graphql.side_effect = RuntimeError("already linked to project")
         assert sync.link_repository(client, "P", "R") is False
+
+
+class TestOrganizationMapping:
+    def test_organization_option_for_owner_maps_known_orgs(self):
+        options = {
+            "Agentic-SSDLC": "A",
+            "complytime": "C",
+            "unbound-force": "U",
+        }
+        assert sync.organization_option_for_owner("complytime", options) == (
+            "complytime",
+            "C",
+        )
+        assert sync.organization_option_for_owner("complytime-labs", options) == (
+            "complytime",
+            "C",
+        )
+        assert sync.organization_option_for_owner("unknown", options) is None
+
+    def test_add_item_sets_status_and_organization(self):
+        client = MagicMock(dry_run=False)
+        client.graphql.side_effect = [
+            {"addProjectV2ItemById": {"item": {"id": "ITEM_1"}}},
+            {"updateProjectV2ItemFieldValue": {"projectV2Item": {"id": "ITEM_1"}}},
+            {"updateProjectV2ItemFieldValue": {"projectV2Item": {"id": "ITEM_1"}}},
+        ]
+        item_id = sync.add_item(
+            client,
+            "PROJECT",
+            "CONTENT",
+            "STATUS_FIELD",
+            "STATUS_OPT",
+            "ORG_FIELD",
+            "ORG_OPT",
+        )
+        assert item_id == "ITEM_1"
+        assert client.graphql.call_count == 3
+        # Second call sets Status; third sets Organization
+        status_vars = client.graphql.call_args_list[1].args[1]
+        org_vars = client.graphql.call_args_list[2].args[1]
+        assert status_vars["fieldId"] == "STATUS_FIELD"
+        assert status_vars["optionId"] == "STATUS_OPT"
+        assert org_vars["fieldId"] == "ORG_FIELD"
+        assert org_vars["optionId"] == "ORG_OPT"
+
+    def test_ensure_organizations_updates_missing_values(
+        self, monkeypatch: pytest.MonkeyPatch
+    ):
+        client = MagicMock(dry_run=False)
+        fields = sync.ProjectFields(
+            project_id="PROJECT",
+            status_field_id="STATUS_FIELD",
+            status_options={"Backlog": "OPT"},
+            organization_field_id="ORG_FIELD",
+            organization_options={
+                "Agentic-SSDLC": "ORG_A",
+                "complytime": "ORG_C",
+                "unbound-force": "ORG_U",
+            },
+        )
+        monkeypatch.setattr(
+            sync,
+            "iter_board_items_for_organization",
+            lambda *_a, **_k: [
+                {
+                    "id": "PVTI_1",
+                    "organization": None,
+                    "content": {
+                        "id": "I_1",
+                        "repository": {
+                            "nameWithOwner": "complytime/demo",
+                            "owner": {"login": "complytime"},
+                        },
+                    },
+                },
+                {
+                    "id": "PVTI_2",
+                    "organization": {"name": "unbound-force"},
+                    "content": {
+                        "id": "I_2",
+                        "repository": {
+                            "nameWithOwner": "unbound-force/gaze",
+                            "owner": {"login": "unbound-force"},
+                        },
+                    },
+                },
+            ],
+        )
+        set_calls = []
+
+        def _set(*args, **kwargs):
+            set_calls.append((args, kwargs))
+
+        monkeypatch.setattr(sync, "set_single_select", _set)
+        stats = sync.SyncStats()
+        sync.ensure_organizations(client, fields, stats)
+        assert stats.organization_set == 1
+        assert set_calls[0][0][2] == "PVTI_1"
+        assert set_calls[0][0][4] == "ORG_C"
+

--- a/tests/test_sync_project_board.py
+++ b/tests/test_sync_project_board.py
@@ -429,7 +429,7 @@ class TestOrganizationMapping:
             {"updateProjectV2ItemFieldValue": {"projectV2Item": {"id": "ITEM_1"}}},
             {"updateProjectV2ItemFieldValue": {"projectV2Item": {"id": "ITEM_1"}}},
         ]
-        item_id = sync.add_item(
+        result = sync.add_item(
             client,
             "PROJECT",
             "CONTENT",
@@ -438,7 +438,9 @@ class TestOrganizationMapping:
             "ORG_FIELD",
             "ORG_OPT",
         )
-        assert item_id == "ITEM_1"
+        assert result.item_id == "ITEM_1"
+        assert result.organization_set is True
+        assert result.organization_error is None
         assert client.graphql.call_count == 3
         # Second call sets Status; third sets Organization
         status_vars = client.graphql.call_args_list[1].args[1]
@@ -447,6 +449,41 @@ class TestOrganizationMapping:
         assert status_vars["optionId"] == "STATUS_OPT"
         assert org_vars["fieldId"] == "ORG_FIELD"
         assert org_vars["optionId"] == "ORG_OPT"
+
+    def test_add_item_org_failure_is_best_effort(self):
+        client = MagicMock(dry_run=False)
+        client.graphql.side_effect = [
+            {"addProjectV2ItemById": {"item": {"id": "ITEM_1"}}},
+            {"updateProjectV2ItemFieldValue": {"projectV2Item": {"id": "ITEM_1"}}},
+            RuntimeError("INSUFFICIENT_SCOPES"),
+        ]
+        result = sync.add_item(
+            client,
+            "PROJECT",
+            "CONTENT",
+            "STATUS_FIELD",
+            "STATUS_OPT",
+            "ORG_FIELD",
+            "ORG_OPT",
+        )
+        assert result.item_id == "ITEM_1"
+        assert result.organization_set is False
+        assert result.organization_error == "INSUFFICIENT_SCOPES"
+
+    def test_add_item_dry_run_returns_no_item_id(self):
+        client = MagicMock(dry_run=True)
+        result = sync.add_item(
+            client,
+            "PROJECT",
+            "CONTENT",
+            "STATUS_FIELD",
+            "STATUS_OPT",
+            "ORG_FIELD",
+            "ORG_OPT",
+        )
+        assert result.item_id is None
+        assert result.organization_set is True
+        client.graphql.assert_not_called()
 
     def test_ensure_organizations_updates_missing_values(
         self, monkeypatch: pytest.MonkeyPatch
@@ -465,7 +502,7 @@ class TestOrganizationMapping:
         )
         monkeypatch.setattr(
             sync,
-            "iter_board_items_for_organization",
+            "list_board_items_with_org_metadata",
             lambda *_a, **_k: [
                 {
                     "id": "PVTI_1",
@@ -500,6 +537,169 @@ class TestOrganizationMapping:
         stats = sync.SyncStats()
         sync.ensure_organizations(client, fields, stats)
         assert stats.organization_set == 1
+        assert len(set_calls) == 1
         assert set_calls[0][0][2] == "PVTI_1"
         assert set_calls[0][0][4] == "ORG_C"
+
+    def test_list_board_items_with_org_metadata_paginates(self):
+        client = MagicMock()
+        client.graphql.side_effect = [
+            {
+                "node": {
+                    "items": {
+                        "pageInfo": {"hasNextPage": True, "endCursor": "c1"},
+                        "nodes": [{"id": "PVTI_1", "organization": None, "content": {}}],
+                    }
+                }
+            },
+            {
+                "node": {
+                    "items": {
+                        "pageInfo": {"hasNextPage": False, "endCursor": "c2"},
+                        "nodes": [{"id": "PVTI_2", "organization": None, "content": {}}],
+                    }
+                }
+            },
+        ]
+        items = sync.list_board_items_with_org_metadata(client, "PROJECT_ID")
+        assert [node["id"] for node in items] == ["PVTI_1", "PVTI_2"]
+        assert client.graphql.call_count == 2
+        assert client.graphql.call_args_list[1].args[1]["cursor"] == "c1"
+
+    @pytest.mark.parametrize(
+        "mode,items_added,organization_failed,expected",
+        [
+            ("always", 3, 0, True),
+            ("never", 0, 1, False),
+            ("auto", 0, 0, True),
+            ("auto", 2, 0, False),
+            ("auto", 2, 1, True),
+        ],
+    )
+    def test_should_run_organization_backfill(
+        self,
+        mode: str,
+        items_added: int,
+        organization_failed: int,
+        expected: bool,
+    ):
+        stats = sync.SyncStats(
+            items_added=items_added, organization_failed=organization_failed
+        )
+        assert sync.should_run_organization_backfill(mode, stats) is expected
+
+
+class TestSyncOrganizationStats:
+    def _project_mocks(self, monkeypatch: pytest.MonkeyPatch) -> None:
+        monkeypatch.setattr(
+            sync,
+            "get_project",
+            lambda *_a, **_k: sync.ProjectFields(
+                project_id="PROJECT",
+                status_field_id="STATUS_FIELD",
+                status_options={"Backlog": "OPT"},
+                organization_field_id="ORG_FIELD",
+                organization_options={"complytime": "ORG_C"},
+            ),
+        )
+        monkeypatch.setattr(sync, "existing_content_ids", lambda *_a, **_k: set())
+        monkeypatch.setattr(sync, "link_repository", MagicMock(return_value=True))
+        monkeypatch.setattr(
+            sync,
+            "list_org_repos",
+            MagicMock(
+                return_value=[
+                    {
+                        "name": "demo",
+                        "full_name": "complytime/demo",
+                        "node_id": "R_1",
+                        "archived": False,
+                    }
+                ]
+            ),
+        )
+
+    def test_org_set_failure_still_counts_item_as_added(
+        self, monkeypatch: pytest.MonkeyPatch
+    ):
+        self._project_mocks(monkeypatch)
+        ensure = MagicMock()
+        monkeypatch.setattr(sync, "ensure_organizations", ensure)
+        monkeypatch.setattr(
+            sync,
+            "list_open_items",
+            MagicMock(
+                return_value=[{"number": 7, "title": "work", "node_id": "I_7"}]
+            ),
+        )
+        monkeypatch.setattr(
+            sync,
+            "add_item",
+            MagicMock(
+                return_value=sync.AddItemResult(
+                    item_id="PVTI_7",
+                    organization_set=False,
+                    organization_error="INSUFFICIENT_SCOPES",
+                )
+            ),
+        )
+        stats = sync.sync(
+            _minimal_config(),
+            MagicMock(dry_run=False),
+            org_filter={"complytime"},
+            backfill_org="never",
+        )
+        assert stats.items_added == 1
+        assert stats.items_failed == 0
+        assert stats.organization_set == 0
+        assert stats.organization_failed == 1
+        assert any("Failed setting Organization" in err for err in stats.errors)
+        ensure.assert_not_called()
+
+    def test_auto_backfill_skipped_when_new_items_have_org(
+        self, monkeypatch: pytest.MonkeyPatch
+    ):
+        self._project_mocks(monkeypatch)
+        ensure = MagicMock()
+        monkeypatch.setattr(sync, "ensure_organizations", ensure)
+        monkeypatch.setattr(
+            sync,
+            "list_open_items",
+            MagicMock(
+                return_value=[{"number": 8, "title": "more", "node_id": "I_8"}]
+            ),
+        )
+        monkeypatch.setattr(
+            sync,
+            "add_item",
+            MagicMock(
+                return_value=sync.AddItemResult(
+                    item_id="PVTI_8", organization_set=True
+                )
+            ),
+        )
+        stats = sync.sync(
+            _minimal_config(),
+            MagicMock(dry_run=False),
+            org_filter={"complytime"},
+        )
+        assert stats.items_added == 1
+        assert stats.organization_set == 1
+        assert stats.organization_failed == 0
+        ensure.assert_not_called()
+
+    def test_auto_backfill_runs_when_no_items_added(
+        self, monkeypatch: pytest.MonkeyPatch
+    ):
+        self._project_mocks(monkeypatch)
+        ensure = MagicMock()
+        monkeypatch.setattr(sync, "ensure_organizations", ensure)
+        monkeypatch.setattr(sync, "list_open_items", MagicMock(return_value=[]))
+        sync.sync(
+            _minimal_config(),
+            MagicMock(dry_run=False),
+            org_filter={"complytime"},
+        )
+        ensure.assert_called_once()
+
 


### PR DESCRIPTION
## Summary
- Automatically set the project **Organization** field (`Agentic-SSDLC` / `complytime` / `unbound-force`) when the board sync adds items
- Backfill Organization on existing board items that are unset or wrong (covers manual adds too)
- Map `complytime-labs` repos to `complytime`
- Organization field writes are best-effort: a failed field update does not undo a successful board add
- `--backfill-org auto` (default) skips the extra full-board listing on ticks that already set Organization on new items

## Why a PR
Built-in GitHub Project workflows can only set **fixed** field values — they cannot choose Organization from the item's repo org. Extending the existing `sync_project_board` automation in `org-infra` is the right place.

## Test plan
- [x] `pytest tests/test_sync_project_board.py` (37 passed)
- [ ] Run **Sync Compliance Automation Project Board** with `dry_run=true`
- [ ] Re-run with `dry_run=false` and confirm new/missing items get Organization
- [ ] Spot-check board: no unset Organization except outliers outside the 3 orgs (e.g. `gemaraproj`)

Made with [Cursor](https://cursor.com)