### PR TITLE
feat: assign Evidence Locker MVP reviewers from peribolos team

### DIFF
--- a/.github/workflows/assign_milestone_reviewers.yml
+++ b/.github/workflows/assign_milestone_reviewers.yml
@@ -1,0 +1,74 @@
+# SPDX-License-Identifier: Apache-2.0
+#
+# Assign members of complytime/evidence-locker-mvp-reviewers to open
+# issues and pull requests whose milestone is Evidence Locker MVP.
+# Team membership is read from complytime/.github peribolos.yaml.
+# See docs/MILESTONE_REVIEWERS.md.
+
+name: Assign Evidence Locker MVP Reviewers
+
+on:
+  workflow_dispatch:
+    inputs:
+      dry_run:
+        description: "Preview assignments without applying them"
+        required: false
+        type: boolean
+        default: true
+  schedule:
+    # GitHub Actions does not honor intervals shorter than 5 minutes.
+    - cron: "*/15 * * * *"
+
+permissions:
+  contents: read
+
+concurrency:
+  group: assign-milestone-reviewers
+  cancel-in-progress: false
+
+jobs:
+  assign-reviewers:
+    if: github.repository_owner == 'complytime'
+    name: Assign milestone reviewers
+    runs-on: ubuntu-latest
+    timeout-minutes: 15
+    permissions:
+      contents: read
+    steps:
+      - name: Checkout org-infra
+        uses: actions/checkout@3d3c42e5aac5ba805825da76410c181273ba90b1 # v7.0.1
+        with:
+          fetch-depth: 1
+          persist-credentials: false
+
+      - name: Set up Python
+        uses: actions/setup-python@5fda3b95a4ea91299a34e894583c3862153e4b97 # v7.0.0
+        with:
+          python-version: "3.11"
+          cache: "pip"
+
+      - name: Install dependencies
+        run: python -m pip install --upgrade pip && pip install -r requirements.txt
+
+      - name: Generate GitHub App Token
+        id: generate-token
+        uses: actions/create-github-app-token@bcd2ba49218906704ab6c1aa796996da409d3eb1 # v3.2.0
+        with:
+          client-id: ${{ secrets.SYNC_APP_CLIENT_ID }}
+          private-key: ${{ secrets.SYNC_APP_PRIVATE_KEY }}
+          owner: ${{ github.repository_owner }} # zizmor: ignore[github-app]
+          permission-contents: read
+          permission-issues: write
+          permission-pull-requests: write
+
+      - name: Assign reviewers
+        env:
+          GITHUB_TOKEN: ${{ steps.generate-token.outputs.token }}
+          DRY_RUN: ${{ inputs.dry_run || false }}
+        run: |
+          set -euo pipefail
+          ARGS=(--config milestone-reviewers-config.yml)
+          if [ "$DRY_RUN" = "true" ]; then
+            ARGS+=(--dry-run)
+          fi
+          python3 scripts/assign-milestone-reviewers.py "${ARGS[@]}"

--- a/CHANGELOG.md
+++ b/CHANGELOG.md
@@ -4,6 +4,12 @@
 
 ### Added
 
+- **Evidence Locker MVP reviewers**: Assign `evidence-locker-mvp-reviewers`
+  team members to open issues and pull requests whose milestone is
+  Evidence Locker MVP. Membership is read from `peribolos.yaml` so the
+  reviewer pool can change without editing the workflow. See
+  `docs/MILESTONE_REVIEWERS.md`.
+
 - **Stale review alerts**: Added `reusable_stale_reviews.yml` and
   `ci_stale_reviews.yml` to detect and flag PRs with review requests
   pending beyond a configurable business-day threshold. Applies a

--- a/README.md
+++ b/README.md
@@ -59,6 +59,7 @@ org-infra/
 │  │  ├── reusable_sonarqube.yml            # SonarCloud static analysis for code quality and security.
 │  │  ├── reusable_stale_reviews.yml        # Detect and flag PRs with overdue review requests.
 │  │  ├── reusable_vuln_scan.yml            # Vulnerability scanning via OSV-Scanner and Trivy.
