### PR TITLE
fix(ci): skip unsupported cross-org project repo links

### DIFF
--- a/.github/workflows/sync_project_board.yml
+++ b/.github/workflows/sync_project_board.yml
@@ -23,8 +23,16 @@ on:
         type: string
         default: ''
   schedule:
-    # Daily catch-up for newly opened issues/PRs across orgs.
-    - cron: '0 6 * * *'
+    # Fastest GitHub Actions interval. Cron of every 1 minute is valid YAML
+    # but GitHub will not honor intervals shorter than 5 minutes.
+    # See: https://docs.github.com/en/actions/using-workflows/workflow-syntax-for-github-actions#onschedule
+    - cron: '*/5 * * * *'
+
+# A full sync can take several minutes. Keep one run in flight (and at most
+# one queued) so 5-minute ticks do not pile up.
+concurrency:
+  group: sync-compliance-automation-project-board
+  cancel-in-progress: false
 
 permissions:
   contents: read
@@ -33,7 +41,7 @@ jobs:
   sync-project-board:
     name: Sync project board
     runs-on: ubuntu-latest
-    timeout-minutes: 60
+    timeout-minutes: 15
 
     steps:
       - name: Checkout org-infra

--- a/CHANGELOG.md
+++ b/CHANGELOG.md
@@ -21,6 +21,11 @@
 
 ### Changed
 
+- **Project board sync**: Run the Compliance Automation planning board
+  sync every 5 minutes instead of once daily. GitHub Actions does not
+  honor a 1-minute cron; 5 minutes is the documented minimum. Concurrent
+  runs are serialized so ticks do not pile up.
+
 - **crapload workflow**: Replaced custom `scripts/compare-crapload.sh`
   (315 lines) with gaze's native `gaze crap --baseline` comparison.
   The workflow now writes a temporary `.gaze.yaml` from workflow inputs

--- a/docs/PROJECT_BOARD_SYNC.md
+++ b/docs/PROJECT_BOARD_SYNC.md
@@ -17,7 +17,8 @@ Archived repositories are skipped by default.
 On a daily schedule (and via manual `workflow_dispatch`):
 
 1. Discovers repositories from `project-sync-config.yml`
-2. Links each repository to project `#14` (idempotent)
+2. Links same-org repositories to project `#14` (idempotent). Cross-org repos
+   cannot be linked (GitHub restriction) but their issues/PRs still sync.
 3. Collects open issues and open PRs
 4. Adds any missing items to the board with **Status = Backlog**
 

--- a/docs/PROJECT_BOARD_SYNC.md
+++ b/docs/PROJECT_BOARD_SYNC.md
@@ -14,7 +14,9 @@ Archived repositories are skipped by default.
 
 ## What the automation does
 
-On a daily schedule (and via manual `workflow_dispatch`):
+On a 5-minute schedule (GitHub Actions' shortest interval; 1-minute cron is
+not honored) and via manual `workflow_dispatch`. Scheduled runs can still be
+delayed under GitHub load:
 
 1. Discovers repositories from `project-sync-config.yml`
 2. Links same-org repositories to project `#14` (idempotent). Cross-org repos

--- a/project-sync-config.yml
+++ b/project-sync-config.yml
@@ -16,7 +16,9 @@ sync:
   pull_requests: true
   # Skip archived repositories unless explicitly listed under include_archived
   skip_archived: true
-  # Also link each discovered repository to the project (enables native Project automations)
+  # Link same-org repos to the project (enables native Project automations).
+  # Cross-org repos are skipped for linking — GitHub only allows same-owner links —
+  # but their issues/PRs are still added to the board.
   link_repositories: true
 
 # Organizations and repository selection rules

--- a/scripts/sync-project-board.py
+++ b/scripts/sync-project-board.py
@@ -433,18 +433,32 @@ def sync(config: Dict[str, Any], client: GitHubClient, org_filter: Set[str]) -> 
             print(f"\n- {full_name}")
 
             if link_repos:
-                try:
-                    linked = link_repository(client, project_id, repo["node_id"])
-                    if linked:
-                        stats.repos_linked += 1
-                        print("  linked to project")
-                    else:
+                # GitHub only allows linking a repository to a project owned by
+                # the same org. Cross-org boards (e.g. unbound-force repos on a
+                # complytime project) can still receive issues/PRs via
+                # addProjectV2ItemById — skip the unsupported link step.
+                if org != owner:
+                    stats.repos_link_skipped += 1
+                    print(
+                        "  skip repo link (cross-org; items still sync onto the board)"
+                    )
+                else:
+                    try:
+                        linked = link_repository(
+                            client, project_id, repo["node_id"]
+                        )
+                        if linked:
+                            stats.repos_linked += 1
+                            print("  linked to project")
+                        else:
+                            stats.repos_link_skipped += 1
+                            print("  already linked (or skipped)")
+                    except SYNC_EXCEPTIONS as exc:
+                        # Linking is best-effort for same-org repos (permissions
+                        # may be missing). Do not fail the job: item sync is the
+                        # primary goal.
                         stats.repos_link_skipped += 1
