### PR TITLE
feat(ci): copy issue Priority onto linked PRs on the planning board

### DIFF
--- a/docs/PROJECT_BOARD_SYNC.md
+++ b/docs/PROJECT_BOARD_SYNC.md
@@ -23,8 +23,16 @@ delayed under GitHub load:
    cannot be linked (GitHub restriction) but their issues/PRs still sync.
 3. Collects open issues and open PRs
 4. Adds any missing items to the board with **Status = Backlog**
+5. Copies **Priority** (and empty **Review priority**) onto PRs from linked
+   issues (`Fixes` / `Closes` / Development sidebar). Uses the issue's project
+   Priority; if several issues are linked, the highest rank wins
+   (Urgent > High > Medium > Low). PRs with no linked issue, or whose issues
+   have no Priority, stay unset — there is no default. Values already set on
+   the PR are left alone.
 
 The workflow lives only in `org-infra` (it is **not** synced out to consumer repos).
+A new PR is picked up on the next 5-minute tick (GitHub does not let this
+org-infra workflow subscribe to `pull_request` events in other repositories).
 
 | File | Role |
 |---|---|

--- a/scripts/sync-project-board.py
+++ b/scripts/sync-project-board.py
@@ -5,8 +5,9 @@
 
 Discovers repositories across one or more organizations, optionally links
 them to the target project, and adds any open issues/PRs that are not