+│  │  ├── assign_milestone_reviewers.yml    # Assign Evidence Locker MVP reviewers from a peribolos team.
 │  │  ├── sync_labels.yml                   # Manual workflow to reconcile repository labels from policy.
 │  │  ├── sync_org_repositories.yml         # Manual, scheduled, and event-based workflow to synchronize files.
 │  │  └── sync_project_board.yml            # Sync open issues/PRs into Compliance Automation planning board.
@@ -70,15 +71,18 @@ org-infra/
 ├── docs/                                   # More detailed and specific documentation.
 │  ├── LABEL_SYNC.md                        # Documentation for cross-repo label standardization.
 │  ├── LOCAL_TESTING.md                     # Documentation on how to test synchronization locally.
+│  ├── MILESTONE_REVIEWERS.md               # Evidence Locker MVP milestone reviewer assignment.
 │  ├── PROJECT_BOARD_SYNC.md                # Compliance Automation project board sync setup.
 │  └── SYNC_REPOSITORIES_SETUP.md          # Documentation on how to setup the repository synchronization infrastructure.
 ├── scripts/
+│  ├── assign-milestone-reviewers.py        # Assign peribolos-team members to matching milestone items.
 │  ├── sync-labels.py                       # Python script to reconcile labels from labels-policy.json.
 │  ├── sync-org-repositories.py             # Python script to check and ensure consistence among repositories.
 │  ├── sync-project-board.py                # Sync open issues/PRs into the Compliance Automation project board.
 │  └── resolve-go-packages.sh              # Bash: multi-module Go package auto-discovery
 ├── ...                                     # Multiple technology specific configuration files
 ├── labels-policy.json                      # Label create/rename/preserve/delete policy for sync-labels.py
+├── milestone-reviewers-config.yml          # Team and milestone titles for reviewer assignment
 ├── sync-config.yml                         # Configuration file consumed by `sync-org-repositories.py`
 ├── project-sync-config.yml                 # Orgs/repos synced into Compliance Automation planning board
 └── README.md                               # This file.