-                        print("  already linked (or skipped)")
-                except SYNC_EXCEPTIONS as exc:
-                    msg = f"Link failed for {full_name}: {exc}"
-                    print(f"  {msg}")
-                    stats.errors.append(msg)
+                        print(f"  skip repo link ({exc})")
 
             try:
                 open_items = list_open_items(

--- a/scripts/sync-project-board.py
+++ b/scripts/sync-project-board.py
@@ -458,7 +458,7 @@ def sync(config: Dict[str, Any], client: GitHubClient, org_filter: Set[str]) -> 
                         # may be missing). Do not fail the job: item sync is the
                         # primary goal.
                         stats.repos_link_skipped += 1
-                        print(f"  skip repo link ({exc})")
+                        print(f"  skip repo link for {full_name} ({exc})")
 
             try:
                 open_items = list_open_items(

--- a/tests/test_sync_project_board.py
+++ b/tests/test_sync_project_board.py
@@ -312,6 +312,37 @@ class TestSyncErrorHandling:
         assert stats.items_added == 0
         assert any("Failed adding" in err for err in stats.errors)
 
+    def test_cross_org_repo_link_is_skipped_without_error(
+        self, monkeypatch: pytest.MonkeyPatch
+    ):
+        self._project_mocks(monkeypatch)
+        client = MagicMock(dry_run=False)
+        link = MagicMock(return_value=True)
+        monkeypatch.setattr(sync, "link_repository", link)
+        monkeypatch.setattr(
+            sync,
+            "list_org_repos",
+            MagicMock(
+                return_value=[
+                    {
+                        "name": "website",
+                        "full_name": "unbound-force/website",
+                        "node_id": "R_WEB",
+                        "archived": False,
+                    }
+                ]
+            ),
+        )
+        monkeypatch.setattr(sync, "list_open_items", MagicMock(return_value=[]))
+        config = _minimal_config(
+            organizations=[{"name": "unbound-force"}],
+        )
+        stats = sync.sync(config, client, org_filter={"unbound-force"})
+        link.assert_not_called()
+        assert stats.repos_link_skipped == 1
+        assert stats.repos_linked == 0
+        assert stats.errors == []
+
 
 class TestLinkRepository:
     def test_dry_run_does_not_call_graphql(self):

--- a/tests/test_sync_project_board.py
+++ b/tests/test_sync_project_board.py
@@ -344,7 +344,7 @@ class TestSyncErrorHandling:
         assert stats.errors == []
 
     def test_same_org_link_failure_is_best_effort(
-        self, monkeypatch: pytest.MonkeyPatch
+        self, monkeypatch: pytest.MonkeyPatch, capsys: pytest.CaptureFixture[str]
     ):
         self._project_mocks(monkeypatch)
         client = MagicMock(dry_run=False)
@@ -374,10 +374,12 @@ class TestSyncErrorHandling:
         )
         monkeypatch.setattr(sync, "list_open_items", MagicMock(return_value=[]))
         stats = sync.sync(_minimal_config(), client, org_filter={"complytime"})
+        captured = capsys.readouterr()
         assert stats.repos_link_skipped == 1
         assert stats.repos_linked == 0
         assert stats.errors == []
         assert stats.items_failed == 0
+        assert "skip repo link for complytime/complyapi" in captured.out
 
 
 class TestLinkRepository:

--- a/tests/test_sync_project_board.py
+++ b/tests/test_sync_project_board.py
@@ -343,6 +343,42 @@ class TestSyncErrorHandling:
         assert stats.repos_linked == 0
         assert stats.errors == []
 
+    def test_same_org_link_failure_is_best_effort(
+        self, monkeypatch: pytest.MonkeyPatch
+    ):
+        self._project_mocks(monkeypatch)
+        client = MagicMock(dry_run=False)
+        monkeypatch.setattr(
+            sync,
+            "link_repository",
+            MagicMock(
+                side_effect=RuntimeError(
+                    "beatrizmcouto does not have the correct permissions "
+                    "to execute `LinkProjectV2ToRepository`"
+                )
+            ),
+        )
+        monkeypatch.setattr(
+            sync,
+            "list_org_repos",
+            MagicMock(
+                return_value=[
+                    {
+                        "name": "complyapi",
+                        "full_name": "complytime/complyapi",
+                        "node_id": "R_API",
+                        "archived": False,
+                    }
+                ]
+            ),
+        )
+        monkeypatch.setattr(sync, "list_open_items", MagicMock(return_value=[]))
+        stats = sync.sync(_minimal_config(), client, org_filter={"complytime"})
+        assert stats.repos_link_skipped == 1
+        assert stats.repos_linked == 0
+        assert stats.errors == []
+        assert stats.items_failed == 0
+
 
 class TestLinkRepository:
     def test_dry_run_does_not_call_graphql(self):


### PR DESCRIPTION
## Summary
- `unbound-force/website` issues were missing from the Compliance Automation board because the daily sync never completed successfully (missing `PROJECT_SYNC_TOKEN`, then fatal cross-org `linkProjectV2ToRepository` errors)
- Token is now configured; a manual sync already added the website issues (138 on the board, including recent ones like #236)
- This PR keeps future syncs green: skip repo-linking for cross-org repos (GitHub only allows same-owner links) and treat same-org link permission failures as best-effort so item sync remains the success criteria
- Run the board sync every 5 minutes (GitHub Actions' shortest interval) instead of once daily, with concurrency so overlapping ticks do not pile up

## Test plan
- [x] `pytest tests/test_sync_project_board.py` (22 passed)
- [x] Confirm `unbound-force/website` issues are already on [project #14](https://github.com/orgs/complytime/projects/14)
- [ ] After merge, confirm **Sync Compliance Automation Project Board** concludes successfully (no fatal link errors for `unbound-force/*`)
- [ ] After merge, confirm the workflow schedule is `*/5 * * * *` and a new item appears on the board within about 5 minutes