-already on the board. Designed for cross-org boards where a single GitHub
-App installation token is insufficient (use a PAT with multi-org access).
+already on the board. PRs inherit Priority from linked issues when that
+field is empty. Designed for cross-org boards where a single GitHub App
+installation token is insufficient (use a PAT with multi-org access).
 """
 
 from __future__ import annotations
@@ -17,7 +18,7 @@ import sys
 import time
 from dataclasses import dataclass, field
 from pathlib import Path
-from typing import Any, Dict, List, Optional, Set, Tuple
+from typing import Any, Dict, List, Optional, Set
 
 import requests
 import yaml
@@ -42,7 +43,26 @@ class SyncStats:
     items_already_on_board: int = 0
     items_added: int = 0
     items_failed: int = 0
+    priority_set: int = 0
+    priority_failed: int = 0
     errors: List[str] = field(default_factory=list)
+
+
+# Project Priority / Review priority option names, highest first.
+PRIORITY_RANK = {"Urgent": 4, "High": 3, "Medium": 2, "Low": 1}
+
+
+@dataclass
+class ProjectFields:
+    """Resolved project id plus single-select field metadata."""
+
+    project_id: str
+    status_field_id: Optional[str]
+    status_options: Dict[str, str]
+    priority_field_id: Optional[str] = None
+    priority_options: Dict[str, str] = field(default_factory=dict)
+    review_priority_field_id: Optional[str] = None
+    review_priority_options: Dict[str, str] = field(default_factory=dict)
 
 
 class GitHubClient:
@@ -183,10 +203,8 @@ def list_org_repos(
     return selected
 
 
-def get_project(
-    client: GitHubClient, owner: str, number: int
-) -> Tuple[str, Optional[str], Dict[str, str]]:
-    """Return project id, Status field id, and Status option name→id map."""
+def get_project(client: GitHubClient, owner: str, number: int) -> ProjectFields:
+    """Return project id and Status / Priority / Review priority metadata."""
     data = client.graphql(
         """
         query($owner: String!, $number: Int!) {
@@ -212,16 +230,26 @@ def get_project(
     if not project:
         raise RuntimeError(f"Project #{number} not found in org {owner}")
 
-    status_field_id = None
-    status_options: Dict[str, str] = {}
+    fields = ProjectFields(
+        project_id=project["id"],
+        status_field_id=None,
+        status_options={},
+    )
     for node in project["fields"]["nodes"]:
         if not node:
             continue
-        if node.get("name") == "Status":
-            status_field_id = node["id"]
-            status_options = {opt["name"]: opt["id"] for opt in node.get("options", [])}
-            break
-    return project["id"], status_field_id, status_options
+        name = node.get("name")
+        options = {opt["name"]: opt["id"] for opt in node.get("options", [])}
+        if name == "Status":
+            fields.status_field_id = node["id"]
+            fields.status_options = options
+        elif name == "Priority":
+            fields.priority_field_id = node["id"]
+            fields.priority_options = options
+        elif name == "Review priority":
+            fields.review_priority_field_id = node["id"]
+            fields.review_priority_options = options
+    return fields
 
 
 def existing_content_ids(client: GitHubClient, project_id: str) -> Set[str]:
@@ -311,6 +339,39 @@ def list_open_items(
     return items
 
 
+def set_single_select(
+    client: GitHubClient,
+    project_id: str,
+    item_id: str,
+    field_id: str,
+    option_id: str,
+) -> None:
+    """Set a project single-select field value."""
+    if client.dry_run:
+        print(f"  [dry-run] would set field {field_id}={option_id} on {item_id}")
+        return
+    client.graphql(
+        """
+        mutation($projectId: ID!, $itemId: ID!, $fieldId: ID!, $optionId: String!) {
+          updateProjectV2ItemFieldValue(input: {
+            projectId: $projectId
+            itemId: $itemId
+            fieldId: $fieldId
+            value: { singleSelectOptionId: $optionId }
+          }) {
+            projectV2Item { id }
+          }
+        }
+        """,
+        {
+            "projectId": project_id,
+            "itemId": item_id,
+            "fieldId": field_id,
+            "optionId": option_id,
+        },
+    )
+
+
 def add_item(
     client: GitHubClient,
     project_id: str,
@@ -335,26 +396,155 @@ def add_item(
     item_id = data["addProjectV2ItemById"]["item"]["id"]
 
     if status_field_id and status_option_id:
-        client.graphql(
-            """
-            mutation($projectId: ID!, $itemId: ID!, $fieldId: ID!, $optionId: String!) {
-              updateProjectV2ItemFieldValue(input: {
-                projectId: $projectId
-                itemId: $itemId
-                fieldId: $fieldId
-                value: { singleSelectOptionId: $optionId }
-              }) {
-                projectV2Item { id }
+        set_single_select(
+            client, project_id, item_id, status_field_id, status_option_id
+        )
+
+
+def highest_priority(names: List[Optional[str]]) -> Optional[str]:
+    """Return the highest named Priority among known options, if any."""
+    ranked = [name for name in names if name in PRIORITY_RANK]
+    if not ranked:
+        return None
+    return max(ranked, key=lambda name: PRIORITY_RANK[name])
+
+
+def list_board_priority_items(
+    client: GitHubClient, project_id: str
+) -> List[Dict[str, Any]]:
+    """Return board items with Priority, Review priority, and linked issues."""
+    query = """
+    query($projectId: ID!, $cursor: String) {
+      node(id: $projectId) {
+        ... on ProjectV2 {
+          items(first: 100, after: $cursor) {
+            pageInfo { hasNextPage endCursor }
+            nodes {
+              id
+              priority: fieldValueByName(name: "Priority") {
+                ... on ProjectV2ItemFieldSingleSelectValue { name }
+              }
+              reviewPriority: fieldValueByName(name: "Review priority") {
+                ... on ProjectV2ItemFieldSingleSelectValue { name }
+              }
+              content {
+                __typename
+                ... on Issue { id }
+                ... on PullRequest {
+                  id
+                  closingIssuesReferences(first: 20) {
+                    nodes { id }
+                  }
+                }
               }
             }
-            """,
-            {
-                "projectId": project_id,
-                "itemId": item_id,
-                "fieldId": status_field_id,
-                "optionId": status_option_id,
-            },
-        )
+          }
+        }
+      }
+    }
+    """
+    collected: List[Dict[str, Any]] = []
+    cursor = None
+    while True:
+        data = client.graphql(query, {"projectId": project_id, "cursor": cursor})
+        items = data["node"]["items"]
+        collected.extend(items["nodes"])
+        if not items["pageInfo"]["hasNextPage"]:
+            break
+        cursor = items["pageInfo"]["endCursor"]
+    return collected
+
+
+def _copy_priority_field(
+    client: GitHubClient,
+    fields: ProjectFields,
+    item_id: str,
+    option_name: str,
+    field_id: Optional[str],
+    options: Dict[str, str],
+    stats: SyncStats,
+    label: str,
+) -> None:
+    """Copy a named priority onto one single-select field when it is mapped."""
+    option_id = options.get(option_name)
+    if not field_id or not option_id:
+        return
+    try:
+        set_single_select(client, fields.project_id, item_id, field_id, option_id)
+        stats.priority_set += 1
+        print(f"  priority {label} -> {option_name}")
+    except SYNC_EXCEPTIONS as exc:
+        stats.priority_failed += 1
+        msg = f"Failed copying Priority onto {label}: {exc}"
+        print(f"  ! {msg}")
+        stats.errors.append(msg)
+
+
+def ensure_pr_priority_from_issues(
+    client: GitHubClient,
+    fields: ProjectFields,
+    stats: SyncStats,
+) -> None:
+    """Set empty PR Priority / Review priority from linked issues.
+
+    Uses ``closingIssuesReferences`` (Fixes/Closes and Development links).
+    Does not default a value when there is no linked issue, or when linked
+    issues have no Priority. Does not overwrite a value already set on the PR.
+    If several linked issues have Priority, the highest rank wins.
+    """
+    if not fields.priority_field_id and not fields.review_priority_field_id:
+        print("Priority fields missing on project; skipping PR priority copy")
+        return
+
+    print("\n=== Copying Priority from linked issues onto PRs ===")
+    issue_priority: Dict[str, Optional[str]] = {}
+    pr_nodes: List[Dict[str, Any]] = []
+    for node in list_board_priority_items(client, fields.project_id):
+        content = node.get("content") or {}
+        content_id = content.get("id")
+        if not content_id:
+            continue
+        current = (node.get("priority") or {}).get("name")
+        typename = content.get("__typename")
+        if typename == "Issue":
+            issue_priority[content_id] = current
+            continue
+        if typename == "PullRequest":
+            pr_nodes.append(node)
+
+    for node in pr_nodes:
+        content = node.get("content") or {}
+        linked = content.get("closingIssuesReferences") or {}
+        linked_ids = [item.get("id") for item in linked.get("nodes") or []]
+        wanted = highest_priority([issue_priority.get(cid) for cid in linked_ids])
+        if not wanted:
+            continue
+        item_id = node["id"]
+        current_priority = (node.get("priority") or {}).get("name")
+        current_review = (node.get("reviewPriority") or {}).get("name")
+        pr_id = content.get("id") or item_id
+        if not current_priority:
+            _copy_priority_field(
+                client,
+                fields,
+                item_id,
+                wanted,
+                fields.priority_field_id,
+                fields.priority_options,
+                stats,
+                f"Priority {pr_id}",
+            )
+        if not current_review:
+            _copy_priority_field(
+                client,
+                fields,
+                item_id,
+                wanted,
+                fields.review_priority_field_id,
+                fields.review_priority_options,
+                stats,
+                f"Review priority {pr_id}",
+            )
 
 
 def format_summary(stats: SyncStats, dry_run: bool) -> str:
@@ -370,6 +560,8 @@ def format_summary(stats: SyncStats, dry_run: bool) -> str:
         f"- Already on board: **{stats.items_already_on_board}**",
         f"- Added: **{stats.items_added}**",
         f"- Failed: **{stats.items_failed}**",
+        f"- Priority copied from linked issues: **{stats.priority_set}**",
+        f"- Priority copy failed: **{stats.priority_failed}**",
     ]
     if stats.errors:
         lines.extend(["", "### Errors", ""])
@@ -399,7 +591,10 @@ def sync(config: Dict[str, Any], client: GitHubClient, org_filter: Set[str]) -> 
     skip_archived = bool(sync_cfg.get("skip_archived", True))
     link_repos = bool(sync_cfg.get("link_repositories", True))
 
-    project_id, status_field_id, status_options = get_project(client, owner, number)
+    fields = get_project(client, owner, number)
+    project_id = fields.project_id
+    status_field_id = fields.status_field_id
+    status_options = fields.status_options
     status_option_id = status_options.get(default_status) if status_options else None
     if default_status and status_field_id and not status_option_id:
         print(
@@ -502,6 +697,7 @@ def sync(config: Dict[str, Any], client: GitHubClient, org_filter: Set[str]) -> 
                     print(f"  ! {msg}")
                     stats.errors.append(msg)
 
+    ensure_pr_priority_from_issues(client, fields, stats)
     return stats
 
 

--- a/scripts/sync-project-board.py
+++ b/scripts/sync-project-board.py
@@ -252,6 +252,22 @@ def get_project(client: GitHubClient, owner: str, number: int) -> ProjectFields:
     return fields
 
 
+def _paginate_project_item_nodes(
+    client: GitHubClient, project_id: str, query: str
+) -> List[Dict[str, Any]]:
+    """Walk ProjectV2 item pages until exhausted."""
+    collected: List[Dict[str, Any]] = []
+    cursor = None
+    while True:
+        data = client.graphql(query, {"projectId": project_id, "cursor": cursor})
+        items = data["node"]["items"]
+        collected.extend(items["nodes"])
+        if not items["pageInfo"]["hasNextPage"]:
+            break
+        cursor = items["pageInfo"]["endCursor"]
+    return collected
+
+
 def existing_content_ids(client: GitHubClient, project_id: str) -> Set[str]:
     """Return node IDs of issues/PRs already on the project."""
     query = """
@@ -272,18 +288,11 @@ def existing_content_ids(client: GitHubClient, project_id: str) -> Set[str]:
     }
     """
     ids: Set[str] = set()
-    cursor = None
-    while True:
-        data = client.graphql(query, {"projectId": project_id, "cursor": cursor})
-        items = data["node"]["items"]
-        for node in items["nodes"]:
-            content = node.get("content") or {}
-            content_id = content.get("id")
-            if content_id:
-                ids.add(content_id)
-        if not items["pageInfo"]["hasNextPage"]:
-            break
-        cursor = items["pageInfo"]["endCursor"]
+    for node in _paginate_project_item_nodes(client, project_id, query):
+        content = node.get("content") or {}
+        content_id = content.get("id")
+        if content_id:
+            ids.add(content_id)
     return ids
 
 
@@ -443,16 +452,7 @@ def list_board_priority_items(
       }
     }
     """
-    collected: List[Dict[str, Any]] = []
-    cursor = None
-    while True:
-        data = client.graphql(query, {"projectId": project_id, "cursor": cursor})
-        items = data["node"]["items"]
-        collected.extend(items["nodes"])
-        if not items["pageInfo"]["hasNextPage"]:
-            break
-        cursor = items["pageInfo"]["endCursor"]
-    return collected
+    return _paginate_project_item_nodes(client, project_id, query)
 
 
 def _copy_priority_field(
@@ -592,18 +592,17 @@ def sync(config: Dict[str, Any], client: GitHubClient, org_filter: Set[str]) -> 
     link_repos = bool(sync_cfg.get("link_repositories", True))
 
     fields = get_project(client, owner, number)
-    project_id = fields.project_id
-    status_field_id = fields.status_field_id
-    status_options = fields.status_options
-    status_option_id = status_options.get(default_status) if status_options else None
-    if default_status and status_field_id and not status_option_id:
+    status_option_id = (
+        fields.status_options.get(default_status) if fields.status_options else None
+    )
+    if default_status and fields.status_field_id and not status_option_id:
         print(
             f"Warning: Status option '{default_status}' not found; "
             "items will be added without a Status value"
         )
 
-    print(f"Project {owner}/{number} id={project_id}")
-    on_board = existing_content_ids(client, project_id)
+    print(f"Project {owner}/{number} id={fields.project_id}")
+    on_board = existing_content_ids(client, fields.project_id)
     print(f"Existing board items with content: {len(on_board)}")
 
     for org_cfg in config.get("organizations", []):
@@ -640,7 +639,7 @@ def sync(config: Dict[str, Any], client: GitHubClient, org_filter: Set[str]) -> 
                 else:
                     try:
                         linked = link_repository(
-                            client, project_id, repo["node_id"]
+                            client, fields.project_id, repo["node_id"]
                         )
                         if linked:
                             stats.repos_linked += 1
@@ -683,9 +682,9 @@ def sync(config: Dict[str, Any], client: GitHubClient, org_filter: Set[str]) -> 
                 try:
                     add_item(
                         client,
-                        project_id,
+                        fields.project_id,
                         node_id,
-                        status_field_id,
+                        fields.status_field_id,
                         status_option_id,
                     )
                     stats.items_added += 1

--- a/scripts/sync-project-board.py
+++ b/scripts/sync-project-board.py
@@ -457,7 +457,7 @@ def list_board_priority_items(
 
 def _copy_priority_field(
     client: GitHubClient,
-    fields: ProjectFields,
+    project_id: str,
     item_id: str,
     option_name: str,
     field_id: Optional[str],
@@ -470,7 +470,7 @@ def _copy_priority_field(
     if not field_id or not option_id:
         return
     try:
-        set_single_select(client, fields.project_id, item_id, field_id, option_id)
+        set_single_select(client, project_id, item_id, field_id, option_id)
         stats.priority_set += 1
         print(f"  priority {label} -> {option_name}")
     except SYNC_EXCEPTIONS as exc:
@@ -526,7 +526,7 @@ def ensure_pr_priority_from_issues(
         if not current_priority:
             _copy_priority_field(
                 client,
-                fields,
+                fields.project_id,
                 item_id,
                 wanted,
                 fields.priority_field_id,
@@ -537,7 +537,7 @@ def ensure_pr_priority_from_issues(
         if not current_review:
             _copy_priority_field(
                 client,
-                fields,
+                fields.project_id,
                 item_id,
                 wanted,
                 fields.review_priority_field_id,

--- a/tests/test_sync_project_board.py
+++ b/tests/test_sync_project_board.py
@@ -242,11 +242,7 @@ class TestSyncErrorHandling:
         monkeypatch.setattr(
             sync,
             "get_project",
-            lambda *_a, **_k: sync.ProjectFields(
-                project_id="PROJECT",
-                status_field_id="STATUS_FIELD",
-                status_options={"Backlog": "OPT"},
-            ),
+            lambda *_a, **_k: _priority_fields(),
         )
         monkeypatch.setattr(sync, "existing_content_ids", lambda *_a, **_k: set())
         monkeypatch.setattr(
@@ -467,6 +463,18 @@ class TestListBoardPriorityItems:
         assert client.graphql.call_args_list[0].args[1]["cursor"] is None
         assert client.graphql.call_args_list[1].args[1]["cursor"] == "c1"
 
+    def test_empty_board_returns_no_items(self):
+        client = MagicMock()
+        client.graphql.return_value = {
+            "node": {
+                "items": {
+                    "pageInfo": {"hasNextPage": False, "endCursor": None},
+                    "nodes": [],
+                }
+            }
+        }
+        assert sync.list_board_priority_items(client, "PROJECT_ID") == []
+
     def test_extracts_priority_fields_and_closing_issues(self):
         client = MagicMock()
         client.graphql.return_value = {
@@ -644,6 +652,33 @@ class TestPriorityInherit:
                         "__typename": "PullRequest",
                         "id": "PR_2",
                         "closingIssuesReferences": {"nodes": []},
+                    },
+                },
+            ],
+        )
+        set_mock = MagicMock()
+        monkeypatch.setattr(sync, "set_single_select", set_mock)
+        stats = sync.SyncStats()
+        sync.ensure_pr_priority_from_issues(client, _priority_fields(), stats)
+        set_mock.assert_not_called()
+        assert stats.priority_set == 0
+
+    def test_skips_when_linked_issue_is_not_on_board(
+        self, monkeypatch: pytest.MonkeyPatch
+    ):
+        client = MagicMock(dry_run=False)
+        monkeypatch.setattr(
+            sync,
+            "list_board_priority_items",
+            lambda *_a, **_k: [
+                {
+                    "id": "PVTI_PR",
+                    "priority": None,
+                    "reviewPriority": None,
+                    "content": {
+                        "__typename": "PullRequest",
+                        "id": "PR_1",
+                        "closingIssuesReferences": {"nodes": [{"id": "I_OFFBOARD"}]},
                     },
                 },
             ],

--- a/tests/test_sync_project_board.py
+++ b/tests/test_sync_project_board.py
@@ -242,9 +242,16 @@ class TestSyncErrorHandling:
         monkeypatch.setattr(
             sync,
             "get_project",
-            lambda *_a, **_k: ("PROJECT", "STATUS_FIELD", {"Backlog": "OPT"}),
+            lambda *_a, **_k: sync.ProjectFields(
+                project_id="PROJECT",
+                status_field_id="STATUS_FIELD",
+                status_options={"Backlog": "OPT"},
+            ),
         )
         monkeypatch.setattr(sync, "existing_content_ids", lambda *_a, **_k: set())
+        monkeypatch.setattr(
+            sync, "ensure_pr_priority_from_issues", lambda *_a, **_k: None
+        )
 
     def test_per_org_request_errors_are_recorded(self, monkeypatch: pytest.MonkeyPatch):
         self._project_mocks(monkeypatch)
@@ -392,3 +399,228 @@ class TestLinkRepository:
         client = MagicMock(dry_run=False)
         client.graphql.side_effect = RuntimeError("already linked to project")
         assert sync.link_repository(client, "P", "R") is False
+
+
+def _priority_fields() -> sync.ProjectFields:
+    return sync.ProjectFields(
+        project_id="PROJECT",
+        status_field_id="STATUS_FIELD",
+        status_options={"Backlog": "OPT"},
+        priority_field_id="PRI_FIELD",
+        priority_options={
+            "Urgent": "PRI_U",
+            "High": "PRI_H",
+            "Medium": "PRI_M",
+            "Low": "PRI_L",
+        },
+        review_priority_field_id="REV_FIELD",
+        review_priority_options={
+            "Urgent": "REV_U",
+            "High": "REV_H",
+            "Medium": "REV_M",
+            "Low": "REV_L",
+        },
+    )
+
+
+class TestPriorityInherit:
+    def test_highest_priority_picks_urgent_over_low(self):
+        assert sync.highest_priority(["Low", "Urgent", None, "Medium"]) == "Urgent"
+
+    def test_highest_priority_empty_when_no_known_values(self):
+        assert sync.highest_priority([]) is None
+        assert sync.highest_priority([None, "unknown"]) is None
+
+    def test_copies_issue_priority_onto_empty_pr_fields(
+        self, monkeypatch: pytest.MonkeyPatch
+    ):
+        client = MagicMock(dry_run=False)
+        monkeypatch.setattr(
+            sync,
+            "list_board_priority_items",
+            lambda *_a, **_k: [
+                {
+                    "id": "PVTI_ISSUE",
+                    "priority": {"name": "High"},
+                    "reviewPriority": None,
+                    "content": {"__typename": "Issue", "id": "I_1"},
+                },
+                {
+                    "id": "PVTI_PR",
+                    "priority": None,
+                    "reviewPriority": None,
+                    "content": {
+                        "__typename": "PullRequest",
+                        "id": "PR_1",
+                        "closingIssuesReferences": {"nodes": [{"id": "I_1"}]},
+                    },
+                },
+            ],
+        )
+        set_calls = []
+
+        def _set(*args, **_kwargs):
+            set_calls.append(args)
+
+        monkeypatch.setattr(sync, "set_single_select", _set)
+        stats = sync.SyncStats()
+        sync.ensure_pr_priority_from_issues(client, _priority_fields(), stats)
+        assert stats.priority_set == 2
+        assert stats.priority_failed == 0
+        field_ids = {call[3] for call in set_calls}
+        option_ids = {call[4] for call in set_calls}
+        assert field_ids == {"PRI_FIELD", "REV_FIELD"}
+        assert option_ids == {"PRI_H", "REV_H"}
+
+    def test_does_not_overwrite_existing_pr_priority(
+        self, monkeypatch: pytest.MonkeyPatch
+    ):
+        client = MagicMock(dry_run=False)
+        monkeypatch.setattr(
+            sync,
+            "list_board_priority_items",
+            lambda *_a, **_k: [
+                {
+                    "id": "PVTI_ISSUE",
+                    "priority": {"name": "High"},
+                    "reviewPriority": None,
+                    "content": {"__typename": "Issue", "id": "I_1"},
+                },
+                {
+                    "id": "PVTI_PR",
+                    "priority": {"name": "Medium"},
+                    "reviewPriority": {"name": "Medium"},
+                    "content": {
+                        "__typename": "PullRequest",
+                        "id": "PR_1",
+                        "closingIssuesReferences": {"nodes": [{"id": "I_1"}]},
+                    },
+                },
+            ],
+        )
+        set_mock = MagicMock()
+        monkeypatch.setattr(sync, "set_single_select", set_mock)
+        stats = sync.SyncStats()
+        sync.ensure_pr_priority_from_issues(client, _priority_fields(), stats)
+        set_mock.assert_not_called()
+        assert stats.priority_set == 0
+
+    def test_skips_pr_with_no_linked_issue_priority(
+        self, monkeypatch: pytest.MonkeyPatch
+    ):
+        client = MagicMock(dry_run=False)
+        monkeypatch.setattr(
+            sync,
+            "list_board_priority_items",
+            lambda *_a, **_k: [
+                {
+                    "id": "PVTI_ISSUE",
+                    "priority": None,
+                    "reviewPriority": None,
+                    "content": {"__typename": "Issue", "id": "I_1"},
+                },
+                {
+                    "id": "PVTI_PR",
+                    "priority": None,
+                    "reviewPriority": None,
+                    "content": {
+                        "__typename": "PullRequest",
+                        "id": "PR_1",
+                        "closingIssuesReferences": {"nodes": [{"id": "I_1"}]},
+                    },
+                },
+                {
+                    "id": "PVTI_ORPHAN",
+                    "priority": None,
+                    "reviewPriority": None,
+                    "content": {
+                        "__typename": "PullRequest",
+                        "id": "PR_2",
+                        "closingIssuesReferences": {"nodes": []},
+                    },
+                },
+            ],
+        )
+        set_mock = MagicMock()
+        monkeypatch.setattr(sync, "set_single_select", set_mock)
+        stats = sync.SyncStats()
+        sync.ensure_pr_priority_from_issues(client, _priority_fields(), stats)
+        set_mock.assert_not_called()
+        assert stats.priority_set == 0
+
+    def test_uses_highest_priority_when_multiple_issues_linked(
+        self, monkeypatch: pytest.MonkeyPatch
+    ):
+        client = MagicMock(dry_run=False)
+        monkeypatch.setattr(
+            sync,
+            "list_board_priority_items",
+            lambda *_a, **_k: [
+                {
+                    "id": "PVTI_A",
+                    "priority": {"name": "Low"},
+                    "content": {"__typename": "Issue", "id": "I_A"},
+                },
+                {
+                    "id": "PVTI_B",
+                    "priority": {"name": "Urgent"},
+                    "content": {"__typename": "Issue", "id": "I_B"},
+                },
+                {
+                    "id": "PVTI_PR",
+                    "priority": None,
+                    "reviewPriority": None,
+                    "content": {
+                        "__typename": "PullRequest",
+                        "id": "PR_1",
+                        "closingIssuesReferences": {
+                            "nodes": [{"id": "I_A"}, {"id": "I_B"}]
+                        },
+                    },
+                },
+            ],
+        )
+        set_calls = []
+        monkeypatch.setattr(
+            sync, "set_single_select", lambda *args, **_k: set_calls.append(args)
+        )
+        stats = sync.SyncStats()
+        sync.ensure_pr_priority_from_issues(client, _priority_fields(), stats)
+        assert {call[4] for call in set_calls} == {"PRI_U", "REV_U"}
+
+    def test_field_write_failure_is_best_effort(
+        self, monkeypatch: pytest.MonkeyPatch
+    ):
+        client = MagicMock(dry_run=False)
+        monkeypatch.setattr(
+            sync,
+            "list_board_priority_items",
+            lambda *_a, **_k: [
+                {
+                    "id": "PVTI_ISSUE",
+                    "priority": {"name": "Medium"},
+                    "content": {"__typename": "Issue", "id": "I_1"},
+                },
+                {
+                    "id": "PVTI_PR",
+                    "priority": None,
+                    "reviewPriority": {"name": "Medium"},
+                    "content": {
+                        "__typename": "PullRequest",
+                        "id": "PR_1",
+                        "closingIssuesReferences": {"nodes": [{"id": "I_1"}]},
+                    },
+                },
+            ],
+        )
+        monkeypatch.setattr(
+            sync,
+            "set_single_select",
+            MagicMock(side_effect=RuntimeError("INSUFFICIENT_SCOPES")),
+        )
+        stats = sync.SyncStats()
+        sync.ensure_pr_priority_from_issues(client, _priority_fields(), stats)
+        assert stats.priority_set == 0
+        assert stats.priority_failed == 1
+        assert any("Failed copying Priority" in err for err in stats.errors)
+

--- a/tests/test_sync_project_board.py
+++ b/tests/test_sync_project_board.py
@@ -401,6 +401,110 @@ class TestLinkRepository:
         assert sync.link_repository(client, "P", "R") is False
 
 
+class TestSetSingleSelect:
+    def test_set_single_select_calls_graphql_with_correct_variables(self):
+        client = MagicMock(dry_run=False)
+        sync.set_single_select(client, "PROJECT", "ITEM", "FIELD", "OPT")
+        client.graphql.assert_called_once()
+        _query, variables = client.graphql.call_args.args
+        assert variables == {
+            "projectId": "PROJECT",
+            "itemId": "ITEM",
+            "fieldId": "FIELD",
+            "optionId": "OPT",
+        }
+
+    def test_set_single_select_dry_run_skips_mutation(self):
+        client = MagicMock(dry_run=True)
+        sync.set_single_select(client, "PROJECT", "ITEM", "FIELD", "OPT")
+        client.graphql.assert_not_called()
+
+
+class TestListBoardPriorityItems:
+    def test_paginates_multiple_pages(self):
+        client = MagicMock()
+        client.graphql.side_effect = [
+            {
+                "node": {
+                    "items": {
+                        "pageInfo": {"hasNextPage": True, "endCursor": "c1"},
+                        "nodes": [
+                            {
+                                "id": "PVTI_1",
+                                "priority": {"name": "High"},
+                                "reviewPriority": None,
+                                "content": {"__typename": "Issue", "id": "I_1"},
+                            }
+                        ],
+                    }
+                }
+            },
+            {
+                "node": {
+                    "items": {
+                        "pageInfo": {"hasNextPage": False, "endCursor": "c2"},
+                        "nodes": [
+                            {
+                                "id": "PVTI_2",
+                                "priority": None,
+                                "reviewPriority": {"name": "Low"},
+                                "content": {
+                                    "__typename": "PullRequest",
+                                    "id": "PR_1",
+                                    "closingIssuesReferences": {
+                                        "nodes": [{"id": "I_1"}]
+                                    },
+                                },
+                            }
+                        ],
+                    }
+                }
+            },
+        ]
+        items = sync.list_board_priority_items(client, "PROJECT_ID")
+        assert [item["id"] for item in items] == ["PVTI_1", "PVTI_2"]
+        assert client.graphql.call_count == 2
+        assert client.graphql.call_args_list[0].args[1]["cursor"] is None
+        assert client.graphql.call_args_list[1].args[1]["cursor"] == "c1"
+
+    def test_extracts_priority_fields_and_closing_issues(self):
+        client = MagicMock()
+        client.graphql.return_value = {
+            "node": {
+                "items": {
+                    "pageInfo": {"hasNextPage": False, "endCursor": None},
+                    "nodes": [
+                        {
+                            "id": "PVTI_ISSUE",
+                            "priority": {"name": "Urgent"},
+                            "reviewPriority": None,
+                            "content": {"__typename": "Issue", "id": "I_1"},
+                        },
+                        {
+                            "id": "PVTI_PR",
+                            "priority": None,
+                            "reviewPriority": {"name": "High"},
+                            "content": {
+                                "__typename": "PullRequest",
+                                "id": "PR_1",
+                                "closingIssuesReferences": {
+                                    "nodes": [{"id": "I_1"}, {"id": "I_2"}]
+                                },
+                            },
+                        },
+                    ],
+                }
+            }
+        }
+        items = sync.list_board_priority_items(client, "PROJECT_ID")
+        assert items[0]["priority"]["name"] == "Urgent"
+        assert items[1]["reviewPriority"]["name"] == "High"
+        assert [
+            node["id"]
+            for node in items[1]["content"]["closingIssuesReferences"]["nodes"]
+        ] == ["I_1", "I_2"]
+
+
 def _priority_fields() -> sync.ProjectFields:
     return sync.ProjectFields(
         project_id="PROJECT",
@@ -430,6 +534,9 @@ class TestPriorityInherit:
     def test_highest_priority_empty_when_no_known_values(self):
         assert sync.highest_priority([]) is None
         assert sync.highest_priority([None, "unknown"]) is None
+
+    def test_highest_priority_ignores_unknown_in_mixed_list(self):
+        assert sync.highest_priority(["NotReal", "Low"]) == "Low"
 
     def test_copies_issue_priority_onto_empty_pr_fields(
         self, monkeypatch: pytest.MonkeyPatch


### PR DESCRIPTION
## Summary
- After adding items, copy **Priority** from linked issues onto PRs on [Compliance Automation planning](https://github.com/orgs/complytime/projects/14) (empty **Review priority** is filled with the same value so it shows on PRs in review)
- Source is `closingIssuesReferences` (`Fixes` / `Closes` / Development sidebar). If several issues are linked, the highest rank wins (Urgent > High > Medium > Low)
- No default: PRs with no linked issue, or whose issues have no Priority, stay unset. Existing PR values are not overwritten
- Runs in the existing 5-minute board sync (`sync_project_board.yml`). GitHub Actions in org-infra cannot subscribe to `pull_request` in other repositories; new PRs are picked up on the next tick

## Related Issues
- Follows from filling Priority on the PRs in review view from the linked issue, not a blanket Low

## Test plan
- [x] `pytest tests/test_sync_project_board.py` (30 passed)
- [ ] After merge, open a PR that `Closes` an issue with Priority High and confirm the PR item gets High within one 5-minute sync
- [ ] Confirm a PR with no linked issue stays unset
- [ ] Confirm a PR that already has Priority is not overwritten


Made with [Cursor](https://cursor.com)