--- a/docs/CODE_REVIEW_ASSIGNMENT.md
+++ b/docs/CODE_REVIEW_ASSIGNMENT.md
@@ -138,6 +138,23 @@ Revisit this configuration when:
 - Stale review alerts are firing frequently -- see
   [Stale Review Alerts](#stale-review-alerts) for threshold tuning.
 
+## Milestone-based reviewer assignment
+
+GitHub CODEOWNERS cannot select reviewers by milestone. For the
+**Evidence Locker MVP** milestone, org-infra runs a scheduled workflow
+that assigns the `evidence-locker-mvp-reviewers` team instead.
+
+- **Membership**: `complytime/.github` `peribolos.yaml` team
+  `evidence-locker-mvp-reviewers` (currently `@hbraswelrh`,
+  `@sedonnel`, `@trevor-vaughan`). Edit that list to change reviewers.
+- **Issues**: members are added as assignees.
+- **Pull requests**: members are requested as reviewers.
+- **Native GitHub code review assignment** is not enabled on this team;
+  every current member is requested/assigned.
+
+See [Evidence Locker MVP Reviewer Assignment](MILESTONE_REVIEWERS.md)
+for the workflow, dry-run, and local testing.
+
 ## Stale Review Alerts
 
 Even with Load Balance, a review request can silently stall if the assigned

--- a/docs/MILESTONE_REVIEWERS.md
+++ b/docs/MILESTONE_REVIEWERS.md
@@ -1,0 +1,78 @@
+# Evidence Locker MVP Reviewer Assignment
+
+Automatically assigns the `evidence-locker-mvp-reviewers` GitHub team to
+open issues and pull requests in the `complytime` organization whose
+milestone title is **Evidence Locker MVP** (or **Internal Evidence Locker
+MVP**).
+
+CODEOWNERS cannot filter on milestones, so this is a scheduled org-infra
+workflow rather than a CODEOWNERS rule. The workflow is **not** synced to
+consumer repositories.
+
+## Membership
+
+Team membership is the source of truth and lives in
+[`complytime/.github` `peribolos.yaml`](https://github.com/complytime/.github/blob/main/peribolos.yaml).
+
+To add or remove reviewers:
+
+1. Edit the `members` list on `evidence-locker-mvp-reviewers` in
+   `peribolos.yaml`.
+2. Merge that PR. Peribolos applies the team change.
+3. The next assignment run reads the updated member list from
+   `peribolos.yaml` on `main`. No workflow change is required.
+
+Current members: `@hbraswelrh`, `@sedonnel`, `@trevor-vaughan`.
+
+## What the automation does
+
+On a 15-minute schedule and via manual `workflow_dispatch`:
+
+1. Reads `milestone-reviewers-config.yml`
+2. Loads `evidence-locker-mvp-reviewers` members from `peribolos.yaml`
+3. Scans non-archived `complytime` repositories for matching open milestones
+4. **Issues:** adds those members as assignees (does not remove anyone)
+5. **Pull requests:** requests those members as reviewers (does not
+   remove existing review requests)
+6. Skips the item author so people are not assigned to review themselves
+
+GitHub cannot assign a team as an issue assignee, so individuals from the
+team are used. Changing the team later only affects new/unassigned items;
+existing assignees and review requests are left alone.
+
+## Files
+
+| File | Role |
+| --- | --- |
+| `milestone-reviewers-config.yml` | Org, team slug, and milestone titles |
+| `scripts/assign-milestone-reviewers.py` | Discovery + assignment |
+| `.github/workflows/assign_milestone_reviewers.yml` | Schedule + manual trigger |
+
+## Run the workflow
+
+Go to **Actions → Assign Evidence Locker MVP Reviewers → Run workflow**:
+
+- **dry_run**: `true` to preview, `false` to apply (manual runs default to `true`)
+
+Scheduled runs always apply.
+
+Authentication uses the org-infra sync GitHub App
+(`SYNC_APP_CLIENT_ID`, `SYNC_APP_PRIVATE_KEY`) with `contents:read`,
+`issues:write`, and `pull-requests:write`.
+
+## Local dry-run
+
+```bash
+export GITHUB_TOKEN="$(gh auth token)"
+python3 scripts/assign-milestone-reviewers.py \
+  --config milestone-reviewers-config.yml \
+  --peribolos-file /path/to/peribolos.yaml \
+  --dry-run
+```
+
+## Adding another milestone-based reviewer team
+
+Add a new closed team in `peribolos.yaml`, then either extend
+`milestone-reviewers-config.yml` (if this script is generalized) or add a
+second config/workflow pair. Prefer a peribolos team over a hardcoded
+login list so membership stays editable in one place.

--- a/milestone-reviewers-config.yml
+++ b/milestone-reviewers-config.yml
@@ -1,0 +1,16 @@
+# Assign reviewers from a peribolos team to open issues and pull requests
+# whose milestone title matches. Membership changes in peribolos.yaml;
+# this file only names the team and the milestone titles to match.
+#
+# See docs/MILESTONE_REVIEWERS.md.
+
+org: complytime
+peribolos_repo: ".github"
+peribolos_path: peribolos.yaml
+peribolos_ref: main
+team: evidence-locker-mvp-reviewers
+milestone_titles:
+  - Evidence Locker MVP
+  - Internal Evidence Locker MVP
+# Archived repositories are always skipped. Add names here to skip others.
+exclude_repos: []

--- a/scripts/assign-milestone-reviewers.py
+++ b/scripts/assign-milestone-reviewers.py
@@ -1,0 +1,356 @@
+#!/usr/bin/env python3
+# SPDX-License-Identifier: Apache-2.0
+"""Assign peribolos-team members to open issues/PRs with matching milestones.
+
+Reads team membership from complytime/.github peribolos.yaml so reviewer
+changes are a single peribolos PR. Issues get those members as assignees;
+pull requests get them as requested reviewers. Existing assignees/reviewers
+are left in place. The item author is skipped.
+"""
+
+from __future__ import annotations
+
+import argparse
+import json
+import os
+import sys
+import urllib.error
+import urllib.parse
+import urllib.request
+from typing import Any, Dict, Iterable, List, Optional, Sequence, Set
+
+import yaml
+
+API_ROOT = "https://api.github.com"
+HTTP_ERROR_DETAIL_LIMIT = 500
+
+
+def parse_args() -> argparse.Namespace:
+    parser = argparse.ArgumentParser(
+        description="Assign milestone reviewers from a peribolos team"
+    )
+    parser.add_argument(
+        "--config",
+        default="milestone-reviewers-config.yml",
+        help="Path to the assignment config YAML file",
+    )
+    parser.add_argument(
+        "--peribolos-file",
+        help="Read peribolos YAML from disk instead of the GitHub API",
+    )
+    parser.add_argument(
+        "--dry-run",
+        action="store_true",
+        help="Show intended changes without applying them",
+    )
+    parser.add_argument(
+        "--token-env",
+        default="GITHUB_TOKEN",
+        help="Environment variable that contains the GitHub token",
+    )
+    return parser.parse_args()
+
+
+def get_token(name: str) -> str:
+    token = os.getenv(name)
+    if not token:
+        raise SystemExit(f"Missing required token environment variable: {name}")
+    return token
+
+
+def load_yaml_file(path: str) -> dict:
+    with open(path, "r", encoding="utf-8") as handle:
+        data = yaml.safe_load(handle)
+    if not isinstance(data, dict):
+        raise SystemExit(f"Expected mapping in {path}")
+    return data
+
+
+def load_config(path: str) -> dict:
+    config = load_yaml_file(path)
+    for required in ("org", "team", "milestone_titles", "peribolos_repo", "peribolos_path"):
+        if required not in config:
+            raise SystemExit(f"Config {path} is missing required key: {required}")
+    titles = config["milestone_titles"]
+    if not isinstance(titles, list) or not titles:
+        raise SystemExit("milestone_titles must be a non-empty list")
+    config.setdefault("peribolos_ref", "main")
+    config.setdefault("exclude_repos", [])
+    return config
+
+
+def normalize_title(title: str) -> str:
+    return " ".join(title.strip().split()).casefold()
+
+
+def matching_titles(configured: Sequence[str]) -> Set[str]:
+    return {normalize_title(title) for title in configured if str(title).strip()}
+
+
+def extract_team_members(peribolos: dict, org: str, team: str) -> List[str]:
+    """Return the reviewer pool from peribolos team members (not maintainers)."""
+    orgs = peribolos.get("orgs")
+    if not isinstance(orgs, dict) or org not in orgs:
+        raise SystemExit(f"Organization {org!r} not found in peribolos config")
+    teams = orgs[org].get("teams")
+    if not isinstance(teams, dict) or team not in teams:
+        raise SystemExit(f"Team {team!r} not found in peribolos config for {org}")
+    members = teams[team].get("members") or []
+    if not isinstance(members, list):
+        raise SystemExit(f"Team {team!r} members must be a list")
+    cleaned = [str(login).strip() for login in members if str(login).strip()]
+    if not cleaned:
+        raise SystemExit(f"Team {team!r} has no members to assign")
+    return cleaned
+
+
+def logins_to_add(candidates: Sequence[str], skip: Iterable[str]) -> List[str]:
+    """Preserve peribolos order; drop skipped logins case-insensitively."""
+    skipped = {login.casefold() for login in skip if login}
+    seen: Set[str] = set()
+    result: List[str] = []
+    for login in candidates:
+        key = login.casefold()
+        if key in skipped or key in seen:
+            continue
+        seen.add(key)
+        result.append(login)
+    return result
+
+
+def is_pull_request(item: dict) -> bool:
+    return bool(item.get("pull_request")) or "pull_request" in item
+
+
+def gh_request(
+    token: str,
+    method: str,
+    path: str,
+    body: dict | None = None,
+    query: dict | None = None,
+    extra_headers: Optional[Dict[str, str]] = None,
+    raw: bool = False,
+) -> Any:
+    url = f"{API_ROOT}{path}"
+    if query:
+        url = f"{url}?{urllib.parse.urlencode(query)}"
+    data = None if body is None else json.dumps(body).encode("utf-8")
+    headers = {
+        "Accept": "application/vnd.github.raw" if raw else "application/vnd.github+json",
+        "Authorization": f"Bearer {token}",
+        "X-GitHub-Api-Version": "2022-11-28",
+        "User-Agent": "complytime-milestone-reviewers",
+    }
+    if body is not None:
+        headers["Content-Type"] = "application/json"
+    if extra_headers:
+        headers.update(extra_headers)
+    request = urllib.request.Request(url=url, data=data, method=method, headers=headers)
+    try:
+        with urllib.request.urlopen(request, timeout=30) as response:
+            payload = response.read()
+            if not payload:
+                return None
+            if raw:
+                return payload.decode("utf-8")
+            return json.loads(payload.decode("utf-8"))
+    except urllib.error.HTTPError as exc:
+        detail = exc.read().decode("utf-8", errors="replace")
+        if len(detail) > HTTP_ERROR_DETAIL_LIMIT:
+            detail = detail[:HTTP_ERROR_DETAIL_LIMIT] + "...(truncated)"
+        raise RuntimeError(f"{method} {path} failed: HTTP {exc.code}: {detail}") from exc
+
+
+def gh_paginate(token: str, path: str, query: Optional[dict] = None) -> List[dict]:
+    items: List[dict] = []
+    page = 1
+    base_query = dict(query or {})
+    while True:
+        page_query = {**base_query, "per_page": 100, "page": page}
+        batch = gh_request(token, "GET", path, query=page_query)
+        if not isinstance(batch, list):
+            raise TypeError(f"Expected list from {path}, got {type(batch).__name__}")
+        if not batch:
+            break
+        items.extend(batch)
+        page += 1
+    return items
+
+
+def fetch_peribolos(token: str, org: str, repo: str, path: str, ref: str) -> dict:
+    raw = gh_request(
+        token,
+        "GET",
+        f"/repos/{org}/{urllib.parse.quote(repo)}/contents/{path}",
+        query={"ref": ref},
+        raw=True,
+    )
+    if not isinstance(raw, str) or not raw.strip():
+        raise SystemExit(f"Empty peribolos file at {org}/{repo}/{path}@{ref}")
+    data = yaml.safe_load(raw)
+    if not isinstance(data, dict):
+        raise SystemExit("peribolos.yaml is not a mapping")
+    return data
+
+
+def list_repos(token: str, org: str, exclude: Sequence[str]) -> List[dict]:
+    exclude_set = {name.strip() for name in exclude if str(name).strip()}
+    repos = []
+    for repo in gh_paginate(token, f"/orgs/{org}/repos", query={"type": "all"}):
+        name = repo.get("name")
+        if not name or name in exclude_set or repo.get("archived"):
+            continue
+        repos.append(repo)
+    repos.sort(key=lambda item: item["name"])
+    return repos
+
+
+def matching_milestones(milestones: Sequence[dict], titles: Set[str]) -> List[dict]:
+    matched = []
+    for milestone in milestones:
+        title = milestone.get("title") or ""
+        if normalize_title(title) in titles:
+            matched.append(milestone)
+    return matched
+
+
+def current_assignees(item: dict) -> Set[str]:
+    return {
+        (assignee.get("login") or "")
+        for assignee in item.get("assignees") or []
+        if assignee.get("login")
+    }
+
+
+def current_reviewers(review_payload: dict) -> Set[str]:
+    users = {
+        (user.get("login") or "")
+        for user in review_payload.get("users") or []
+        if user.get("login")
+    }
+    return users
+
+
+def assign_issue(token: str, org: str, repo: str, number: int, logins: Sequence[str]) -> None:
+    gh_request(
+        token,
+        "POST",
+        f"/repos/{org}/{repo}/issues/{number}/assignees",
+        body={"assignees": list(logins)},
+    )
+
+
+def request_reviewers(
+    token: str, org: str, repo: str, number: int, logins: Sequence[str]
+) -> None:
+    gh_request(
+        token,
+        "POST",
+        f"/repos/{org}/{repo}/pulls/{number}/requested_reviewers",
+        body={"reviewers": list(logins)},
+    )
+
+
+def process_item(
+    token: str,
+    org: str,
+    repo: str,
+    item: dict,
+    members: Sequence[str],
+    dry_run: bool,
+) -> str:
+    number = item["number"]
+    author = ((item.get("user") or {}).get("login")) or ""
+    html_url = item.get("html_url") or f"{org}/{repo}#{number}"
+
+    if is_pull_request(item):
+        requested = gh_request(
+            token, "GET", f"/repos/{org}/{repo}/pulls/{number}/requested_reviewers"
+        ) or {"users": []}
+        if not isinstance(requested, dict):
+            requested = {"users": []}
+        skip = {author, *current_reviewers(requested)}
+        to_add = logins_to_add(members, skip)
+        if not to_add:
+            return f"skip PR {html_url}: reviewers already requested"
+        action = f"request reviewers {', '.join(to_add)} on PR {html_url}"
+        if not dry_run:
+            request_reviewers(token, org, repo, number, to_add)
+        return action
+
+    skip = {author, *current_assignees(item)}
+    to_add = logins_to_add(members, skip)
+    if not to_add:
+        return f"skip issue {html_url}: assignees already set"
+    action = f"assign {', '.join(to_add)} on issue {html_url}"
+    if not dry_run:
+        assign_issue(token, org, repo, number, to_add)
+    return action
+
+
+def run(config: dict, token: str, peribolos: dict, dry_run: bool) -> int:
+    org = config["org"]
+    team = config["team"]
+    members = extract_team_members(peribolos, org, team)
+    titles = matching_titles(config["milestone_titles"])
+    repos = list_repos(token, org, config.get("exclude_repos") or [])
+
+    print(f"Team {team} members: {', '.join(members)}")
+    print(f"Milestone titles: {', '.join(config['milestone_titles'])}")
+    print(f"Repositories: {len(repos)}")
+    if dry_run:
+        print("Dry run: no assignments will be written")
+
+    actions = 0
+    errors = 0
+    for repo in repos:
+        name = repo["name"]
+        try:
+            milestones = gh_paginate(token, f"/repos/{org}/{name}/milestones", query={"state": "open"})
+            matched = matching_milestones(milestones, titles)
+            if not matched:
+                continue
+            for milestone in matched:
+                issues = gh_paginate(
+                    token,
+                    f"/repos/{org}/{name}/issues",
+                    query={"state": "open", "milestone": milestone["number"]},
+                )
+                for item in issues:
+                    try:
+                        message = process_item(token, org, name, item, members, dry_run)
+                    except RuntimeError as exc:
+                        errors += 1
+                        print(f"ERROR {name}#{item.get('number')}: {exc}", file=sys.stderr)
+                        continue
+                    print(message)
+                    if not message.startswith("skip "):
+                        actions += 1
+        except RuntimeError as exc:
+            errors += 1
+            print(f"ERROR repo {name}: {exc}", file=sys.stderr)
+            continue
+
+    print(f"Done. applied={actions} errors={errors}")
+    return 1 if errors else 0
+
+
+def main() -> int:
+    args = parse_args()
+    config = load_config(args.config)
+    token = get_token(args.token_env)
+    if args.peribolos_file:
+        peribolos = load_yaml_file(args.peribolos_file)
+    else:
+        peribolos = fetch_peribolos(
+            token,
+            config["org"],
+            config["peribolos_repo"],
+            config["peribolos_path"],
+            config["peribolos_ref"],
+        )
+    return run(config, token, peribolos, args.dry_run)
+
+
+if __name__ == "__main__":
+    raise SystemExit(main())

--- a/tests/test_assign_milestone_reviewers.py
+++ b/tests/test_assign_milestone_reviewers.py
@@ -1,0 +1,175 @@
+# SPDX-License-Identifier: Apache-2.0
+
+"""Tests for assign-milestone-reviewers.py."""
+
+from __future__ import annotations
+
+import importlib
+import sys
+from pathlib import Path
+from unittest.mock import patch
+
+import pytest
+
+sys.path.insert(0, str(Path(__file__).parent.parent / "scripts"))
+
+assign = importlib.import_module("assign-milestone-reviewers")
+
+PERIBOLOS = {
+    "orgs": {
+        "complytime": {
+            "teams": {
+                "evidence-locker-mvp-reviewers": {
+                    "members": ["hbraswelrh", "sedonnel", "trevor-vaughan"],
+                    "maintainers": ["gxmiranda", "jpower432", "marcusburghardt"],
+                }
+            }
+        }
+    }
+}
+
+
+class TestExtractTeamMembers:
+    def test_returns_members_not_maintainers(self):
+        members = assign.extract_team_members(
+            PERIBOLOS, "complytime", "evidence-locker-mvp-reviewers"
+        )
+        assert members == ["hbraswelrh", "sedonnel", "trevor-vaughan"]
+
+    def test_missing_team_exits(self):
+        with pytest.raises(SystemExit, match="not found"):
+            assign.extract_team_members(PERIBOLOS, "complytime", "nope")
+
+    def test_empty_members_exits(self):
+        data = {
+            "orgs": {
+                "complytime": {
+                    "teams": {"empty-team": {"members": [], "maintainers": ["gxmiranda"]}}
+                }
+            }
+        }
+        with pytest.raises(SystemExit, match="no members"):
+            assign.extract_team_members(data, "complytime", "empty-team")
+
+
+class TestLoginsToAdd:
+    def test_skips_author_and_existing_casefold(self):
+        result = assign.logins_to_add(
+            ["hbraswelrh", "sedonnel", "trevor-vaughan"],
+            ["Trevor-Vaughan", "author"],
+        )
+        assert result == ["hbraswelrh", "sedonnel"]
+
+    def test_preserves_peribolos_order(self):
+        result = assign.logins_to_add(["sedonnel", "hbraswelrh"], [])
+        assert result == ["sedonnel", "hbraswelrh"]
+
+    def test_empty_when_all_skipped(self):
+        result = assign.logins_to_add(["sedonnel"], ["sedonnel"])
+        assert result == []
+
+
+class TestMilestoneMatching:
+    def test_normalizes_whitespace_and_case(self):
+        titles = assign.matching_titles(["Evidence Locker MVP", "Internal Evidence Locker MVP"])
+        matched = assign.matching_milestones(
+            [
+                {"title": "evidence  locker mvp", "number": 1},
+                {"title": "ComplyTime improvements", "number": 2},
+                {"title": "Internal Evidence Locker MVP", "number": 3},
+            ],
+            titles,
+        )
+        assert [item["number"] for item in matched] == [1, 3]
+
+
+class TestIsPullRequest:
+    def test_issue_without_pull_request_key(self):
+        assert assign.is_pull_request({"number": 1}) is False
+
+    def test_pull_request_payload(self):
+        assert assign.is_pull_request({"number": 2, "pull_request": {"url": "https://x"}}) is True
+
+
+class TestProcessItem:
+    def test_assigns_issue_and_skips_author(self):
+        item = {
+            "number": 10,
+            "html_url": "https://github.com/complytime/nunya/issues/10",
+            "user": {"login": "hbraswelrh"},
+            "assignees": [],
+        }
+        with patch.object(assign, "assign_issue") as mocked:
+            message = assign.process_item(
+                "token",
+                "complytime",
+                "nunya",
+                item,
+                ["hbraswelrh", "sedonnel", "trevor-vaughan"],
+                dry_run=False,
+            )
+        mocked.assert_called_once_with(
+            "token", "complytime", "nunya", 10, ["sedonnel", "trevor-vaughan"]
+        )
+        assert "assign sedonnel, trevor-vaughan" in message
+
+    def test_dry_run_does_not_write_issue(self):
+        item = {
+            "number": 11,
+            "html_url": "https://github.com/complytime/nunya/issues/11",
+            "user": {"login": "someone"},
+            "assignees": [],
+        }
+        with patch.object(assign, "assign_issue") as mocked:
+            message = assign.process_item(
+                "token",
+                "complytime",
+                "nunya",
+                item,
+                ["sedonnel"],
+                dry_run=True,
+            )
+        mocked.assert_not_called()
+        assert message.startswith("assign")
+
+    def test_requests_pr_reviewers(self):
+        item = {
+            "number": 12,
+            "html_url": "https://github.com/complytime/nunya/pull/12",
+            "user": {"login": "author"},
+            "pull_request": {"url": "https://api.github.com/repos/complytime/nunya/pulls/12"},
+        }
+        with patch.object(
+            assign, "gh_request", return_value={"users": [{"login": "sedonnel"}]}
+        ), patch.object(assign, "request_reviewers") as mocked:
+            message = assign.process_item(
+                "token",
+                "complytime",
+                "nunya",
+                item,
+                ["hbraswelrh", "sedonnel", "trevor-vaughan"],
+                dry_run=False,
+            )
+        mocked.assert_called_once_with(
+            "token", "complytime", "nunya", 12, ["hbraswelrh", "trevor-vaughan"]
+        )
+        assert "request reviewers hbraswelrh, trevor-vaughan" in message
+
+    def test_skips_when_nothing_to_add(self):
+        item = {
+            "number": 13,
+            "html_url": "https://github.com/complytime/nunya/issues/13",
+            "user": {"login": "sedonnel"},
+            "assignees": [{"login": "hbraswelrh"}, {"login": "trevor-vaughan"}],
+        }
+        with patch.object(assign, "assign_issue") as mocked:
+            message = assign.process_item(
+                "token",
+                "complytime",
+                "nunya",
+                item,
+                ["hbraswelrh", "sedonnel", "trevor-vaughan"],
+                dry_run=False,
+            )
+        mocked.assert_not_called()
+        assert message.startswith("skip")


### PR DESCRIPTION
## Summary

- Add a scheduled org-infra workflow that assigns `complytime/evidence-locker-mvp-reviewers` to open issues and pull requests whose milestone is **Evidence Locker MVP** (or **Internal Evidence Locker MVP**).
- Membership is read from `peribolos.yaml`, so reviewer changes stay in the `.github` team PR rather than hardcoded logins.
- Issues get those members as assignees; PRs get them as requested reviewers. The author is skipped, and existing assignees/review requests are left in place.

## Related Issues

Depends on the companion team PR in `complytime/.github` (`feat: add evidence-locker-mvp-reviewers team`). Merge that first so Peribolos creates the team before this workflow runs on a schedule.

## Review Hints

- Review `scripts/assign-milestone-reviewers.py` and `tests/test_assign_milestone_reviewers.py` together.
- Manual dry-run after merge: **Actions → Assign Evidence Locker MVP Reviewers → Run workflow** with `dry_run: true`.
- The sync GitHub App must be installed on any repo that uses this milestone (currently `nunya` already has **Evidence Locker MVP**). If a repo is missing from App installation, those items will be skipped with an error log.
- Scheduled runs apply every 15 minutes; manual dispatch defaults to dry-run.


Made with [Cursor](https://cursor.com)