### PR TITLE
feat(ci): inherit PR Review priority from linked issue Priority

### DIFF
--- a/CHANGELOG.md
+++ b/CHANGELOG.md
@@ -4,6 +4,12 @@
 
 ### Added
 
+- **Project board sync**: Fill empty **Review priority** on pull requests
+  from the linked closing issue's **Priority** (highest rank when several
+  issues are linked). Existing Review priority values are left alone so
+  reviewers can still override them; PRs without a parent Priority stay
+  empty.
+
 - **Stale review alerts**: Added `reusable_stale_reviews.yml` and
   `ci_stale_reviews.yml` to detect and flag PRs with review requests
   pending beyond a configurable business-day threshold. Applies a
@@ -20,12 +26,6 @@
   Baseline Level 1 compliance (OSPS-VM-02.01) across all org repositories.
 
 ### Changed
-
-- **Project board sync**: Fill empty **Review priority** on pull requests
-  from the linked closing issue's **Priority** (highest rank when several
-  issues are linked). Existing Review priority values are left alone so
-  reviewers can still override them; PRs without a parent Priority stay
-  empty.
 
 - **Project board sync**: Run the Compliance Automation planning board
   sync every 5 minutes instead of once daily. GitHub Actions does not

--- a/CHANGELOG.md
+++ b/CHANGELOG.md
@@ -21,6 +21,12 @@
 
 ### Changed
 
+- **Project board sync**: Fill empty **Review priority** on pull requests
+  from the linked closing issue's **Priority** (highest rank when several
+  issues are linked). Existing Review priority values are left alone so
+  reviewers can still override them; PRs without a parent Priority stay
+  empty.
+
 - **Project board sync**: Run the Compliance Automation planning board
   sync every 5 minutes instead of once daily. GitHub Actions does not
   honor a 1-minute cron; 5 minutes is the documented minimum. Concurrent

--- a/docs/PROJECT_BOARD_SYNC.md
+++ b/docs/PROJECT_BOARD_SYNC.md
@@ -23,6 +23,11 @@ delayed under GitHub load:
    cannot be linked (GitHub restriction) but their issues/PRs still sync.
 3. Collects open issues and open PRs
 4. Adds any missing items to the board with **Status = Backlog**
+5. Fills **Review priority** on pull requests when the field is empty and a
+   linked closing issue (`Fixes` / `Closes`) on the board has **Priority**.
+   Several linked issues use the highest rank (Urgent > High > Medium > Low).
+   An existing Review priority is never overwritten, so a human can still
+   change it. PRs with no parent Priority stay empty for hand review.
 
 The workflow lives only in `org-infra` (it is **not** synced out to consumer repos).
 

--- a/scripts/sync-project-board.py
+++ b/scripts/sync-project-board.py
@@ -56,7 +56,12 @@ class SyncStats:
     items_failed: int = 0
     review_priority_set: int = 0
     review_priority_failed: int = 0
+    review_priority_unmapped: int = 0
     errors: List[str] = field(default_factory=list)
+
+
+# How many closing-issue refs to fetch per PR. Warn when GitHub has more.
+CLOSING_ISSUES_PAGE_SIZE = 20
 
 
 class GitHubClient:
@@ -347,52 +352,6 @@ def list_open_items(
     return items
 
 
-def add_item(
-    client: GitHubClient,
-    project_id: str,
-    content_id: str,
-    status_field_id: Optional[str],
-    status_option_id: Optional[str],
-) -> None:
-    if client.dry_run:
-        print(f"  [dry-run] would add {content_id}")
-        return
-
-    data = client.graphql(
-        """
-        mutation($projectId: ID!, $contentId: ID!) {
-          addProjectV2ItemById(input: {projectId: $projectId, contentId: $contentId}) {
-            item { id }
-          }
-        }
-        """,
-        {"projectId": project_id, "contentId": content_id},
-    )
-    item_id = data["addProjectV2ItemById"]["item"]["id"]
-
-    if status_field_id and status_option_id:
-        client.graphql(
-            """
-            mutation($projectId: ID!, $itemId: ID!, $fieldId: ID!, $optionId: String!) {
-              updateProjectV2ItemFieldValue(input: {
-                projectId: $projectId
-                itemId: $itemId
-                fieldId: $fieldId
-                value: { singleSelectOptionId: $optionId }
-              }) {
-                projectV2Item { id }
-              }
-            }
-            """,
-            {
-                "projectId": project_id,
-                "itemId": item_id,
-                "fieldId": status_field_id,
-                "optionId": status_option_id,
-            },
-        )
-
-
 def set_single_select(
     client: GitHubClient,
     project_id: str,
@@ -426,12 +385,53 @@ def set_single_select(
     )
 
 
+def add_item(
+    client: GitHubClient,
+    project_id: str,
+    content_id: str,
+    status_field_id: Optional[str],
+    status_option_id: Optional[str],
+) -> None:
+    if client.dry_run:
+        print(f"  [dry-run] would add {content_id}")
+        return
+
+    data = client.graphql(
+        """
+        mutation($projectId: ID!, $contentId: ID!) {
+          addProjectV2ItemById(input: {projectId: $projectId, contentId: $contentId}) {
+            item { id }
+          }
+        }
+        """,
+        {"projectId": project_id, "contentId": content_id},
+    )
+    item_id = data["addProjectV2ItemById"]["item"]["id"]
+
+    if status_field_id and status_option_id:
+        set_single_select(
+            client, project_id, item_id, status_field_id, status_option_id
+        )
+
+
 def highest_priority_name(names: List[str]) -> Optional[str]:
     """Return the highest known Priority name, or None if none are ranked."""
     ranked = [name for name in names if name in PRIORITY_RANK]
     if not ranked:
         return None
     return max(ranked, key=lambda name: PRIORITY_RANK[name])
+
+
+def remember_highest_priority(
+    store: Dict[str, str], issue_id: str, priority_name: str
+) -> None:
+    """Keep the highest-ranked Priority if the same issue is seen twice."""
+    existing = store.get(issue_id)
+    winner = highest_priority_name(
+        [name for name in (existing, priority_name) if name]
+    )
+    if winner:
+        store[issue_id] = winner
 
 
 def list_board_items_for_review_priority(
@@ -459,7 +459,8 @@ def list_board_items_for_review_priority(
                   id
                   number
                   repository { nameWithOwner }
-                  closingIssuesReferences(first: 10) {
+                  closingIssuesReferences(first: __CLOSING_LIMIT__) {
+                    pageInfo { hasNextPage }
                     nodes { id }
                   }
                 }
@@ -470,6 +471,7 @@ def list_board_items_for_review_priority(
       }
     }
     """
+    query = query.replace("__CLOSING_LIMIT__", str(CLOSING_ISSUES_PAGE_SIZE))
     collected: List[Dict[str, Any]] = []
     cursor = None
     while True:
@@ -482,22 +484,23 @@ def list_board_items_for_review_priority(
     return collected
 
 
-def ensure_review_priority(
+def backfill_review_priority(
     client: GitHubClient,
     fields: ProjectFields,
     stats: SyncStats,
 ) -> None:
     """Fill empty PR Review priority from linked issues' Priority.
 
-    Only writes when Review priority is unset so a human override sticks.
-    If the PR has no closing issue on the board with Priority, the field is
-    left empty for manual review. Several linked issues use the highest rank.
+    Best-effort: only writes when Review priority is unset so a human
+    override sticks. If the PR has no closing issue on the board with
+    Priority, the field is left empty for manual review. Several linked
+    issues use the highest rank.
     """
     if not fields.review_priority_field_id or not fields.review_priority_options:
         print("Review priority field missing on project; skipping review-priority sync")
         return
 
-    print("\n=== Ensuring Review priority on PRs from linked issues ===")
+    print("\n=== Backfilling Review priority on PRs from linked issues ===")
     items = list_board_items_for_review_priority(client, fields.project_id)
 
     issue_priority: Dict[str, str] = {}
@@ -508,7 +511,7 @@ def ensure_review_priority(
         issue_id = content.get("id")
         priority_name = (node.get("priority") or {}).get("name")
         if issue_id and priority_name:
-            issue_priority[issue_id] = priority_name
+            remember_highest_priority(issue_priority, issue_id, priority_name)
 
     for node in items:
         content = node.get("content") or {}
@@ -517,10 +520,18 @@ def ensure_review_priority(
         current = (node.get("reviewPriority") or {}).get("name")
         if current:
             continue
-        closing = (content.get("closingIssuesReferences") or {}).get("nodes") or []
+        closing = content.get("closingIssuesReferences") or {}
+        repo = (content.get("repository") or {}).get("nameWithOwner") or "unknown"
+        number = content.get("number")
+        label = f"{repo}#{number}" if number is not None else repo
+        if (closing.get("pageInfo") or {}).get("hasNextPage"):
+            print(
+                f"  warning: closing issues truncated at "
+                f"{CLOSING_ISSUES_PAGE_SIZE} for {label}"
+            )
         parent_priorities = [
             issue_priority[ref["id"]]
-            for ref in closing
+            for ref in closing.get("nodes") or []
             if ref.get("id") in issue_priority
         ]
         target = highest_priority_name(parent_priorities)
@@ -528,11 +539,12 @@ def ensure_review_priority(
             continue
         option_id = fields.review_priority_options.get(target)
         if not option_id:
+            stats.review_priority_unmapped += 1
+            print(
+                f"  skip {label}: no Review priority option named '{target}'"
+            )
             continue
         item_id = node["id"]
-        repo = (content.get("repository") or {}).get("nameWithOwner") or "unknown"
-        number = content.get("number")
-        label = f"{repo}#{number}" if number is not None else repo
         try:
             set_single_select(
                 client,
@@ -565,6 +577,7 @@ def format_summary(stats: SyncStats, dry_run: bool) -> str:
         f"- Failed: **{stats.items_failed}**",
         f"- Review priority set: **{stats.review_priority_set}**",
         f"- Review priority failed: **{stats.review_priority_failed}**",
+        f"- Review priority unmapped: **{stats.review_priority_unmapped}**",
     ]
     if stats.errors:
         lines.extend(["", "### Errors", ""])
@@ -705,7 +718,7 @@ def sync(config: Dict[str, Any], client: GitHubClient, org_filter: Set[str]) -> 
                     print(f"  ! {msg}")
                     stats.errors.append(msg)
 
-    ensure_review_priority(client, fields, stats)
+    backfill_review_priority(client, fields, stats)
     return stats
 
 

--- a/scripts/sync-project-board.py
+++ b/scripts/sync-project-board.py
@@ -5,8 +5,11 @@
 
 Discovers repositories across one or more organizations, optionally links
 them to the target project, and adds any open issues/PRs that are not
-already on the board. Designed for cross-org boards where a single GitHub
-App installation token is insufficient (use a PAT with multi-org access).
+already on the board. Pull requests with an empty Review priority inherit
+it from the highest Priority among linked closing issues already on the
+board; existing Review priority values are never overwritten. Designed
+for cross-org boards where a single GitHub App installation token is
+insufficient (use a PAT with multi-org access).
 """
 
 from __future__ import annotations
@@ -17,7 +20,7 @@ import sys
 import time
 from dataclasses import dataclass, field
 from pathlib import Path
-from typing import Any, Dict, List, Optional, Set, Tuple
+from typing import Any, Dict, List, Optional, Set
 
 import requests
 import yaml
@@ -25,6 +28,15 @@ import yaml
 GITHUB_API = "https://api.github.com"
 GITHUB_GRAPHQL = f"{GITHUB_API}/graphql"
 DEFAULT_CONFIG = "project-sync-config.yml"
+
+# Rank used to pick Review priority when a PR closes several issues.
+# Names must match the Priority / Review priority single-select options.
+PRIORITY_RANK = {
+    "Urgent": 4,
+    "High": 3,
+    "Medium": 2,
+    "Low": 1,
+}
 
 # Expected failure modes while iterating orgs/repos (HTTP + explicit RuntimeError).
 # Keeps programming bugs (TypeError, KeyError, …) from being swallowed per item.
@@ -42,6 +54,8 @@ class SyncStats:
     items_already_on_board: int = 0
     items_added: int = 0
     items_failed: int = 0
+    review_priority_set: int = 0
+    review_priority_failed: int = 0
     errors: List[str] = field(default_factory=list)
 
 
@@ -183,10 +197,19 @@ def list_org_repos(
     return selected
 
 
-def get_project(
-    client: GitHubClient, owner: str, number: int
-) -> Tuple[str, Optional[str], Dict[str, str]]:
-    """Return project id, Status field id, and Status option name→id map."""
+@dataclass
+class ProjectFields:
+    """Resolved project id plus Status / Review priority single-select metadata."""
+
+    project_id: str
+    status_field_id: Optional[str]
+    status_options: Dict[str, str]
+    review_priority_field_id: Optional[str] = None
+    review_priority_options: Dict[str, str] = field(default_factory=dict)
+
+
+def get_project(client: GitHubClient, owner: str, number: int) -> ProjectFields:
+    """Return project id and Status / Review priority field metadata."""
     data = client.graphql(
         """
         query($owner: String!, $number: Int!) {
@@ -214,14 +237,27 @@ def get_project(
 
     status_field_id = None
     status_options: Dict[str, str] = {}
+    review_priority_field_id = None
+    review_priority_options: Dict[str, str] = {}
     for node in project["fields"]["nodes"]:
         if not node:
             continue
-        if node.get("name") == "Status":
+        name = node.get("name")
+        if name == "Status":
             status_field_id = node["id"]
             status_options = {opt["name"]: opt["id"] for opt in node.get("options", [])}
-            break
-    return project["id"], status_field_id, status_options
+        elif name == "Review priority":
+            review_priority_field_id = node["id"]
+            review_priority_options = {
+                opt["name"]: opt["id"] for opt in node.get("options", [])
+            }
+    return ProjectFields(
+        project_id=project["id"],
+        status_field_id=status_field_id,
+        status_options=status_options,
+        review_priority_field_id=review_priority_field_id,
+        review_priority_options=review_priority_options,
+    )
 
 
 def existing_content_ids(client: GitHubClient, project_id: str) -> Set[str]:
@@ -357,6 +393,163 @@ def add_item(
         )
 
 
+def set_single_select(
+    client: GitHubClient,
+    project_id: str,
+    item_id: str,
+    field_id: str,
+    option_id: str,
+) -> None:
+    """Set a project single-select field value."""
+    if client.dry_run:
+        print(f"  [dry-run] would set field {field_id}={option_id} on {item_id}")
+        return
+    client.graphql(
+        """
+        mutation($projectId: ID!, $itemId: ID!, $fieldId: ID!, $optionId: String!) {
+          updateProjectV2ItemFieldValue(input: {
+            projectId: $projectId
+            itemId: $itemId
+            fieldId: $fieldId
+            value: { singleSelectOptionId: $optionId }
+          }) {
+            projectV2Item { id }
+          }
+        }
+        """,
+        {
+            "projectId": project_id,
+            "itemId": item_id,
+            "fieldId": field_id,
+            "optionId": option_id,
+        },
+    )
+
+
+def highest_priority_name(names: List[str]) -> Optional[str]:
+    """Return the highest known Priority name, or None if none are ranked."""
+    ranked = [name for name in names if name in PRIORITY_RANK]
+    if not ranked:
+        return None
+    return max(ranked, key=lambda name: PRIORITY_RANK[name])
+
+
+def list_board_items_for_review_priority(
+    client: GitHubClient, project_id: str
+) -> List[Dict[str, Any]]:
+    """Return board items with Priority, Review priority, and PR closing issues."""
+    query = """
+    query($projectId: ID!, $cursor: String) {
+      node(id: $projectId) {
+        ... on ProjectV2 {
+          items(first: 100, after: $cursor) {
+            pageInfo { hasNextPage endCursor }
+            nodes {
+              id
+              reviewPriority: fieldValueByName(name: "Review priority") {
+                ... on ProjectV2ItemFieldSingleSelectValue { name }
+              }
+              priority: fieldValueByName(name: "Priority") {
+                ... on ProjectV2ItemFieldSingleSelectValue { name }
+              }
+              content {
+                __typename
+                ... on Issue { id }
+                ... on PullRequest {
+                  id
+                  number
+                  repository { nameWithOwner }
+                  closingIssuesReferences(first: 10) {
+                    nodes { id }
+                  }
+                }
+              }
+            }
+          }
+        }
+      }
+    }
+    """
+    collected: List[Dict[str, Any]] = []
+    cursor = None
+    while True:
+        data = client.graphql(query, {"projectId": project_id, "cursor": cursor})
+        items = data["node"]["items"]
+        collected.extend(items["nodes"])
+        if not items["pageInfo"]["hasNextPage"]:
+            break
+        cursor = items["pageInfo"]["endCursor"]
+    return collected
+
+
+def ensure_review_priority(
+    client: GitHubClient,
+    fields: ProjectFields,
+    stats: SyncStats,
+) -> None:
+    """Fill empty PR Review priority from linked issues' Priority.
+
+    Only writes when Review priority is unset so a human override sticks.
+    If the PR has no closing issue on the board with Priority, the field is
+    left empty for manual review. Several linked issues use the highest rank.
+    """
+    if not fields.review_priority_field_id or not fields.review_priority_options:
+        print("Review priority field missing on project; skipping review-priority sync")
+        return
+
+    print("\n=== Ensuring Review priority on PRs from linked issues ===")
+    items = list_board_items_for_review_priority(client, fields.project_id)
+
+    issue_priority: Dict[str, str] = {}
+    for node in items:
+        content = node.get("content") or {}
+        if content.get("__typename") != "Issue":
+            continue
+        issue_id = content.get("id")
+        priority_name = (node.get("priority") or {}).get("name")
+        if issue_id and priority_name:
+            issue_priority[issue_id] = priority_name
+
+    for node in items:
+        content = node.get("content") or {}
+        if content.get("__typename") != "PullRequest":
+            continue
+        current = (node.get("reviewPriority") or {}).get("name")
+        if current:
+            continue
+        closing = (content.get("closingIssuesReferences") or {}).get("nodes") or []
+        parent_priorities = [
+            issue_priority[ref["id"]]
+            for ref in closing
+            if ref.get("id") in issue_priority
+        ]
+        target = highest_priority_name(parent_priorities)
+        if not target:
+            continue
+        option_id = fields.review_priority_options.get(target)
+        if not option_id:
+            continue
+        item_id = node["id"]
+        repo = (content.get("repository") or {}).get("nameWithOwner") or "unknown"
+        number = content.get("number")
+        label = f"{repo}#{number}" if number is not None else repo
+        try:
+            set_single_select(
+                client,
+                fields.project_id,
+                item_id,
+                fields.review_priority_field_id,
+                option_id,
+            )
+            stats.review_priority_set += 1
+            print(f"  review-priority {label} -> {target}")
+        except SYNC_EXCEPTIONS as exc:
+            stats.review_priority_failed += 1
+            msg = f"Failed setting Review priority on {label}: {exc}"
+            print(f"  ! {msg}")
+            stats.errors.append(msg)
+
+
 def format_summary(stats: SyncStats, dry_run: bool) -> str:
     """Format the job summary markdown (pure; no I/O)."""
     lines = [
@@ -370,6 +563,8 @@ def format_summary(stats: SyncStats, dry_run: bool) -> str:
         f"- Already on board: **{stats.items_already_on_board}**",
         f"- Added: **{stats.items_added}**",
         f"- Failed: **{stats.items_failed}**",
+        f"- Review priority set: **{stats.review_priority_set}**",
+        f"- Review priority failed: **{stats.review_priority_failed}**",
     ]
     if stats.errors:
         lines.extend(["", "### Errors", ""])
@@ -399,12 +594,20 @@ def sync(config: Dict[str, Any], client: GitHubClient, org_filter: Set[str]) -> 
     skip_archived = bool(sync_cfg.get("skip_archived", True))
     link_repos = bool(sync_cfg.get("link_repositories", True))
 
-    project_id, status_field_id, status_options = get_project(client, owner, number)
+    fields = get_project(client, owner, number)
+    project_id = fields.project_id
+    status_field_id = fields.status_field_id
+    status_options = fields.status_options
     status_option_id = status_options.get(default_status) if status_options else None
     if default_status and status_field_id and not status_option_id:
         print(
             f"Warning: Status option '{default_status}' not found; "
             "items will be added without a Status value"
+        )
+    if not fields.review_priority_field_id:
+        print(
+            "Warning: Review priority field not found; "
+            "PRs will not inherit priority from linked issues"
         )
 
     print(f"Project {owner}/{number} id={project_id}")
@@ -502,6 +705,7 @@ def sync(config: Dict[str, Any], client: GitHubClient, org_filter: Set[str]) -> 
                     print(f"  ! {msg}")
                     stats.errors.append(msg)
 
+    ensure_review_priority(client, fields, stats)
     return stats
 
 

--- a/tests/test_sync_project_board.py
+++ b/tests/test_sync_project_board.py
@@ -164,6 +164,9 @@ class TestFormatAndWriteSummary:
         assert "skipped/already linked: 2" in text
         assert "**5**" in text
         assert "`boom`" in text
+        assert "Review priority set: **0**" in text
+        assert "Review priority failed: **0**" in text
+        assert "Review priority unmapped: **0**" in text
 
     def test_write_summary_appends_step_summary(self, tmp_path: Path, monkeypatch):
         summary_path = tmp_path / "summary.md"
@@ -251,7 +254,7 @@ class TestSyncErrorHandling:
             ),
         )
         monkeypatch.setattr(sync, "existing_content_ids", lambda *_a, **_k: set())
-        monkeypatch.setattr(sync, "ensure_review_priority", lambda *_a, **_k: None)
+        monkeypatch.setattr(sync, "backfill_review_priority", lambda *_a, **_k: None)
 
     def test_per_org_request_errors_are_recorded(self, monkeypatch: pytest.MonkeyPatch):
         self._project_mocks(monkeypatch)
@@ -402,7 +405,7 @@ class TestLinkRepository:
 
 
 class TestReviewPriority:
-    def _fields(self) -> Any:
+    def _fields(self) -> sync.ProjectFields:
         return sync.ProjectFields(
             project_id="PROJECT",
             status_field_id="STATUS_FIELD",
@@ -429,7 +432,7 @@ class TestReviewPriority:
     def test_highest_priority_name(self, names: list, expected: Optional[str]):
         assert sync.highest_priority_name(names) == expected
 
-    def test_ensure_review_priority_fills_empty_from_linked_issue(
+    def test_backfill_review_priority_fills_empty_from_linked_issue(
         self, monkeypatch: pytest.MonkeyPatch
     ):
         client = MagicMock(dry_run=False)
@@ -464,7 +467,7 @@ class TestReviewPriority:
 
         monkeypatch.setattr(sync, "set_single_select", _set)
         stats = sync.SyncStats()
-        sync.ensure_review_priority(client, self._fields(), stats)
+        sync.backfill_review_priority(client, self._fields(), stats)
         assert stats.review_priority_set == 1
         assert stats.review_priority_failed == 0
         assert len(set_calls) == 1
@@ -472,7 +475,7 @@ class TestReviewPriority:
         assert set_calls[0][0][3] == "RP_FIELD"
         assert set_calls[0][0][4] == "RP_H"
 
-    def test_ensure_review_priority_does_not_overwrite_existing(
+    def test_backfill_review_priority_does_not_overwrite_existing(
         self, monkeypatch: pytest.MonkeyPatch
     ):
         client = MagicMock(dry_run=False)
@@ -503,11 +506,11 @@ class TestReviewPriority:
         set_fn = MagicMock()
         monkeypatch.setattr(sync, "set_single_select", set_fn)
         stats = sync.SyncStats()
-        sync.ensure_review_priority(client, self._fields(), stats)
+        sync.backfill_review_priority(client, self._fields(), stats)
         set_fn.assert_not_called()
         assert stats.review_priority_set == 0
 
-    def test_ensure_review_priority_leaves_empty_without_parent_priority(
+    def test_backfill_review_priority_leaves_empty_without_parent_priority(
         self, monkeypatch: pytest.MonkeyPatch
     ):
         client = MagicMock(dry_run=False)
@@ -550,11 +553,11 @@ class TestReviewPriority:
         set_fn = MagicMock()
         monkeypatch.setattr(sync, "set_single_select", set_fn)
         stats = sync.SyncStats()
-        sync.ensure_review_priority(client, self._fields(), stats)
+        sync.backfill_review_priority(client, self._fields(), stats)
         set_fn.assert_not_called()
         assert stats.review_priority_set == 0
 
-    def test_ensure_review_priority_uses_highest_of_several_parents(
+    def test_backfill_review_priority_uses_highest_of_several_parents(
         self, monkeypatch: pytest.MonkeyPatch
     ):
         client = MagicMock(dry_run=False)
@@ -595,11 +598,11 @@ class TestReviewPriority:
             sync, "set_single_select", lambda *args, **kwargs: set_calls.append(args)
         )
         stats = sync.SyncStats()
-        sync.ensure_review_priority(client, self._fields(), stats)
+        sync.backfill_review_priority(client, self._fields(), stats)
         assert stats.review_priority_set == 1
         assert set_calls[0][4] == "RP_U"
 
-    def test_ensure_review_priority_write_failure_is_best_effort(
+    def test_backfill_review_priority_write_failure_is_best_effort(
         self, monkeypatch: pytest.MonkeyPatch
     ):
         client = MagicMock(dry_run=False)
@@ -633,12 +636,12 @@ class TestReviewPriority:
             MagicMock(side_effect=RuntimeError("INSUFFICIENT_SCOPES")),
         )
         stats = sync.SyncStats()
-        sync.ensure_review_priority(client, self._fields(), stats)
+        sync.backfill_review_priority(client, self._fields(), stats)
         assert stats.review_priority_set == 0
         assert stats.review_priority_failed == 1
         assert any("Failed setting Review priority" in err for err in stats.errors)
 
-    def test_ensure_review_priority_skips_when_field_missing(
+    def test_backfill_review_priority_skips_when_field_missing(
         self, monkeypatch: pytest.MonkeyPatch
     ):
         client = MagicMock(dry_run=False)
@@ -650,8 +653,173 @@ class TestReviewPriority:
             status_options={"Backlog": "OPT"},
         )
         stats = sync.SyncStats()
-        sync.ensure_review_priority(client, fields, stats)
+        sync.backfill_review_priority(client, fields, stats)
         list_fn.assert_not_called()
+
+    def test_remember_highest_priority_keeps_max_rank_on_duplicates(self):
+        store: Dict[str, str] = {}
+        sync.remember_highest_priority(store, "I_1", "Low")
+        sync.remember_highest_priority(store, "I_1", "Urgent")
+        sync.remember_highest_priority(store, "I_1", "Medium")
+        assert store["I_1"] == "Urgent"
+
+    def test_backfill_review_priority_uses_highest_duplicate_issue_item(
+        self, monkeypatch: pytest.MonkeyPatch
+    ):
+        client = MagicMock(dry_run=False)
+        monkeypatch.setattr(
+            sync,
+            "list_board_items_for_review_priority",
+            lambda *_a, **_k: [
+                {
+                    "id": "PVTI_I1_LOW",
+                    "priority": {"name": "Low"},
+                    "content": {"__typename": "Issue", "id": "I_1"},
+                },
+                {
+                    "id": "PVTI_I1_HIGH",
+                    "priority": {"name": "High"},
+                    "content": {"__typename": "Issue", "id": "I_1"},
+                },
+                {
+                    "id": "PVTI_PR",
+                    "reviewPriority": None,
+                    "content": {
+                        "__typename": "PullRequest",
+                        "id": "PR_1",
+                        "number": 4,
+                        "repository": {"nameWithOwner": "complytime/demo"},
+                        "closingIssuesReferences": {"nodes": [{"id": "I_1"}]},
+                    },
+                },
+            ],
+        )
+        set_calls = []
+        monkeypatch.setattr(
+            sync, "set_single_select", lambda *args, **_k: set_calls.append(args)
+        )
+        stats = sync.SyncStats()
+        sync.backfill_review_priority(client, self._fields(), stats)
+        assert stats.review_priority_set == 1
+        assert set_calls[0][4] == "RP_H"
+
+    def test_backfill_review_priority_logs_unmapped_option(
+        self, monkeypatch: pytest.MonkeyPatch, capsys: pytest.CaptureFixture[str]
+    ):
+        client = MagicMock(dry_run=False)
+        monkeypatch.setattr(
+            sync,
+            "list_board_items_for_review_priority",
+            lambda *_a, **_k: [
+                {
+                    "id": "PVTI_ISSUE",
+                    "priority": {"name": "High"},
+                    "content": {"__typename": "Issue", "id": "I_1"},
+                },
+                {
+                    "id": "PVTI_PR",
+                    "reviewPriority": None,
+                    "content": {
+                        "__typename": "PullRequest",
+                        "id": "PR_1",
+                        "number": 5,
+                        "repository": {"nameWithOwner": "complytime/demo"},
+                        "closingIssuesReferences": {"nodes": [{"id": "I_1"}]},
+                    },
+                },
+            ],
+        )
+        fields = self._fields()
+        fields.review_priority_options = {"Low": "RP_L"}
+        set_fn = MagicMock()
+        monkeypatch.setattr(sync, "set_single_select", set_fn)
+        stats = sync.SyncStats()
+        sync.backfill_review_priority(client, fields, stats)
+        set_fn.assert_not_called()
+        assert stats.review_priority_unmapped == 1
+        assert stats.review_priority_set == 0
+        captured = capsys.readouterr()
+        assert "no Review priority option named 'High'" in captured.out
+
+    def test_backfill_review_priority_warns_when_closing_issues_truncated(
+        self, monkeypatch: pytest.MonkeyPatch, capsys: pytest.CaptureFixture[str]
+    ):
+        client = MagicMock(dry_run=False)
+        monkeypatch.setattr(
+            sync,
+            "list_board_items_for_review_priority",
+            lambda *_a, **_k: [
+                {
+                    "id": "PVTI_ISSUE",
+                    "priority": {"name": "Medium"},
+                    "content": {"__typename": "Issue", "id": "I_1"},
+                },
+                {
+                    "id": "PVTI_PR",
+                    "reviewPriority": None,
+                    "content": {
+                        "__typename": "PullRequest",
+                        "id": "PR_1",
+                        "number": 6,
+                        "repository": {"nameWithOwner": "complytime/demo"},
+                        "closingIssuesReferences": {
+                            "pageInfo": {"hasNextPage": True},
+                            "nodes": [{"id": "I_1"}],
+                        },
+                    },
+                },
+            ],
+        )
+        monkeypatch.setattr(sync, "set_single_select", lambda *_a, **_k: None)
+        stats = sync.SyncStats()
+        sync.backfill_review_priority(client, self._fields(), stats)
+        captured = capsys.readouterr()
+        assert "closing issues truncated" in captured.out
+        assert stats.review_priority_set == 1
+
+    def test_backfill_review_priority_dry_run_does_not_write(
+        self, monkeypatch: pytest.MonkeyPatch, capsys: pytest.CaptureFixture[str]
+    ):
+        client = MagicMock(dry_run=True)
+        monkeypatch.setattr(
+            sync,
+            "list_board_items_for_review_priority",
+            lambda *_a, **_k: [
+                {
+                    "id": "PVTI_ISSUE",
+                    "priority": {"name": "High"},
+                    "content": {"__typename": "Issue", "id": "I_1"},
+                },
+                {
+                    "id": "PVTI_PR",
+                    "reviewPriority": None,
+                    "content": {
+                        "__typename": "PullRequest",
+                        "id": "PR_1",
+                        "number": 11,
+                        "repository": {"nameWithOwner": "complytime/demo"},
+                        "closingIssuesReferences": {"nodes": [{"id": "I_1"}]},
+                    },
+                },
+            ],
+        )
+        stats = sync.SyncStats()
+        sync.backfill_review_priority(client, self._fields(), stats)
+        client.graphql.assert_not_called()
+        assert stats.review_priority_set == 1
+        captured = capsys.readouterr()
+        assert "[dry-run] would set field" in captured.out
+
+    def test_add_item_sets_status_via_set_single_select(self):
+        client = MagicMock(dry_run=False)
+        client.graphql.return_value = {
+            "addProjectV2ItemById": {"item": {"id": "ITEM_1"}}
+        }
+        sync.add_item(client, "PROJECT", "CONTENT", "STATUS_FIELD", "STATUS_OPT")
+        assert client.graphql.call_count == 2
+        status_vars = client.graphql.call_args_list[1].args[1]
+        assert status_vars["fieldId"] == "STATUS_FIELD"
+        assert status_vars["optionId"] == "STATUS_OPT"
 
     def test_list_board_items_for_review_priority_paginates(self):
         client = MagicMock()
@@ -677,6 +845,9 @@ class TestReviewPriority:
         assert [node["id"] for node in items] == ["PVTI_1", "PVTI_2"]
         assert client.graphql.call_count == 2
         assert client.graphql.call_args_list[1].args[1]["cursor"] == "c1"
+        query = client.graphql.call_args_list[0].args[0]
+        assert f"first: {sync.CLOSING_ISSUES_PAGE_SIZE}" in query
+        assert "pageInfo { hasNextPage }" in query
 
     def test_get_project_resolves_review_priority_field(self):
         client = MagicMock()
@@ -727,7 +898,7 @@ class TestReviewPriority:
         )
         monkeypatch.setattr(sync, "existing_content_ids", lambda *_a, **_k: set())
         ensure_rp = MagicMock()
-        monkeypatch.setattr(sync, "ensure_review_priority", ensure_rp)
+        monkeypatch.setattr(sync, "backfill_review_priority", ensure_rp)
         monkeypatch.setattr(sync, "link_repository", MagicMock(return_value=True))
         monkeypatch.setattr(
             sync,

--- a/tests/test_sync_project_board.py
+++ b/tests/test_sync_project_board.py
@@ -242,9 +242,16 @@ class TestSyncErrorHandling:
         monkeypatch.setattr(
             sync,
             "get_project",
-            lambda *_a, **_k: ("PROJECT", "STATUS_FIELD", {"Backlog": "OPT"}),
+            lambda *_a, **_k: sync.ProjectFields(
+                project_id="PROJECT",
+                status_field_id="STATUS_FIELD",
+                status_options={"Backlog": "OPT"},
+                review_priority_field_id="RP_FIELD",
+                review_priority_options={"High": "RP_H"},
+            ),
         )
         monkeypatch.setattr(sync, "existing_content_ids", lambda *_a, **_k: set())
+        monkeypatch.setattr(sync, "ensure_review_priority", lambda *_a, **_k: None)
 
     def test_per_org_request_errors_are_recorded(self, monkeypatch: pytest.MonkeyPatch):
         self._project_mocks(monkeypatch)
@@ -392,3 +399,354 @@ class TestLinkRepository:
         client = MagicMock(dry_run=False)
         client.graphql.side_effect = RuntimeError("already linked to project")
         assert sync.link_repository(client, "P", "R") is False
+
+
+class TestReviewPriority:
+    def _fields(self) -> Any:
+        return sync.ProjectFields(
+            project_id="PROJECT",
+            status_field_id="STATUS_FIELD",
+            status_options={"Backlog": "OPT"},
+            review_priority_field_id="RP_FIELD",
+            review_priority_options={
+                "Urgent": "RP_U",
+                "High": "RP_H",
+                "Medium": "RP_M",
+                "Low": "RP_L",
+            },
+        )
+
+    @pytest.mark.parametrize(
+        "names,expected",
+        [
+            ([], None),
+            (["unknown"], None),
+            (["Medium"], "Medium"),
+            (["Low", "High", "Medium"], "High"),
+            (["High", "Urgent"], "Urgent"),
+        ],
+    )
+    def test_highest_priority_name(self, names: list, expected: Optional[str]):
+        assert sync.highest_priority_name(names) == expected
+
+    def test_ensure_review_priority_fills_empty_from_linked_issue(
+        self, monkeypatch: pytest.MonkeyPatch
+    ):
+        client = MagicMock(dry_run=False)
+        monkeypatch.setattr(
+            sync,
+            "list_board_items_for_review_priority",
+            lambda *_a, **_k: [
+                {
+                    "id": "PVTI_ISSUE",
+                    "priority": {"name": "High"},
+                    "reviewPriority": None,
+                    "content": {"__typename": "Issue", "id": "I_1"},
+                },
+                {
+                    "id": "PVTI_PR",
+                    "priority": None,
+                    "reviewPriority": None,
+                    "content": {
+                        "__typename": "PullRequest",
+                        "id": "PR_1",
+                        "number": 42,
+                        "repository": {"nameWithOwner": "complytime/demo"},
+                        "closingIssuesReferences": {"nodes": [{"id": "I_1"}]},
+                    },
+                },
+            ],
+        )
+        set_calls = []
+
+        def _set(*args, **kwargs):
+            set_calls.append((args, kwargs))
+
+        monkeypatch.setattr(sync, "set_single_select", _set)
+        stats = sync.SyncStats()
+        sync.ensure_review_priority(client, self._fields(), stats)
+        assert stats.review_priority_set == 1
+        assert stats.review_priority_failed == 0
+        assert len(set_calls) == 1
+        assert set_calls[0][0][2] == "PVTI_PR"
+        assert set_calls[0][0][3] == "RP_FIELD"
+        assert set_calls[0][0][4] == "RP_H"
+
+    def test_ensure_review_priority_does_not_overwrite_existing(
+        self, monkeypatch: pytest.MonkeyPatch
+    ):
+        client = MagicMock(dry_run=False)
+        monkeypatch.setattr(
+            sync,
+            "list_board_items_for_review_priority",
+            lambda *_a, **_k: [
+                {
+                    "id": "PVTI_ISSUE",
+                    "priority": {"name": "Urgent"},
+                    "reviewPriority": None,
+                    "content": {"__typename": "Issue", "id": "I_1"},
+                },
+                {
+                    "id": "PVTI_PR",
+                    "priority": None,
+                    "reviewPriority": {"name": "Low"},
+                    "content": {
+                        "__typename": "PullRequest",
+                        "id": "PR_1",
+                        "number": 42,
+                        "repository": {"nameWithOwner": "complytime/demo"},
+                        "closingIssuesReferences": {"nodes": [{"id": "I_1"}]},
+                    },
+                },
+            ],
+        )
+        set_fn = MagicMock()
+        monkeypatch.setattr(sync, "set_single_select", set_fn)
+        stats = sync.SyncStats()
+        sync.ensure_review_priority(client, self._fields(), stats)
+        set_fn.assert_not_called()
+        assert stats.review_priority_set == 0
+
+    def test_ensure_review_priority_leaves_empty_without_parent_priority(
+        self, monkeypatch: pytest.MonkeyPatch
+    ):
+        client = MagicMock(dry_run=False)
+        monkeypatch.setattr(
+            sync,
+            "list_board_items_for_review_priority",
+            lambda *_a, **_k: [
+                {
+                    "id": "PVTI_ISSUE",
+                    "priority": None,
+                    "reviewPriority": None,
+                    "content": {"__typename": "Issue", "id": "I_1"},
+                },
+                {
+                    "id": "PVTI_PR_UNLINKED",
+                    "priority": None,
+                    "reviewPriority": None,
+                    "content": {
+                        "__typename": "PullRequest",
+                        "id": "PR_1",
+                        "number": 7,
+                        "repository": {"nameWithOwner": "complytime/demo"},
+                        "closingIssuesReferences": {"nodes": []},
+                    },
+                },
+                {
+                    "id": "PVTI_PR_NO_PRIORITY",
+                    "priority": None,
+                    "reviewPriority": None,
+                    "content": {
+                        "__typename": "PullRequest",
+                        "id": "PR_2",
+                        "number": 8,
+                        "repository": {"nameWithOwner": "complytime/demo"},
+                        "closingIssuesReferences": {"nodes": [{"id": "I_1"}]},
+                    },
+                },
+            ],
+        )
+        set_fn = MagicMock()
+        monkeypatch.setattr(sync, "set_single_select", set_fn)
+        stats = sync.SyncStats()
+        sync.ensure_review_priority(client, self._fields(), stats)
+        set_fn.assert_not_called()
+        assert stats.review_priority_set == 0
+
+    def test_ensure_review_priority_uses_highest_of_several_parents(
+        self, monkeypatch: pytest.MonkeyPatch
+    ):
+        client = MagicMock(dry_run=False)
+        monkeypatch.setattr(
+            sync,
+            "list_board_items_for_review_priority",
+            lambda *_a, **_k: [
+                {
+                    "id": "PVTI_I1",
+                    "priority": {"name": "Low"},
+                    "reviewPriority": None,
+                    "content": {"__typename": "Issue", "id": "I_1"},
+                },
+                {
+                    "id": "PVTI_I2",
+                    "priority": {"name": "Urgent"},
+                    "reviewPriority": None,
+                    "content": {"__typename": "Issue", "id": "I_2"},
+                },
+                {
+                    "id": "PVTI_PR",
+                    "priority": None,
+                    "reviewPriority": None,
+                    "content": {
+                        "__typename": "PullRequest",
+                        "id": "PR_1",
+                        "number": 9,
+                        "repository": {"nameWithOwner": "complytime/demo"},
+                        "closingIssuesReferences": {
+                            "nodes": [{"id": "I_1"}, {"id": "I_2"}]
+                        },
+                    },
+                },
+            ],
+        )
+        set_calls = []
+        monkeypatch.setattr(
+            sync, "set_single_select", lambda *args, **kwargs: set_calls.append(args)
+        )
+        stats = sync.SyncStats()
+        sync.ensure_review_priority(client, self._fields(), stats)
+        assert stats.review_priority_set == 1
+        assert set_calls[0][4] == "RP_U"
+
+    def test_ensure_review_priority_write_failure_is_best_effort(
+        self, monkeypatch: pytest.MonkeyPatch
+    ):
+        client = MagicMock(dry_run=False)
+        monkeypatch.setattr(
+            sync,
+            "list_board_items_for_review_priority",
+            lambda *_a, **_k: [
+                {
+                    "id": "PVTI_ISSUE",
+                    "priority": {"name": "Medium"},
+                    "reviewPriority": None,
+                    "content": {"__typename": "Issue", "id": "I_1"},
+                },
+                {
+                    "id": "PVTI_PR",
+                    "priority": None,
+                    "reviewPriority": None,
+                    "content": {
+                        "__typename": "PullRequest",
+                        "id": "PR_1",
+                        "number": 3,
+                        "repository": {"nameWithOwner": "complytime/demo"},
+                        "closingIssuesReferences": {"nodes": [{"id": "I_1"}]},
+                    },
+                },
+            ],
+        )
+        monkeypatch.setattr(
+            sync,
+            "set_single_select",
+            MagicMock(side_effect=RuntimeError("INSUFFICIENT_SCOPES")),
+        )
+        stats = sync.SyncStats()
+        sync.ensure_review_priority(client, self._fields(), stats)
+        assert stats.review_priority_set == 0
+        assert stats.review_priority_failed == 1
+        assert any("Failed setting Review priority" in err for err in stats.errors)
+
+    def test_ensure_review_priority_skips_when_field_missing(
+        self, monkeypatch: pytest.MonkeyPatch
+    ):
+        client = MagicMock(dry_run=False)
+        list_fn = MagicMock()
+        monkeypatch.setattr(sync, "list_board_items_for_review_priority", list_fn)
+        fields = sync.ProjectFields(
+            project_id="PROJECT",
+            status_field_id="STATUS_FIELD",
+            status_options={"Backlog": "OPT"},
+        )
+        stats = sync.SyncStats()
+        sync.ensure_review_priority(client, fields, stats)
+        list_fn.assert_not_called()
+
+    def test_list_board_items_for_review_priority_paginates(self):
+        client = MagicMock()
+        client.graphql.side_effect = [
+            {
+                "node": {
+                    "items": {
+                        "pageInfo": {"hasNextPage": True, "endCursor": "c1"},
+                        "nodes": [{"id": "PVTI_1"}],
+                    }
+                }
+            },
+            {
+                "node": {
+                    "items": {
+                        "pageInfo": {"hasNextPage": False, "endCursor": "c2"},
+                        "nodes": [{"id": "PVTI_2"}],
+                    }
+                }
+            },
+        ]
+        items = sync.list_board_items_for_review_priority(client, "PROJECT_ID")
+        assert [node["id"] for node in items] == ["PVTI_1", "PVTI_2"]
+        assert client.graphql.call_count == 2
+        assert client.graphql.call_args_list[1].args[1]["cursor"] == "c1"
+
+    def test_get_project_resolves_review_priority_field(self):
+        client = MagicMock()
+        client.graphql.return_value = {
+            "organization": {
+                "projectV2": {
+                    "id": "PROJECT",
+                    "fields": {
+                        "nodes": [
+                            {
+                                "id": "STATUS_FIELD",
+                                "name": "Status",
+                                "options": [{"id": "S1", "name": "Backlog"}],
+                            },
+                            {
+                                "id": "RP_FIELD",
+                                "name": "Review priority",
+                                "options": [
+                                    {"id": "RP_H", "name": "High"},
+                                    {"id": "RP_L", "name": "Low"},
+                                ],
+                            },
+                            None,
+                        ]
+                    },
+                }
+            }
+        }
+        fields = sync.get_project(client, "complytime", 14)
+        assert fields.project_id == "PROJECT"
+        assert fields.status_field_id == "STATUS_FIELD"
+        assert fields.review_priority_field_id == "RP_FIELD"
+        assert fields.review_priority_options == {"High": "RP_H", "Low": "RP_L"}
+
+    def test_sync_always_runs_review_priority_backfill(
+        self, monkeypatch: pytest.MonkeyPatch
+    ):
+        monkeypatch.setattr(
+            sync,
+            "get_project",
+            lambda *_a, **_k: sync.ProjectFields(
+                project_id="PROJECT",
+                status_field_id="STATUS_FIELD",
+                status_options={"Backlog": "OPT"},
+                review_priority_field_id="RP_FIELD",
+                review_priority_options={"High": "RP_H"},
+            ),
+        )
+        monkeypatch.setattr(sync, "existing_content_ids", lambda *_a, **_k: set())
+        ensure_rp = MagicMock()
+        monkeypatch.setattr(sync, "ensure_review_priority", ensure_rp)
+        monkeypatch.setattr(sync, "link_repository", MagicMock(return_value=True))
+        monkeypatch.setattr(
+            sync,
+            "list_org_repos",
+            MagicMock(
+                return_value=[
+                    {
+                        "name": "demo",
+                        "full_name": "complytime/demo",
+                        "node_id": "R_1",
+                        "archived": False,
+                    }
+                ]
+            ),
+        )
+        monkeypatch.setattr(sync, "list_open_items", MagicMock(return_value=[]))
+        sync.sync(
+            _minimal_config(),
+            MagicMock(dry_run=False),
+            org_filter={"complytime"},
+        )
+        ensure_rp.assert_called_once()


### PR DESCRIPTION
## Summary
- Fill empty **Review priority** on Compliance Automation planning PRs from the linked closing issue's **Priority** (`Fixes` / `Closes`).
- Leave an existing Review priority alone so it can still be changed by hand; leave it empty when there is no parent Priority.
- Several linked issues use the highest rank (Urgent > High > Medium > Low).

## Test plan
- [ ] `python3 -m pytest tests/test_sync_project_board.py -v`
- [ ] After merge, confirm a PR that closes a High-priority issue gets Review priority = High on [PRs in review](https://github.com/orgs/complytime/projects/14/views/10)
- [ ] Confirm a PR with Review priority already set is not overwritten
- [ ] Confirm a PR with no closing issue (or an issue without Priority) stays empty


Made with [Cursor](https://cursor.com)