### PR TITLE
chore: exclude nunya from the Compliance Automation planning board

### DIFF
--- a/CHANGELOG.md
+++ b/CHANGELOG.md
@@ -21,6 +21,10 @@
 
 ### Changed
 
+- **Project board sync**: Exclude `complytime/nunya` from the Compliance
+  Automation planning board (`project-sync-config.yml`). Nunya is private
+  internal tooling and should not be backfilled or linked onto project `#14`.
+
 - **crapload workflow**: Replaced custom `scripts/compare-crapload.sh`
   (315 lines) with gaze's native `gaze crap --baseline` comparison.
   The workflow now writes a temporary `.gaze.yaml` from workflow inputs

--- a/docs/PROJECT_BOARD_SYNC.md
+++ b/docs/PROJECT_BOARD_SYNC.md
@@ -7,7 +7,7 @@ board populated with open issues and pull requests from:
 | Organization | Selection |
 |---|---|
 | `Agentic-SSDLC` | All repositories |
-| `complytime` | All repositories **except** `roadmap` and `complytime` |
+| `complytime` | All repositories **except** `roadmap`, `complytime`, and `nunya` |
 | `unbound-force` | All repositories |
 
 Archived repositories are skipped by default.

--- a/project-sync-config.yml
+++ b/project-sync-config.yml
@@ -28,6 +28,7 @@ organizations:
     exclude_repos:
       - roadmap
       - complytime
+      - nunya # Private internal tooling; keep off the planning board
 
   - name: unbound-force
     # All repositories

--- a/tests/test_sync_project_board.py
+++ b/tests/test_sync_project_board.py
@@ -45,6 +45,12 @@ class TestLoadAndValidateConfig:
         assert loaded["project"]["owner"] == "complytime"
         assert loaded["organizations"][0]["exclude_repos"] == ["roadmap", "complytime"]
 
+    def test_committed_config_excludes_nunya(self):
+        path = Path(__file__).parent.parent / "project-sync-config.yml"
+        loaded = sync.load_config(path)
+        org = next(o for o in loaded["organizations"] if o["name"] == "complytime")
+        assert "nunya" in org.get("exclude_repos", [])
+
     def test_validate_config_accepts_minimal(self):
         assert sync.validate_config(_minimal_config())["project"]["number"] == 14
 


### PR DESCRIPTION
## Summary
- Stop the project-board sync from adding `complytime/nunya` issues and PRs to [project #14](https://github.com/orgs/complytime/projects/14).
- Existing nunya items have already been removed from the board (34 issues) and the repository has been unlinked so GitHub will not auto-add new ones.
- This change must land before the next daily sync (`06:00 UTC`) so those items are not backfilled again.

## Test plan
- [x] `pytest tests/test_sync_project_board.py` (22 passed)
- [x] Confirm project #14 has 0 nunya items and `nunya` is not in the linked-repo list
- [ ] After merge, optionally run **Sync Compliance Automation Project Board** and confirm nunya is skipped


Made with [Cursor](https://cursor.com)